### PR TITLE
fix: use unique tmux session names so concurrent runs coexist

### DIFF
--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -68,13 +68,8 @@ def _build_coral_command(args: argparse.Namespace) -> list[str]:
 def _start_in_tmux(args: argparse.Namespace, config: CoralConfig) -> None:
     """Create a tmux session and run coral start inside it."""
     task_name = config.task.name.replace(" ", "-").lower()
-    session_name = f"coral-{task_name}"
-
-    # Kill existing session with same name if it exists
-    subprocess.run(
-        ["tmux", "kill-session", "-t", session_name],
-        capture_output=True,
-    )
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    session_name = f"coral-{task_name}-{timestamp}"
 
     coral_cmd = _build_coral_command(args)
     shell_cmd = " ".join(f"'{c}'" if " " in c else c for c in coral_cmd)
@@ -108,8 +103,10 @@ def _start_in_tmux(args: argparse.Namespace, config: CoralConfig) -> None:
 def _resume_in_tmux(args: argparse.Namespace, config: CoralConfig, coral_dir: Path) -> None:
     """Resume CORAL inside a tmux session."""
     task_name = config.task.name.replace(" ", "-").lower()
-    session_name = f"coral-{task_name}"
+    run_name = coral_dir.resolve().parent.name
+    session_name = f"coral-{task_name}-{run_name}"
 
+    # Kill stale session with same name (same run being re-resumed)
     subprocess.run(
         ["tmux", "kill-session", "-t", session_name],
         capture_output=True,

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -28,11 +28,20 @@ def _make_config(repo_path: str, results_dir: str | None = None) -> CoralConfig:
     )
 
 
+def _git_init(d: str) -> None:
+    """Initialise a git repo with a dummy commit (works without global config)."""
+    subprocess.run(["git", "init", d], capture_output=True, check=True)
+    subprocess.run(
+        ["git", "-C", d, "-c", "user.name=test", "-c", "user.email=test@test.com",
+         "commit", "--allow-empty", "-m", "init"],
+        capture_output=True, check=True,
+    )
+
+
 def test_create_project_structure():
     with tempfile.TemporaryDirectory() as d:
         # Init a git repo so workspace can create worktrees
-        subprocess.run(["git", "init", d], capture_output=True, check=True)
-        subprocess.run(["git", "-C", d, "commit", "--allow-empty", "-m", "init"], capture_output=True, check=True)
+        _git_init(d)
 
         config = _make_config(d)
         paths = create_project(config)
@@ -58,8 +67,7 @@ def test_create_project_structure():
 def test_create_project_unique_runs():
     """Each create_project call gets a unique run directory."""
     with tempfile.TemporaryDirectory() as d:
-        subprocess.run(["git", "init", d], capture_output=True, check=True)
-        subprocess.run(["git", "-C", d, "commit", "--allow-empty", "-m", "init"], capture_output=True, check=True)
+        _git_init(d)
 
         config = _make_config(d)
         paths1 = create_project(config)


### PR DESCRIPTION
## Summary

Fixes #28.

- **Root cause**: `_start_in_tmux` used `coral-<task-name>` as the tmux session name. Starting a second run for the same task would `tmux kill-session` the first run's session, destroying its manager process and orphaning agents.
- **Fix**: Each `coral start` now generates a timestamped session name (`coral-<task-name>-<YYYYMMDD-HHMMSS>`), and no longer kills existing sessions. `_resume_in_tmux` derives its session name from the run directory, so it only kills stale sessions for the same run.
- **Bonus**: Fixes pre-existing test failures in `test_workspace.py` where `git commit` failed in environments without global git user config.

## Test plan

- [x] All 79 tests pass (`uv run pytest tests/ -v`)
- [x] Linting clean (`uv run ruff check`)
- [ ] Manual: start two runs of the same task, verify both coexist in separate tmux sessions
- [ ] Manual: `coral stop` correctly stops each run independently
- [ ] Manual: `coral resume` correctly resumes a specific run

🤖 Generated with [Claude Code](https://claude.com/claude-code)