### PR TITLE
fix: persist config overrides to disk on resume

### DIFF
--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -279,6 +279,8 @@ def cmd_resume(args: argparse.Namespace) -> None:
     overrides = getattr(args, "overrides", [])
     if overrides:
         config = CoralConfig.merge_dotlist(config, overrides)
+        # Persist overrides so eval hooks (which re-read config.yaml) see them
+        config.to_yaml(config_path)
 
     if config.run.tmux:
         existing_session = find_tmux_session(coral_dir)


### PR DESCRIPTION
## Summary
- When `coral resume` is called with dotlist overrides (e.g. `grader.timeout=6000`), the merged config was only held in memory
- The eval hook (`post_commit.py`) re-reads `.coral/config.yaml` from disk, so overrides were silently ignored during grading
- Now writes the merged config back to `.coral/config.yaml` after applying overrides

## Test plan
- [ ] Run `coral start -c task.yaml` with default grader timeout
- [ ] Stop the run, then `coral resume grader.timeout=6000`
- [ ] Verify `.coral/config.yaml` reflects the updated timeout
- [ ] Run `coral eval` and confirm the grader uses the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)