### PR TITLE
fix: resolve tmux breadcrumb path relative to CWD

### DIFF
--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -105,9 +105,10 @@ def _start_in_tmux(args: argparse.Namespace) -> None:
         print(f"Error creating tmux session: {result.stderr}", file=sys.stderr)
         sys.exit(1)
 
-    # Pre-create the results directory so we can save tmux markers there
+    # Pre-create the results directory so we can save tmux markers there.
+    # Must match create_project()'s resolution: relative to CWD, not task config dir.
     from coral.workspace.setup import _slugify
-    results_dir = (config.task_dir or config_path.parent or Path.cwd()) / config.workspace.results_dir
+    results_dir = Path(config.workspace.results_dir).resolve()
     task_dir = results_dir / _slugify(config.task.name)
     task_dir.mkdir(parents=True, exist_ok=True)
     save_tmux_session_name(task_dir, session_name)


### PR DESCRIPTION
## Summary
- Fixed `_start_in_tmux` computing `results_dir` relative to the task config directory instead of CWD, causing tmux breadcrumb files (`.coral_tmux_session`, `.coral_tmux_owned`) to be written to the wrong location (e.g. `examples/math/.../results/` instead of `<project_root>/results/`)
- Aligned with `create_project()`'s behavior: `Path(config.workspace.results_dir).resolve()`

## Test plan
- [ ] Run `coral start --config examples/math/heilbronn_convex_13/task.yaml` from project root and verify tmux breadcrumb files appear under `<project_root>/results/` not under `examples/math/heilbronn_convex_13/results/`
- [ ] Verify `coral stop` correctly finds and kills the tmux session

🤖 Generated with [Claude Code](https://claude.com/claude-code)