### PR TITLE
fix: --full-auto sandbox blocks git worktree writes and CUDA

### DIFF
--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -106,7 +106,7 @@ class CodexRuntime:
                 "codex", "exec",
                 "resume", resume_session_id,
                 prompt,
-                "--full-auto",
+                "--dangerously-bypass-approvals-and-sandbox",
                 "--model", model,
                 *option_args,
                 "--json",
@@ -116,7 +116,7 @@ class CodexRuntime:
             cmd = [
                 "codex", "exec",
                 prompt,
-                "--full-auto",
+                "--dangerously-bypass-approvals-and-sandbox",
                 "--model", model,
                 *option_args,
                 "--json",


### PR DESCRIPTION
## Summary
- Replaces `--full-auto` with `--dangerously-bypass-approvals-and-sandbox` in the Codex runtime
- The `--full-auto` sandbox blocks filesystem writes (breaking `coral eval` git lock files) and hides GPU devices (breaking CUDA workloads)
- CORAL already isolates agents via git worktrees, making the sandbox redundant

Closes #6

## Test plan
- [x] `uv run pytest tests/ -v` — all 46 tests pass
- [x] `uv run ruff check .` — no new lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)