### PR TITLE
fix: normalize naive datetimes to UTC in notes sort key

### DIFF
--- a/coral/hub/notes.py
+++ b/coral/hub/notes.py
@@ -128,7 +128,10 @@ def _sort_key(entry: dict[str, Any]) -> datetime:
     date_str = entry.get("date", "")
     if date_str:
         try:
-            return datetime.fromisoformat(date_str)
+            dt = datetime.fromisoformat(date_str)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+            return dt
         except (ValueError, TypeError):
             pass
     mtime = entry.get("_mtime")


### PR DESCRIPTION
Notes from different agent runtimes (e.g. OpenCode) may write timezone-naive timestamps in frontmatter, while fallback paths return UTC-aware datetimes. Mixing both causes TypeError on sort.