### PR TITLE
feat: add Kiro CLI runtime + agent spawn stagger for rate-limit backpressure

### DIFF
--- a/coral/agent/builtin/kiro.py
+++ b/coral/agent/builtin/kiro.py
@@ -1,0 +1,134 @@
+"""Kiro CLI subprocess lifecycle."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+from coral.agent.runtime import AgentHandle, write_coral_log_entry
+from coral.workspace.repo import _clean_env
+
+logger = logging.getLogger(__name__)
+
+
+class KiroRuntime:
+    """Spawn and manage Kiro CLI agent subprocesses."""
+
+    @property
+    def instruction_filename(self) -> str:
+        return "KIRO.md"
+
+    @property
+    def shared_dir_name(self) -> str:
+        return ".kiro"
+
+    def extract_session_id(self, log_path: Path) -> str | None:
+        return None  # Kiro doesn't expose session IDs in the same way
+
+    def start(
+        self,
+        worktree_path: Path,
+        coral_md_path: Path,
+        model: str = "default",
+        runtime_options: dict[str, Any] | None = None,
+        max_turns: int = 200,
+        log_dir: Path | None = None,
+        verbose: bool = False,
+        resume_session_id: str | None = None,
+        prompt: str | None = None,
+        prompt_source: str | None = None,
+        task_name: str | None = None,
+        task_description: str | None = None,
+    ) -> AgentHandle:
+        agent_id_file = worktree_path / ".coral_agent_id"
+        agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
+
+        if log_dir is None:
+            log_dir = worktree_path / ".kiro" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        log_idx = len(list(log_dir.glob(f"{agent_id}*.log")))
+        log_path = log_dir / f"{agent_id}.{log_idx}.log"
+
+        if prompt is None:
+            prompt = "Begin."
+
+        cmd = [
+            "kiro-cli", "chat",
+            prompt,
+            "--no-interactive",
+            "-a",  # trust all tools
+        ]
+
+        if model and model != "default":
+            cmd.extend(["--model", model])
+
+        logger.info(f"Starting Kiro agent {agent_id} in {worktree_path}")
+        logger.info(f"Command: {' '.join(cmd)}")
+
+        agent_env = _clean_env()
+
+        log_file = open(log_path, "w", buffering=1)
+
+        write_coral_log_entry(
+            log_file,
+            prompt=prompt,
+            source=prompt_source or "start",
+            agent_id=agent_id,
+            task_name=task_name,
+            task_description=task_description,
+        )
+
+        if verbose:
+            process = subprocess.Popen(
+                cmd,
+                cwd=str(worktree_path),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                env=agent_env,
+            )
+
+            def _tee_output(proc, log_f, agent):
+                try:
+                    assert proc.stdout is not None
+                    for line in iter(proc.stdout.readline, b""):
+                        decoded = line.decode("utf-8", errors="replace")
+                        sys.stdout.write(f"[{agent}] {decoded}")
+                        sys.stdout.flush()
+                        log_f.write(decoded)
+                        log_f.flush()
+                except Exception as e:
+                    logger.error(f"Tee thread error: {e}")
+                finally:
+                    log_f.close()
+
+            tee_thread = threading.Thread(
+                target=_tee_output, args=(process, log_file, agent_id), daemon=True
+            )
+            tee_thread.start()
+            log_file_ref = None
+        else:
+            process = subprocess.Popen(
+                cmd,
+                cwd=str(worktree_path),
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                env=agent_env,
+            )
+            log_file_ref = log_file
+
+        logger.info(f"Kiro agent {agent_id} started with PID {process.pid}")
+
+        return AgentHandle(
+            agent_id=agent_id,
+            process=process,
+            worktree_path=worktree_path,
+            log_path=log_path,
+            _log_file=log_file_ref,
+        )

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -8,6 +8,7 @@ import logging
 import os
 import signal
 import threading
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -78,8 +79,12 @@ class AgentManager:
 
         # 3. For each agent: create worktree, generate CLAUDE.md, spawn runtime
         handles = []
+        stagger = self.config.agents.stagger_seconds
         for i in range(self.config.agents.count):
             agent_id = f"agent-{i + 1}"
+            if i > 0 and stagger > 0:
+                logger.info(f"Staggering {agent_id} by {stagger}s (rate-limit backpressure)")
+                time.sleep(stagger)
             handle = self._setup_and_start_agent(agent_id)
             handles.append(handle)
 

--- a/coral/agent/registry.py
+++ b/coral/agent/registry.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from coral.agent.builtin.claude_code import ClaudeCodeRuntime
 from coral.agent.builtin.codex import CodexRuntime
+from coral.agent.builtin.kiro import KiroRuntime
 from coral.agent.builtin.opencode import OpenCodeRuntime
 from coral.agent.runtime import AgentRuntime
 
 _RUNTIMES: dict[str, type] = {
     "claude_code": ClaudeCodeRuntime,
     "codex": CodexRuntime,
+    "kiro": KiroRuntime,
     "opencode": OpenCodeRuntime,
 }
 
@@ -20,12 +22,14 @@ _ALIASES: dict[str, str] = {
     "openai": "codex",
     "openai-codex": "codex",
     "open-code": "opencode",
+    "kiro-cli": "kiro",
 }
 
 # Default models per runtime (used when user doesn't specify --model)
 _DEFAULT_MODELS: dict[str, str] = {
     "claude_code": "sonnet",
     "codex": "gpt-5.4",
+    "kiro": "auto",
     "opencode": "openai/gpt-5",
 }
 

--- a/coral/config.py
+++ b/coral/config.py
@@ -63,6 +63,7 @@ class AgentConfig:
         ]
     )
     research: bool = True  # enable web search / literature review step in workflow
+    stagger_seconds: int = 0  # delay between spawning each agent (rate-limit backpressure)
 
     def heartbeat_interval(self, name: str) -> int:
         """Get the interval for a heartbeat action by name."""


### PR DESCRIPTION
## What

Two additions to make CORAL work well with hosted-model runtimes like Kiro CLI:

### 1. Kiro CLI Runtime (`coral/agent/builtin/kiro.py`)

Adds first-class support for [Kiro CLI](https://kiro.dev) as an agent runtime. Kiro provides access to Claude Opus 4.6 with 1M context window, making it ideal for research and long-context tasks.

```yaml
agents:
  runtime: kiro
  model: claude-opus-4.6-1m
```

Features:
- Spawns `kiro-cli chat` with `--no-interactive -a` (autonomous mode)
- Supports `--model` flag for model selection
- Verbose mode with output teeing
- Registered with `kiro` and `kiro-cli` aliases

### 2. Agent Spawn Stagger (`agents.stagger_seconds`)

When running multiple agents against hosted APIs (Anthropic, OpenAI, etc.), simultaneous spawns cause immediate rate-limit errors. This adds a configurable delay between agent starts:

```yaml
agents:
  count: 3
  stagger_seconds: 60  # wait 60s between each agent spawn
```

Default is 0 (no stagger) for backward compatibility.

## Why

We've been running CORAL with 3 Kiro agents on `claude-opus-4.6-1m` for autonomous research paper generation. Without stagger, all 3 agents hit the API simultaneously and get rate-limited. With 60s stagger, each agent gets time to establish its initial context before the next one starts.

## Changes

- `coral/agent/builtin/kiro.py` — new KiroRuntime
- `coral/agent/registry.py` — register kiro runtime + aliases
- `coral/agent/manager.py` — stagger delay in spawn loop
- `coral/config.py` — `stagger_seconds` field on AgentConfig