### PR TITLE
Add runtime-specific Codex options via agents.runtime_options

### DIFF
--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import threading
 from pathlib import Path
+from typing import Any
 
 from coral.agent.runtime import AgentHandle, _extract_session_id, write_coral_log_entry
 
@@ -32,6 +33,7 @@ class ClaudeCodeRuntime:
         worktree_path: Path,
         coral_md_path: Path,
         model: str = "opus",
+        runtime_options: dict[str, Any] | None = None,
         max_turns: int = 200,
         log_dir: Path | None = None,
         verbose: bool = False,

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -8,10 +8,18 @@ import subprocess
 import sys
 import threading
 from pathlib import Path
+from typing import Any
 
 from coral.agent.runtime import AgentHandle, write_coral_log_entry
 
 logger = logging.getLogger(__name__)
+
+_CODEX_RUNTIME_OPTION_KEYS = {
+    "model_reasoning_effort",
+    "fast_mode",
+    "personality",
+    "web_search",
+}
 
 
 def _extract_codex_session_id(log_path: Path) -> str | None:
@@ -57,6 +65,7 @@ class CodexRuntime:
         worktree_path: Path,
         coral_md_path: Path,
         model: str = "gpt-5.4",
+        runtime_options: dict[str, Any] | None = None,
         max_turns: int = 200,
         log_dir: Path | None = None,
         verbose: bool = False,
@@ -88,6 +97,8 @@ class CodexRuntime:
             else:
                 prompt = "Begin."
 
+        option_args = _build_codex_runtime_option_args(runtime_options)
+
         if resume_session_id:
             # codex exec resume <session_id> "follow-up prompt"
             cmd = [
@@ -96,6 +107,7 @@ class CodexRuntime:
                 prompt,
                 "--full-auto",
                 "--model", model,
+                *option_args,
                 "--json",
             ]
         else:
@@ -105,6 +117,7 @@ class CodexRuntime:
                 prompt,
                 "--full-auto",
                 "--model", model,
+                *option_args,
                 "--json",
             ]
 
@@ -178,3 +191,26 @@ class CodexRuntime:
             session_id=resume_session_id,
             _log_file=log_file_ref,
         )
+
+
+def _toml_literal(value: Any) -> str:
+    """Serialize a scalar value for `codex -c key=value`."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    return json.dumps(str(value))
+
+
+def _build_codex_runtime_option_args(runtime_options: dict[str, Any] | None) -> list[str]:
+    """Translate runtime options into `codex exec -c key=value` arguments."""
+    if not runtime_options:
+        return []
+
+    args: list[str] = []
+    for key in sorted(runtime_options):
+        if key not in _CODEX_RUNTIME_OPTION_KEYS:
+            logger.warning(f"Ignoring unsupported Codex runtime option: {key}")
+            continue
+        args.extend(["-c", f"{key}={_toml_literal(runtime_options[key])}"])
+    return args

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import threading
 from pathlib import Path
+from typing import Any
 
 from coral.agent.runtime import AgentHandle, write_coral_log_entry
 
@@ -61,6 +62,7 @@ class OpenCodeRuntime:
         worktree_path: Path,
         coral_md_path: Path,
         model: str = "gpt-5",
+        runtime_options: dict[str, Any] | None = None,
         max_turns: int = 200,
         log_dir: Path | None = None,
         verbose: bool = False,

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -143,6 +143,7 @@ class AgentManager:
             worktree_path=worktree_path,
             coral_md_path=worktree_path / instruction_file,
             model=self.config.agents.model,
+            runtime_options=self.config.agents.runtime_options,
             max_turns=self.config.agents.max_turns,
             verbose=self.verbose,
             log_dir=self.paths.coral_dir / "public" / "logs",

--- a/coral/agent/runtime.py
+++ b/coral/agent/runtime.py
@@ -24,6 +24,7 @@ class AgentRuntime(Protocol):
         worktree_path: Path,
         coral_md_path: Path,
         model: str = "sonnet",
+        runtime_options: dict[str, Any] | None = None,
         max_turns: int = 200,
         log_dir: Path | None = None,
         verbose: bool = False,

--- a/coral/config.py
+++ b/coral/config.py
@@ -48,6 +48,7 @@ class AgentConfig:
     count: int = 1
     runtime: str = "claude_code"
     model: str = "sonnet"
+    runtime_options: dict[str, Any] = field(default_factory=dict)
     max_turns: int = 200
     timeout: int = 3600
     heartbeat: list[HeartbeatActionConfig] = field(default_factory=lambda: [
@@ -186,6 +187,7 @@ class CoralConfig:
                 "count": self.agents.count,
                 "runtime": self.agents.runtime,
                 "model": self.agents.model,
+                "runtime_options": self.agents.runtime_options,
                 "max_turns": self.agents.max_turns,
                 "timeout": self.agents.timeout,
                 "heartbeat": [

--- a/examples/mnist/task_codex.yaml
+++ b/examples/mnist/task_codex.yaml
@@ -1,0 +1,56 @@
+task:
+  name: "MNIST"
+  description: |
+    Classify handwritten digits (0–9) from the MNIST dataset.
+
+    The dataset contains 60,000 training images and 10,000 test images of
+    28x28 grayscale handwritten digits. Each image is flattened to a 784-dimensional
+    vector with pixel values in [0, 255].
+
+    **Data format:**
+
+    - `data/train.npz` — Training data with keys:
+      - `images`: float64 array of shape (60000, 784), pixel values 0–255
+      - `labels`: int64 array of shape (60000,), digit labels 0–9
+    - `data/test.npz` — Test data with key:
+      - `images`: float64 array of shape (10000, 784), pixel values 0–255
+
+    **Your program** (`solution.py`) must define a `run(train_path, test_path)` function that:
+    - Loads training data from `train_path` (npz with `images` and `labels` keys)
+    - Loads test data from `test_path` (npz with `images` key)
+    - Returns a numpy int array of shape (10000,) with predicted digit labels (0–9)
+
+    **Environment:** cpu is available for use.
+
+  files:
+    - "solution.py"
+  tips: |
+    - Metric is classification accuracy (higher is better, 0–1 scale)
+    - A random baseline scores ~0.10, a simple logistic regression scores ~0.92
+    - Good CNNs score 0.99+. State-of-the-art exceeds 0.998
+    - The eval timeout is 300s — keep training time reasonable
+    - Pixel values are 0–255 floats; normalize as needed
+    - Images are flattened 28x28; reshape to (N, 28, 28) or (N, 1, 28, 28) for CNNs
+
+grader:
+  timeout: 300
+  direction: maximize
+  args:
+    program_file: "solution.py"
+    train_file: "data/train.npz"
+    test_file: "data/test.npz"
+
+agents:
+  count: 2
+  runtime: codex
+  model: gpt-5.4
+  runtime_options:
+    model_reasoning_effort: "low" # "low", "medium", "high" (default: "medium")
+    fast_mode: false
+    personality: "friendly" # "friendly", "pragmatic", "none"
+    web_search: "live" # "disabled", "live", "cached" (default)
+
+
+workspace:
+  results_dir: "./results"
+  repo_path: "./mnist/repo"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,3 +33,26 @@ def test_config_from_dict():
     assert config.task.name == "t"
     assert config.grader.type == "kernel_builder"
     assert config.agents.count == 1  # default
+
+
+def test_agent_runtime_options_roundtrip():
+    config = CoralConfig(
+        task=TaskConfig(name="test", description="A test"),
+        agents=AgentConfig(
+            runtime="codex",
+            model="gpt-5.4",
+            runtime_options={
+                "model_reasoning_effort": "medium",
+                "fast_mode": True,
+            },
+        ),
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+        config.to_yaml(f.name)
+        restored = CoralConfig.from_yaml(f.name)
+
+    assert restored.agents.runtime_options == {
+        "model_reasoning_effort": "medium",
+        "fast_mode": True,
+    }


### PR DESCRIPTION
## Summary

This PR adds `agents.runtime_options` so task configs can pass runtime-specific
settings without expanding the shared agent config surface.

It wires `runtime_options` through config parsing, the runtime protocol, and
agent startup, and adds Codex support for:

- `model_reasoning_effort`
- `fast_mode`
- `personality`
- `web_search`

`claude_code` and `opencode` now accept the new parameter for interface
consistency, but do not consume it yet.

The same changes were also mirrored under `dev/CORAL`.
