### PR TITLE
fix: pass task/run to inner resume command to avoid double prompt in tmux

### DIFF
--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -134,10 +134,19 @@ def _resume_in_tmux(args: argparse.Namespace, coral_dir: Path) -> None:
     )
 
     cmd = [_resolved_python(), "-m", "coral.cli", "resume"]
+    # Derive task/run from coral_dir path to avoid re-prompting inside tmux.
+    # Path structure: results/<task>/<run>/.coral
+    resolved = coral_dir.resolve()
+    run_name = resolved.parent.name
+    task_slug = resolved.parent.parent.name
     if args.task:
         cmd.extend(["--task", args.task])
+    else:
+        cmd.extend(["--task", task_slug])
     if args.run:
         cmd.extend(["--run", args.run])
+    else:
+        cmd.extend(["--run", run_name])
     if args.model:
         cmd.extend(["--model", args.model])
     if getattr(args, "verbose", False):


### PR DESCRIPTION
## Summary
- When `coral resume` is run without `--task`/`--run`, the user picks a run interactively via `pick_run()`. If tmux is needed, `_resume_in_tmux` re-launches `coral resume` inside tmux but previously didn't forward the selected run, causing a second interactive prompt inside the tmux session.
- Now derives task slug and run name from the resolved `coral_dir` path and always passes `--task`/`--run` to the inner command.

Closes #18

## Test plan
- [x] All 59 existing tests pass
- [ ] Run `coral resume` without `--task`/`--run` when tmux is available — verify no second prompt appears inside the tmux session

🤖 Generated with [Claude Code](https://claude.com/claude-code)