### PR TITLE
Fix venv setup race condition with file lock

### DIFF
--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
@@ -218,28 +219,43 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
        gets its own ``.venv`` with task dependencies.
     2. Install ``coral`` into that venv so ``coral eval`` is available
        when the agent uses ``uv run``.
+
+    A file lock serializes these operations across agents to prevent
+    concurrent ``uv pip install`` calls from corrupting shared venv
+    metadata (dist-info directories).
     """
     if not setup_commands:
         return
 
-    run_setup_commands(setup_commands, worktree_path)
+    # Use a lock file next to the worktree's parent dir to serialize
+    # venv-modifying operations across all agents in the same run.
+    lock_path = worktree_path.parent / ".setup.lock"
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r") as lock_fd:
+        logger.info(f"Acquiring setup lock for {worktree_path.name}...")
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        logger.info(f"Setup lock acquired for {worktree_path.name}")
+        try:
+            run_setup_commands(setup_commands, worktree_path)
 
-    # Install coral into the worktree's venv so agents can use
-    # ``uv run coral eval`` and graders can ``from coral.grader import ...``.
-    venv_python = worktree_path / ".venv" / "bin" / "python"
-    if venv_python.exists() and shutil.which("uv"):
-        coral_root = Path(__file__).resolve().parent.parent.parent
-        if (coral_root / "pyproject.toml").exists():
-            logger.info(f"Installing coral into worktree venv from {coral_root}")
-            result = subprocess.run(
-                ["uv", "pip", "install", "--python", str(venv_python), "-e", str(coral_root)],
-                cwd=str(worktree_path),
-                capture_output=True,
-                text=True,
-                env=_clean_env(),
-            )
-            if result.returncode != 0:
-                logger.warning(
-                    f"Failed to install coral in worktree: {result.stderr.strip()}"
-                )
+            # Install coral into the worktree's venv so agents can use
+            # ``uv run coral eval`` and graders can ``from coral.grader import ...``.
+            venv_python = worktree_path / ".venv" / "bin" / "python"
+            if venv_python.exists() and shutil.which("uv"):
+                coral_root = Path(__file__).resolve().parent.parent.parent
+                if (coral_root / "pyproject.toml").exists():
+                    logger.info(f"Installing coral into worktree venv from {coral_root}")
+                    result = subprocess.run(
+                        ["uv", "pip", "install", "--python", str(venv_python), "-e", str(coral_root)],
+                        cwd=str(worktree_path),
+                        capture_output=True,
+                        text=True,
+                        env=_clean_env(),
+                    )
+                    if result.returncode != 0:
+                        logger.warning(
+                            f"Failed to install coral in worktree: {result.stderr.strip()}"
+                        )
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
 


### PR DESCRIPTION
## Summary
- When multiple agents share the same `.venv` (e.g. task repo without its own `pyproject.toml`), concurrent `uv pip install` calls during setup corrupt dist-info metadata, causing errors like `failed to open file .../colorlog-6.10.1.dist-info/METADATA: No such file or directory`
- Adds an `fcntl` file lock around `setup_worktree_env` so only one agent's venv setup runs at a time, serializing all `uv sync` / `uv pip install` operations

## Test plan
- [ ] Run `coral start` with multiple agents on a task that shares a venv (e.g. `frontier_cs_algo` tasks)
- [ ] Run `coral resume` with multiple agents — previously failing scenario
- [ ] Verify single-agent setup still works without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)