### PR TITLE
fix: cap Python version at <3.14 for ML package compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.0"
 description = "Orchestration system for autonomous coding agents"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.11"
+requires-python = ">=3.11, <3.14"
 authors = [
     { name = "CORAL Team" }
 ]


### PR DESCRIPTION
## Summary
- Caps `requires-python` to `>=3.11, <3.14` so uv/pip won't auto-select Python 3.14, which lacks wheels for common ML packages like PyTorch

Fixes #7

## Test plan
- [ ] Verify `uv sync` on a system with Python 3.14 installed no longer selects it
- [ ] Verify `uv sync` still works with Python 3.11, 3.12, 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)