### PR TITLE
Remove obsolete task.seed and task.files config fields

### DIFF
--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -392,8 +392,6 @@ def cmd_start(args: argparse.Namespace) -> None:
         print(f"[coral] Max turns:  {config.agents.max_turns}")
         print(f"[coral] Results:    {config.workspace.results_dir}")
         print(f"[coral] Repo path:  {config.workspace.repo_path}")
-        if config.task.seed:
-            print(f"[coral] Seed files: {config.task.seed}")
         print()
 
     manager = AgentManager(config, verbose=verbose, config_dir=config_path.parent)

--- a/coral/config.py
+++ b/coral/config.py
@@ -16,9 +16,7 @@ class TaskConfig:
 
     name: str = MISSING
     description: str = MISSING
-    files: list[str] = field(default_factory=list)
     tips: str = ""
-    seed: list[str] = field(default_factory=list)  # files/dirs to copy into workspace
 
 
 @dataclass

--- a/coral/hooks/post_commit.py
+++ b/coral/hooks/post_commit.py
@@ -180,7 +180,7 @@ def run_eval(message: str, agent_id: str, workdir: str = ".") -> Attempt:
         id=config.task.name,
         name=config.task.name,
         description=config.task.description,
-        metadata={"files": config.task.files},
+        metadata={},
     )
 
     # Run evaluation with timeout

--- a/coral/template/coral.md.template
+++ b/coral/template/coral.md.template
@@ -1,7 +1,7 @@
 # Task: {task_name}
 
 {task_description}
-{files_section}
+
 ## How This Works
 
 You are one of several agents working on this task in parallel. These agents are your colleagues. Each agent has its own git worktree (your own branch, your own working copy), but you all share a `.coral/` directory where attempts, notes, and skills are visible to everyone.

--- a/coral/template/coral_md.py
+++ b/coral/template/coral_md.py
@@ -28,11 +28,6 @@ def generate_coral_md(
     template = template_path.read_text()
 
     # Build optional sections
-    files_section = ""
-    if config.task.files:
-        files_list = "\n".join(f"- `{f}`" for f in config.task.files)
-        files_section = f"\n## Key Files\n{files_list}\n"
-
     tips_section = ""
     if config.task.tips:
         tips_section = f"\n## Tips\n{config.task.tips}\n"
@@ -79,7 +74,6 @@ def generate_coral_md(
     return template.format(
         task_name=config.task.name,
         task_description=config.task.description,
-        files_section=files_section,
         tips_section=tips_section,
         score_direction=score_direction,
         agent_id=agent_id,

--- a/coral/template/coral_single.md.template
+++ b/coral/template/coral_single.md.template
@@ -1,7 +1,7 @@
 # Task: {task_name}
 
 {task_description}
-{files_section}
+
 ## How This Works
 
 You are an autonomous agent with your own git worktree (own branch, own working copy). CORAL owns git — you never run `git` commands directly. Instead, you edit files and then run `coral eval -m "description"`. This stages your changes, commits them, runs the grader, and records the result as a JSON file in `.coral/attempts/`. The score is a number — **{score_direction}**.

--- a/coral/workspace/project.py
+++ b/coral/workspace/project.py
@@ -17,7 +17,6 @@ from coral.workspace.repo import (
     copy_eval_to_private,
     copy_private_data,
     copy_seed_directory,
-    copy_seed_files,
 )
 
 logger = logging.getLogger(__name__)
@@ -137,15 +136,10 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
     # Auto-copy eval/ to .coral/private/eval/ (if present in task directory)
     copy_eval_to_private(task_source_dir, coral_dir)
 
-    # Auto-detect and copy seed/ (if present in task directory and no explicit seed paths)
-    if not config.task.seed:
-        seed_dir = task_source_dir / "seed"
-        if seed_dir.is_dir():
-            copy_seed_directory(seed_dir, repo_dir)
-
-    # Copy explicit seed files into the repo
-    if config.task.seed:
-        copy_seed_files(config.task.seed, repo_dir, config_dir or Path.cwd())
+    # Auto-copy seed/ into repo (if present in task directory)
+    seed_dir = task_source_dir / "seed"
+    if seed_dir.is_dir():
+        copy_seed_directory(seed_dir, repo_dir)
 
     # Copy private grader data into .coral/ (hidden from agents)
     if config.grader.private:

--- a/coral/workspace/repo.py
+++ b/coral/workspace/repo.py
@@ -130,34 +130,6 @@ def copy_seed_directory(seed_dir: Path, repo_dir: Path) -> None:
     _commit_staged_changes(repo_dir, "Add seed files")
 
 
-def copy_seed_files(seed_paths: list[str], repo_dir: Path, config_dir: Path) -> None:
-    """Copy seed files/directories into the repo.
-
-    Paths in seed_paths are resolved relative to config_dir.
-    Files are copied to the repo root. Directories are copied recursively.
-    """
-    for seed_path_str in seed_paths:
-        src = Path(seed_path_str)
-        if not src.is_absolute():
-            src = (config_dir / src).resolve()
-
-        if not src.exists():
-            logger.warning(f"Seed path not found, skipping: {src}")
-            continue
-
-        dst = repo_dir / src.name
-        if src.is_dir():
-            if dst.exists():
-                shutil.rmtree(dst)
-            shutil.copytree(src, dst)
-            logger.info(f"Seeded directory: {src.name}/")
-        else:
-            shutil.copy2(src, dst)
-            logger.info(f"Seeded file: {src.name}")
-
-    _commit_staged_changes(repo_dir, "Add seed files")
-
-
 def copy_private_data(private_paths: list[str], coral_dir: Path, config_dir: Path) -> None:
     """Copy private grader data into .coral/ (hidden from agent worktrees).
 

--- a/examples/ADRS/cloudcast/task.yaml
+++ b/examples/ADRS/cloudcast/task.yaml
@@ -25,8 +25,6 @@ task:
     Evaluated across 5 network configs (intra-AWS, intra-Azure, intra-GCP,
     inter-cloud AGZ, inter-cloud GAZ2).
 
-  files:
-    - "initial_program.py"
 
 grader:
   timeout: 600

--- a/examples/ADRS/eplb/task.yaml
+++ b/examples/ADRS/eplb/task.yaml
@@ -28,8 +28,6 @@ task:
     The score is: 0.5 * balancedness_score_expert + 0.5 * speed_score
     where speed_score = 0.002 / avg_inference_time (higher is better).
 
-  files:
-    - "initial_program.py"
 
 grader:
   timeout: 360

--- a/examples/ADRS/llm_sql/task.yaml
+++ b/examples/ADRS/llm_sql/task.yaml
@@ -60,8 +60,6 @@ task:
 
     Simply return the optimized Evolved class, do not provide explanations.
 
-  files:
-    - "initial_program.py"
 
 grader:
   timeout: 360

--- a/examples/ADRS/prism/task.yaml
+++ b/examples/ADRS/prism/task.yaml
@@ -28,8 +28,6 @@ task:
 
     Score: (1 / avg_max_kvpr) + success_rate across 50 random test cases.
 
-  files:
-    - "initial_program.py"
 
 grader:
   timeout: 360

--- a/examples/ADRS/txn_scheduling/task.yaml
+++ b/examples/ADRS/txn_scheduling/task.yaml
@@ -28,8 +28,6 @@ task:
 
     Score: 1,000,000 / (1 + total_makespan) — lower total makespan gives higher score.
 
-  files:
-    - "initial_program.py"
 
 grader:
   timeout: 600

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,203 @@
+# Examples
+
+Example task configurations for CORAL. Each directory contains a `task.yaml` and any supporting files (graders, seed code, data).
+
+To run any example:
+
+```bash
+coral start --config examples/<name>/task.yaml
+```
+
+## Task Structure
+
+Every task directory follows the same layout:
+
+```
+my_task/
+├── task.yaml              # Task configuration (required)
+├── eval/
+│   ├── grader.py          # Grading logic (required. Entrypoint defined in grader.args.program_file)
+│   ├── xxx.py             # Other helper tools (Optional)
+│   └── answers/           # Ground-truth data, if needed
+│       └── ...
+└── seed/                  # Initial codebase given to agents
+    ├── solution.py        # Starter code the agents will modify
+    ├── Dockerfile         # Your custom dockerfile for your task (Optinoal)
+    ├── opencode.json      # Your custom opencode config (Optional)
+    └── data/              # Any input data (datasets, configs, etc. Optional)
+        └── ...
+```
+
+### `task.yaml`
+
+The central configuration file. All available fields (with defaults):
+
+```yaml
+task:
+  name: "My Task"                    # Task name (required)
+  description: |                     # Full problem description shown to agents (required)
+    What the agent should do.
+  tips: |                            # Hints shown to agents (timeouts, constraints, etc.)
+    - Eval timeout is 120s.
+
+grader:
+  timeout: 300                       # Max seconds per evaluation (default: 300)
+  direction: maximize                # "maximize" or "minimize" (default: maximize)
+  type: ""                           # Grader type; empty = auto-discover from eval/grader.py
+  module: ""                         # Python module path for custom graders
+  args:                              # Arbitrary kwargs passed to the grader
+    program_file: "solution.py"
+  private:                           # Files/dirs copied to .coral/ (hidden from agents)
+    - "answers/"
+
+agents:
+  count: 1                           # Number of concurrent agents (default: 1)
+  runtime: claude_code               # "claude_code", "opencode", or "codex" (default: claude_code)
+  model: sonnet                      # Model name or path (default: sonnet)
+  max_turns: 200                     # Max agent turns before stopping (default: 200)
+  timeout: 3600                      # Agent-level timeout in seconds (default: 3600)
+  research: true                     # Enable web search / literature review (default: true)
+  stagger_seconds: 0                 # Delay between spawning each agent (default: 0)
+  gateway:                           # LiteLLM gateway for routing model traffic
+    enabled: false
+    port: 4000
+    config: "./litellm_config.yaml"
+    api_key: ""                      # Auto-generated if empty
+  heartbeat:                         # Periodic agent self-reflection actions
+    - name: reflect
+      every: 1                       # Trigger every N evals
+      global: false                  # false = per-agent count, true = global count
+      trigger: interval              # "interval" or "plateau"
+    - name: consolidate
+      every: 10
+      global: true
+      trigger: interval
+    - name: pivot
+      every: 5
+      trigger: plateau               # Triggers after N evals with no improvement
+
+sharing:
+  attempts: true                     # Share attempt history across agents (default: true)
+  notes: true                        # Share notes across agents (default: true)
+  skills: true                       # Share skills across agents (default: true)
+
+workspace:
+  repo_path: "./examples/my_task/seed"  # Path to seed directory (default: ".")
+  results_dir: "./results"              # Where run outputs are stored (default: ./results)
+  setup:                                # Shell commands run once per worktree before agents start
+    - "uv pip install numpy scipy"
+
+run:
+  verbose: false                     # Verbose output (default: false)
+  ui: false                          # Launch web dashboard (default: false)
+  session: tmux                      # "local", "tmux", or "docker" (default: tmux)
+  docker_image: ""                   # Custom docker image; empty = auto-build from docker/<runtime>/ (default: "")
+```
+
+### `eval/grader.py`
+
+Contains the grading logic. Typically a `TaskGrader` subclass that implements an `evaluate()` method. The grader receives the codebase path and task list, runs the agent's solution, and returns a `ScoreBundle`.
+
+### `seed/`
+
+The starting codebase that gets copied into each agent's git worktree. This is what agents see when they begin working. It should contain starter code (with a function signature the grader expects) and any data files the solution needs at runtime.
+
+## Examples Overview
+
+| Example | Description | Direction |
+|---------|-------------|-----------|
+| [circle_packing](#circle_packing) | Pack 26 circles in a unit square to maximize sum of radii | Maximize |
+| [erdos](#erdos) | Erdos minimum overlap problem | Maximize |
+| [kernel_builder](#kernel_builder) | Optimize VLIW SIMD kernel for tree traversal | Minimize |
+| [kernel_engineering](#kernel_engineering) | Triton kernel for Triangle Multiplicative Update (AlphaFold3) | Maximize |
+| [mnist](#mnist) | Handwritten digit classification (accuracy) | Maximize |
+| [spaceship_titanic](#spaceship_titanic) | Kaggle: predict passenger transportation (accuracy) | Maximize |
+| [stanford_covid_vaccine](#stanford_covid_vaccine) | Predict mRNA degradation rates (MCRMSE) | Minimize |
+| [math](#math) | 17 mathematical optimization problems | Maximize |
+| [ADRS](#adrs) | 5 systems optimization problems (scheduling, placement, etc.) | Maximize |
+| [frontier_cs_algo](#frontier_cs_algo) | 172 algorithmic competition problems (C++) | Maximize |
+| [frontier_cs_research](#frontier_cs_research) | 127 research-level CS problems (Python) | Maximize |
+
+## Details
+
+### circle_packing
+
+Pack N=26 circles into a unit square to maximize the sum of radii. The benchmark is 2.635977 (AlphaEvolve result). Score = `sum_radii / 2.635977`.
+
+- **Agents**: 1 (OpenCode runtime)
+- **Timeout**: 600s
+
+### erdos
+
+Find a step function h: [0,2] -> [0,1] that minimizes the maximum overlap integral. State-of-the-art bound is 0.380871.
+
+- **Agents**: 1
+- **Timeout**: 1100s
+
+### kernel_builder
+
+Optimize instruction scheduling for a VLIW SIMD kernel running tree traversal. The simulator is frozen; only the instruction-building code can be changed. Baseline: 147,734 cycles, best known: 1,363 cycles.
+
+- **Agents**: 1
+- **Timeout**: 120s
+- **Session**: Docker
+
+### kernel_engineering
+
+Implement a fused Triton kernel for the Triangle Multiplicative Update operation from AlphaFold3 (LayerNorm + projections + gating + einsum). Scored by `1000 / geometric_mean(runtime_us)` across 7 configurations.
+
+- **Agents**: 1
+- **Timeout**: 1200s
+
+### mnist
+
+Classify 28x28 handwritten digit images. 60k training / 10k test samples. Scored by accuracy.
+
+- **Agents**: 4
+- **Timeout**: 300s
+
+### spaceship_titanic
+
+Kaggle competition: predict which passengers were transported to an alternate dimension. 13 features, binary classification. Top leaderboard accuracy: ~0.828.
+
+- **Agents**: 4
+- **Timeout**: 120s
+
+### stanford_covid_vaccine
+
+Predict mRNA degradation rates at each base position. Scored by Mean Columnwise RMSE over three degradation targets.
+
+- **Agents**: 4
+- **Timeout**: 300s
+
+### math
+
+17 mathematical optimization problems including circle packing variants, Heilbronn triangle problems, hexagon packing, autocorrelation inequalities, and point placement problems. Each runs 2 agents with a 600s timeout.
+
+### ADRS
+
+5 systems optimization problems:
+
+- **Cloudcast** -- minimize data transfer cost across multi-cloud networks
+- **Prism** -- LLM model placement on GPU clusters (minimize KV cache pressure)
+- **EPLB** -- expert parallelism load balancing for Mixture-of-Experts
+- **LLM-SQL** -- column reordering to maximize LLM prefix cache hits
+- **Transaction Scheduling** -- minimize makespan for concurrent transactions
+
+### frontier_cs_algo
+
+172 algorithmic competition problems. Solutions are self-contained C++17 files compiled with `g++ -std=c++17 -O2`. Each is scored 0-100 across 70 test cases.
+
+### frontier_cs_research
+
+127 research-level CS problems with multiple variants (e.g. scheduling under different availability/deadline/overhead configurations). Solutions in Python with 1800s timeouts.
+
+## Writing Your Own
+
+The quickest way to scaffold a new task is `coral init my-task`. To do it manually, create the three pieces:
+
+1. **`seed/`** -- starter code with the function signature your grader will call
+2. **`eval/grader.py`** -- a `TaskGrader` subclass that imports and runs the agent's code, then returns a score
+3. **`task.yaml`** -- wire them together with the config above
+
+Use `coral validate my-task` to test your grader before launching agents.

--- a/examples/circle_packing/task.yaml
+++ b/examples/circle_packing/task.yaml
@@ -24,10 +24,6 @@ task:
     - Multi-start local optimization with perturbation
     - Gradient descent on a smooth penalty formulation
     - Quasi-Newton methods (L-BFGS-B) with constraint handling
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks: all circles within the unit square, no overlaps, and measures sum of radii.

--- a/examples/erdos/task.yaml
+++ b/examples/erdos/task.yaml
@@ -22,8 +22,6 @@ task:
     - Analytical insights about the optimal h structure
     - Hybrid approaches combining gradient-based and non-gradient methods
     - Binary/step function approximations with careful regularization
-  files:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 1100s. If your solution takes longer, it scores as a timeout — reduce complexity or n_points.
     - More n_points gives finer discretization but slower eval. Balance accuracy vs speed.

--- a/examples/frontier_cs_algo/0/task.yaml
+++ b/examples/frontier_cs_algo/0/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 70 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/1/task.yaml
+++ b/examples/frontier_cs_algo/1/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/10/task.yaml
+++ b/examples/frontier_cs_algo/10/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/101/task.yaml
+++ b/examples/frontier_cs_algo/101/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/104/task.yaml
+++ b/examples/frontier_cs_algo/104/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/106/task.yaml
+++ b/examples/frontier_cs_algo/106/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/107/task.yaml
+++ b/examples/frontier_cs_algo/107/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/108/task.yaml
+++ b/examples/frontier_cs_algo/108/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/109/task.yaml
+++ b/examples/frontier_cs_algo/109/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/11/task.yaml
+++ b/examples/frontier_cs_algo/11/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/110/task.yaml
+++ b/examples/frontier_cs_algo/110/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/111/task.yaml
+++ b/examples/frontier_cs_algo/111/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/112/task.yaml
+++ b/examples/frontier_cs_algo/112/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/113/task.yaml
+++ b/examples/frontier_cs_algo/113/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/117/task.yaml
+++ b/examples/frontier_cs_algo/117/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/119/task.yaml
+++ b/examples/frontier_cs_algo/119/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/120/task.yaml
+++ b/examples/frontier_cs_algo/120/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/121/task.yaml
+++ b/examples/frontier_cs_algo/121/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/122/task.yaml
+++ b/examples/frontier_cs_algo/122/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/123/task.yaml
+++ b/examples/frontier_cs_algo/123/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/124/task.yaml
+++ b/examples/frontier_cs_algo/124/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/125/task.yaml
+++ b/examples/frontier_cs_algo/125/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/127/task.yaml
+++ b/examples/frontier_cs_algo/127/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/13/task.yaml
+++ b/examples/frontier_cs_algo/13/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/132/task.yaml
+++ b/examples/frontier_cs_algo/132/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/133/task.yaml
+++ b/examples/frontier_cs_algo/133/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/134/task.yaml
+++ b/examples/frontier_cs_algo/134/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/135/task.yaml
+++ b/examples/frontier_cs_algo/135/task.yaml
@@ -17,8 +17,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/137/task.yaml
+++ b/examples/frontier_cs_algo/137/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/138/task.yaml
+++ b/examples/frontier_cs_algo/138/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/14/task.yaml
+++ b/examples/frontier_cs_algo/14/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/140/task.yaml
+++ b/examples/frontier_cs_algo/140/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/141/task.yaml
+++ b/examples/frontier_cs_algo/141/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/142/task.yaml
+++ b/examples/frontier_cs_algo/142/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/143/task.yaml
+++ b/examples/frontier_cs_algo/143/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/144/task.yaml
+++ b/examples/frontier_cs_algo/144/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/145/task.yaml
+++ b/examples/frontier_cs_algo/145/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 2 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/147/task.yaml
+++ b/examples/frontier_cs_algo/147/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/148/task.yaml
+++ b/examples/frontier_cs_algo/148/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/149/task.yaml
+++ b/examples/frontier_cs_algo/149/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/15/task.yaml
+++ b/examples/frontier_cs_algo/15/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/150/task.yaml
+++ b/examples/frontier_cs_algo/150/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/151/task.yaml
+++ b/examples/frontier_cs_algo/151/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/152/task.yaml
+++ b/examples/frontier_cs_algo/152/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/153/task.yaml
+++ b/examples/frontier_cs_algo/153/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/154/task.yaml
+++ b/examples/frontier_cs_algo/154/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/155/task.yaml
+++ b/examples/frontier_cs_algo/155/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/156/task.yaml
+++ b/examples/frontier_cs_algo/156/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/157/task.yaml
+++ b/examples/frontier_cs_algo/157/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/158/task.yaml
+++ b/examples/frontier_cs_algo/158/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/159/task.yaml
+++ b/examples/frontier_cs_algo/159/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/16/task.yaml
+++ b/examples/frontier_cs_algo/16/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/160/task.yaml
+++ b/examples/frontier_cs_algo/160/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/161/task.yaml
+++ b/examples/frontier_cs_algo/161/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/162/task.yaml
+++ b/examples/frontier_cs_algo/162/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/163/task.yaml
+++ b/examples/frontier_cs_algo/163/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/164/task.yaml
+++ b/examples/frontier_cs_algo/164/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/165/task.yaml
+++ b/examples/frontier_cs_algo/165/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/166/task.yaml
+++ b/examples/frontier_cs_algo/166/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/167/task.yaml
+++ b/examples/frontier_cs_algo/167/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/168/task.yaml
+++ b/examples/frontier_cs_algo/168/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/169/task.yaml
+++ b/examples/frontier_cs_algo/169/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/17/task.yaml
+++ b/examples/frontier_cs_algo/17/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/170/task.yaml
+++ b/examples/frontier_cs_algo/170/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/171/task.yaml
+++ b/examples/frontier_cs_algo/171/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/174/task.yaml
+++ b/examples/frontier_cs_algo/174/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/175/task.yaml
+++ b/examples/frontier_cs_algo/175/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/176/task.yaml
+++ b/examples/frontier_cs_algo/176/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/177/task.yaml
+++ b/examples/frontier_cs_algo/177/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/178/task.yaml
+++ b/examples/frontier_cs_algo/178/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/179/task.yaml
+++ b/examples/frontier_cs_algo/179/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/180/task.yaml
+++ b/examples/frontier_cs_algo/180/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/181/task.yaml
+++ b/examples/frontier_cs_algo/181/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/182/task.yaml
+++ b/examples/frontier_cs_algo/182/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/183/task.yaml
+++ b/examples/frontier_cs_algo/183/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/184/task.yaml
+++ b/examples/frontier_cs_algo/184/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/185/task.yaml
+++ b/examples/frontier_cs_algo/185/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/186/task.yaml
+++ b/examples/frontier_cs_algo/186/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/187/task.yaml
+++ b/examples/frontier_cs_algo/187/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/188/task.yaml
+++ b/examples/frontier_cs_algo/188/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/189/task.yaml
+++ b/examples/frontier_cs_algo/189/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/192/task.yaml
+++ b/examples/frontier_cs_algo/192/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/193/task.yaml
+++ b/examples/frontier_cs_algo/193/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/2/task.yaml
+++ b/examples/frontier_cs_algo/2/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/203/task.yaml
+++ b/examples/frontier_cs_algo/203/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/205/task.yaml
+++ b/examples/frontier_cs_algo/205/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/207/task.yaml
+++ b/examples/frontier_cs_algo/207/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/209/task.yaml
+++ b/examples/frontier_cs_algo/209/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/210/task.yaml
+++ b/examples/frontier_cs_algo/210/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/211/task.yaml
+++ b/examples/frontier_cs_algo/211/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 4 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/212/task.yaml
+++ b/examples/frontier_cs_algo/212/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 4 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/213/task.yaml
+++ b/examples/frontier_cs_algo/213/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/214/task.yaml
+++ b/examples/frontier_cs_algo/214/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/217/task.yaml
+++ b/examples/frontier_cs_algo/217/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/22/task.yaml
+++ b/examples/frontier_cs_algo/22/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/220/task.yaml
+++ b/examples/frontier_cs_algo/220/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 4 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/222/task.yaml
+++ b/examples/frontier_cs_algo/222/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/225/task.yaml
+++ b/examples/frontier_cs_algo/225/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/227/task.yaml
+++ b/examples/frontier_cs_algo/227/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/228/task.yaml
+++ b/examples/frontier_cs_algo/228/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/229/task.yaml
+++ b/examples/frontier_cs_algo/229/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/23/task.yaml
+++ b/examples/frontier_cs_algo/23/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/231/task.yaml
+++ b/examples/frontier_cs_algo/231/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/233/task.yaml
+++ b/examples/frontier_cs_algo/233/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/239/task.yaml
+++ b/examples/frontier_cs_algo/239/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 4 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/24/task.yaml
+++ b/examples/frontier_cs_algo/24/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/241/task.yaml
+++ b/examples/frontier_cs_algo/241/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 5 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/243/task.yaml
+++ b/examples/frontier_cs_algo/243/task.yaml
@@ -17,8 +17,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 4 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/245/task.yaml
+++ b/examples/frontier_cs_algo/245/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/247/task.yaml
+++ b/examples/frontier_cs_algo/247/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 5 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/248/task.yaml
+++ b/examples/frontier_cs_algo/248/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 4 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/249/task.yaml
+++ b/examples/frontier_cs_algo/249/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/25/task.yaml
+++ b/examples/frontier_cs_algo/25/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/252/task.yaml
+++ b/examples/frontier_cs_algo/252/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/253/task.yaml
+++ b/examples/frontier_cs_algo/253/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/254/task.yaml
+++ b/examples/frontier_cs_algo/254/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/255/task.yaml
+++ b/examples/frontier_cs_algo/255/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/256/task.yaml
+++ b/examples/frontier_cs_algo/256/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/257/task.yaml
+++ b/examples/frontier_cs_algo/257/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/258/task.yaml
+++ b/examples/frontier_cs_algo/258/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/26/task.yaml
+++ b/examples/frontier_cs_algo/26/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/27/task.yaml
+++ b/examples/frontier_cs_algo/27/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/28/task.yaml
+++ b/examples/frontier_cs_algo/28/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/3/task.yaml
+++ b/examples/frontier_cs_algo/3/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/30/task.yaml
+++ b/examples/frontier_cs_algo/30/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/33/task.yaml
+++ b/examples/frontier_cs_algo/33/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/35/task.yaml
+++ b/examples/frontier_cs_algo/35/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/36/task.yaml
+++ b/examples/frontier_cs_algo/36/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/4/task.yaml
+++ b/examples/frontier_cs_algo/4/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/40/task.yaml
+++ b/examples/frontier_cs_algo/40/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/41/task.yaml
+++ b/examples/frontier_cs_algo/41/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/42/task.yaml
+++ b/examples/frontier_cs_algo/42/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/43/task.yaml
+++ b/examples/frontier_cs_algo/43/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/44/task.yaml
+++ b/examples/frontier_cs_algo/44/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/45/task.yaml
+++ b/examples/frontier_cs_algo/45/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/46/task.yaml
+++ b/examples/frontier_cs_algo/46/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/47/task.yaml
+++ b/examples/frontier_cs_algo/47/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/48/task.yaml
+++ b/examples/frontier_cs_algo/48/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/5/task.yaml
+++ b/examples/frontier_cs_algo/5/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/50/task.yaml
+++ b/examples/frontier_cs_algo/50/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/52/task.yaml
+++ b/examples/frontier_cs_algo/52/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/53/task.yaml
+++ b/examples/frontier_cs_algo/53/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/54/task.yaml
+++ b/examples/frontier_cs_algo/54/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/57/task.yaml
+++ b/examples/frontier_cs_algo/57/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/58/task.yaml
+++ b/examples/frontier_cs_algo/58/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/59/task.yaml
+++ b/examples/frontier_cs_algo/59/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/6/task.yaml
+++ b/examples/frontier_cs_algo/6/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/60/task.yaml
+++ b/examples/frontier_cs_algo/60/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/61/task.yaml
+++ b/examples/frontier_cs_algo/61/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 10 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/62/task.yaml
+++ b/examples/frontier_cs_algo/62/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/63/task.yaml
+++ b/examples/frontier_cs_algo/63/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/64/task.yaml
+++ b/examples/frontier_cs_algo/64/task.yaml
@@ -34,8 +34,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/68/task.yaml
+++ b/examples/frontier_cs_algo/68/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/69/task.yaml
+++ b/examples/frontier_cs_algo/69/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/7/task.yaml
+++ b/examples/frontier_cs_algo/7/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/70/task.yaml
+++ b/examples/frontier_cs_algo/70/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/72/task.yaml
+++ b/examples/frontier_cs_algo/72/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/73/task.yaml
+++ b/examples/frontier_cs_algo/73/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/75/task.yaml
+++ b/examples/frontier_cs_algo/75/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/77/task.yaml
+++ b/examples/frontier_cs_algo/77/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/79/task.yaml
+++ b/examples/frontier_cs_algo/79/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/8/task.yaml
+++ b/examples/frontier_cs_algo/8/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/80/task.yaml
+++ b/examples/frontier_cs_algo/80/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/81/task.yaml
+++ b/examples/frontier_cs_algo/81/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/82/task.yaml
+++ b/examples/frontier_cs_algo/82/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/83/task.yaml
+++ b/examples/frontier_cs_algo/83/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/85/task.yaml
+++ b/examples/frontier_cs_algo/85/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 1 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/86/task.yaml
+++ b/examples/frontier_cs_algo/86/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/87/task.yaml
+++ b/examples/frontier_cs_algo/87/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/89/task.yaml
+++ b/examples/frontier_cs_algo/89/task.yaml
@@ -17,8 +17,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/9/task.yaml
+++ b/examples/frontier_cs_algo/9/task.yaml
@@ -33,8 +33,6 @@ task:
     a baseline.
 
     - Test your solution locally before submitting.'
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_algo/93/task.yaml
+++ b/examples/frontier_cs_algo/93/task.yaml
@@ -16,8 +16,6 @@ task:
     \ annealing, beam search, greedy + local search.\n                - Check the\
     \ scoring formula in the statement — some problems score relative to a baseline.\n\
     \                - Test your solution locally before submitting."
-  files:
-  - solution.cpp
   tips: '- Your score is 0-100 based on solution quality across 3 test cases.
 
     - Invalid or crashing solutions score 0.

--- a/examples/frontier_cs_research/cant_be_late__high_availability_loose_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__high_availability_loose_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__high_availability_loose_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__high_availability_loose_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__high_availability_tight_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__high_availability_tight_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__high_availability_tight_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__high_availability_tight_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__low_availability_loose_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__low_availability_loose_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__low_availability_loose_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__low_availability_loose_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__low_availability_tight_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__low_availability_tight_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__low_availability_tight_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__low_availability_tight_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__mixed_availability_loose_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__mixed_availability_loose_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__mixed_availability_loose_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__mixed_availability_loose_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__mixed_availability_tight_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__mixed_availability_tight_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late__mixed_availability_tight_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late__mixed_availability_tight_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late_multi__high_availability_loose_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late_multi__high_availability_loose_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late_multi__high_availability_loose_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late_multi__high_availability_loose_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late_multi__high_availability_tight_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late_multi__high_availability_tight_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late_multi__high_availability_tight_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late_multi__high_availability_tight_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late_multi__low_availability_loose_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late_multi__low_availability_loose_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late_multi__low_availability_loose_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late_multi__low_availability_loose_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late_multi__low_availability_tight_deadline_large_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late_multi__low_availability_tight_deadline_large_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cant_be_late_multi__low_availability_tight_deadline_small_overhead/task.yaml
+++ b/examples/frontier_cs_research/cant_be_late_multi__low_availability_tight_deadline_small_overhead/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cloudcast/task.yaml
+++ b/examples/frontier_cs_research/cloudcast/task.yaml
@@ -11,8 +11,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/cross_entropy/task.yaml
+++ b/examples/frontier_cs_research/cross_entropy/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/decoding_attn/task.yaml
+++ b/examples/frontier_cs_research/decoding_attn/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/flash_attn/task.yaml
+++ b/examples/frontier_cs_research/flash_attn/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/fused_linear_ce/task.yaml
+++ b/examples/frontier_cs_research/fused_linear_ce/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/fused_linear_jsd/task.yaml
+++ b/examples/frontier_cs_research/fused_linear_jsd/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/gdpa_attention/task.yaml
+++ b/examples/frontier_cs_research/gdpa_attention/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/gemm_optimization__annoying/task.yaml
+++ b/examples/frontier_cs_research/gemm_optimization__annoying/task.yaml
@@ -5,8 +5,6 @@ task:
     \ in `statement.md`.\n\n            Write your solution in `solution.py`.\nNOTE:\
     \ This problem requires GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/gemm_optimization__k_skewed/task.yaml
+++ b/examples/frontier_cs_research/gemm_optimization__k_skewed/task.yaml
@@ -5,8 +5,6 @@ task:
     \ in `statement.md`.\n\n            Write your solution in `solution.py`.\nNOTE:\
     \ This problem requires GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/gemm_optimization__near_tile/task.yaml
+++ b/examples/frontier_cs_research/gemm_optimization__near_tile/task.yaml
@@ -5,8 +5,6 @@ task:
     \ in `statement.md`.\n\n            Write your solution in `solution.py`.\nNOTE:\
     \ This problem requires GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/gemm_optimization__rectangles/task.yaml
+++ b/examples/frontier_cs_research/gemm_optimization__rectangles/task.yaml
@@ -5,8 +5,6 @@ task:
     \ in `statement.md`.\n\n            Write your solution in `solution.py`.\nNOTE:\
     \ This problem requires GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/gemm_optimization__squares/task.yaml
+++ b/examples/frontier_cs_research/gemm_optimization__squares/task.yaml
@@ -5,8 +5,6 @@ task:
     \ in `statement.md`.\n\n            Write your solution in `solution.py`.\nNOTE:\
     \ This problem requires GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/gemm_optimization__transformerish/task.yaml
+++ b/examples/frontier_cs_research/gemm_optimization__transformerish/task.yaml
@@ -5,8 +5,6 @@ task:
     \ in `statement.md`.\n\n            Write your solution in `solution.py`.\nNOTE:\
     \ This problem requires GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/grammar_fuzzing__fuzzer_sql/task.yaml
+++ b/examples/frontier_cs_research/grammar_fuzzing__fuzzer_sql/task.yaml
@@ -5,8 +5,6 @@ task:
     \ in `statement.md`.\n\n            Write your solution in `solution.py`.\nDocker\
     \ image: python:3.11-slim\n\n            Your score will be 0-100 based on solution\
     \ quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 300s.

--- a/examples/frontier_cs_research/grammar_fuzzing__seed_sql/task.yaml
+++ b/examples/frontier_cs_research/grammar_fuzzing__seed_sql/task.yaml
@@ -5,8 +5,6 @@ task:
     \ in `statement.md`.\n\n            Write your solution in `solution.py`.\nDocker\
     \ image: python:3.11-slim\n\n            Your score will be 0-100 based on solution\
     \ quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 300s.

--- a/examples/frontier_cs_research/group_gemm/task.yaml
+++ b/examples/frontier_cs_research/group_gemm/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/imagenet_pareto__1m/task.yaml
+++ b/examples/frontier_cs_research/imagenet_pareto__1m/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/imagenet_pareto__200k/task.yaml
+++ b/examples/frontier_cs_research/imagenet_pareto__200k/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/imagenet_pareto__2_5m/task.yaml
+++ b/examples/frontier_cs_research/imagenet_pareto__2_5m/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/imagenet_pareto__500k/task.yaml
+++ b/examples/frontier_cs_research/imagenet_pareto__500k/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/imagenet_pareto__5m/task.yaml
+++ b/examples/frontier_cs_research/imagenet_pareto__5m/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/llm_router/task.yaml
+++ b/examples/frontier_cs_research/llm_router/task.yaml
@@ -11,8 +11,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/llm_sql__large/task.yaml
+++ b/examples/frontier_cs_research/llm_sql__large/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/llm_sql__small/task.yaml
+++ b/examples/frontier_cs_research/llm_sql__small/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/mamba2_scan/task.yaml
+++ b/examples/frontier_cs_research/mamba2_scan/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/mixed_gemm/task.yaml
+++ b/examples/frontier_cs_research/mixed_gemm/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/nbody_simulation__random_100k/task.yaml
+++ b/examples/frontier_cs_research/nbody_simulation__random_100k/task.yaml
@@ -4,8 +4,6 @@ task:
     \ from the Frontier-CS benchmark.\n            Read the full problem statement\
     \ in `statement.md`.\n\n            Write your solution in `solution.cpp`.\nDocker\
     \ image: gcc:13\n\n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.cpp
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 600s.

--- a/examples/frontier_cs_research/nbody_simulation__random_10k/task.yaml
+++ b/examples/frontier_cs_research/nbody_simulation__random_10k/task.yaml
@@ -4,8 +4,6 @@ task:
     \ from the Frontier-CS benchmark.\n            Read the full problem statement\
     \ in `statement.md`.\n\n            Write your solution in `solution.cpp`.\nDocker\
     \ image: gcc:13\n\n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.cpp
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 600s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_arvo_21000/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_arvo_21000/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_arvo_47101/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_arvo_47101/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_arvo_47500/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_arvo_47500/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_372515086/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_372515086/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_376100377/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_376100377/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_382816119/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_382816119/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_383170474/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_383170474/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_383200048/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_383200048/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_385170375/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_385170375/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_388571282/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_388571282/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42535447/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42535447/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42535696/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42535696/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42536108/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42536108/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42536279/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42536279/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42536646/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42536646/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42536679/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42536679/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42537014/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42537014/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42537168/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42537168/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42537171/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42537171/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42537670/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_buffer_overflow_oss_fuzz_42537670/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_21604/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_21604/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_27851/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_27851/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_34584/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_34584/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_35876/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_35876/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_3630/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_3630/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_36861/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_36861/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_41356/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_41356/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_42280/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_42280/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_44597/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_44597/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_47213/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_47213/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_59207/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_59207/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_5921/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_5921/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_60670/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_60670/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_61292/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_61292/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_919/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_arvo_919/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_368076875/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_368076875/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_372994344/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_372994344/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_42535152/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_42535152/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_42536661/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_42536661/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_42537493/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__heap_use_after_free_oss_fuzz_42537493/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_12466/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_12466/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_18615/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_18615/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_20775/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_20775/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_22507/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_22507/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_24538/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_24538/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_28766/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_28766/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_30831/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_30831/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_38870/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_38870/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_44034/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_44034/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_48959/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_48959/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_50683/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_50683/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_53536/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_53536/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_55948/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_55948/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_63746/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_63746/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_7024/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_7024/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_781/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_arvo_781/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_oss_fuzz_385180600/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_oss_fuzz_385180600/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_oss_fuzz_42534949/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_oss_fuzz_42534949/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_oss_fuzz_42536536/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_oss_fuzz_42536536/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_oss_fuzz_42537907/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__stack_buffer_overflow_oss_fuzz_42537907/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__uninitialized_value_oss_fuzz_42536068/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__uninitialized_value_oss_fuzz_42536068/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__uninitialized_value_oss_fuzz_42537583/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__uninitialized_value_oss_fuzz_42537583/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/poc_generation__uninitialized_value_oss_fuzz_42537958/task.yaml
+++ b/examples/frontier_cs_research/poc_generation__uninitialized_value_oss_fuzz_42537958/task.yaml
@@ -5,8 +5,6 @@ task:
     \ problem statement in `statement.md`.\n\n            Write your solution in `solution.py`.\n\
     NOTE: This problem requires GPU (CUDA) for evaluation.\nDocker image: python:3.11-slim-trixie\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/qknorm/task.yaml
+++ b/examples/frontier_cs_research/qknorm/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122-nvcc\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/quant_dot_int4/task.yaml
+++ b/examples/frontier_cs_research/quant_dot_int4/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/ragged_attention/task.yaml
+++ b/examples/frontier_cs_research/ragged_attention/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/symbolic_regression__mccormick/task.yaml
+++ b/examples/frontier_cs_research/symbolic_regression__mccormick/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/symbolic_regression__mixed_polyexp_4d/task.yaml
+++ b/examples/frontier_cs_research/symbolic_regression__mixed_polyexp_4d/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/symbolic_regression__peaks/task.yaml
+++ b/examples/frontier_cs_research/symbolic_regression__peaks/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/symbolic_regression__ripple/task.yaml
+++ b/examples/frontier_cs_research/symbolic_regression__ripple/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/symbolic_regression__sincos/task.yaml
+++ b/examples/frontier_cs_research/symbolic_regression__sincos/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/vdb_pareto__balanced/task.yaml
+++ b/examples/frontier_cs_research/vdb_pareto__balanced/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/vdb_pareto__high_recall/task.yaml
+++ b/examples/frontier_cs_research/vdb_pareto__high_recall/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/vdb_pareto__low_latency/task.yaml
+++ b/examples/frontier_cs_research/vdb_pareto__low_latency/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/vdb_pareto__recall80_latency/task.yaml
+++ b/examples/frontier_cs_research/vdb_pareto__recall80_latency/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/vdb_pareto__recall95_latency/task.yaml
+++ b/examples/frontier_cs_research/vdb_pareto__recall95_latency/task.yaml
@@ -12,8 +12,6 @@ task:
     Your score will be 0-100 based on solution quality.
 
     '
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 3600s.

--- a/examples/frontier_cs_research/vector_addition__2_20/task.yaml
+++ b/examples/frontier_cs_research/vector_addition__2_20/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/vector_addition__2_24/task.yaml
+++ b/examples/frontier_cs_research/vector_addition__2_24/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/frontier_cs_research/vector_addition__2_28/task.yaml
+++ b/examples/frontier_cs_research/vector_addition__2_28/task.yaml
@@ -5,8 +5,6 @@ task:
     \n            Write your solution in `solution.py`.\nNOTE: This problem requires\
     \ GPU (CUDA) for evaluation.\nDocker image: andylizf/triton-tlx:tlx-nv-cu122\n\
     \n            Your score will be 0-100 based on solution quality.\n"
-  files:
-  - solution.py
   tips: '- Read statement.md carefully for the exact interface and scoring formula.
 
     - Evaluation timeout: 1800s.

--- a/examples/kernel_builder/task.yaml
+++ b/examples/kernel_builder/task.yaml
@@ -28,10 +28,6 @@ task:
     3. Loop unrolling: Reduce loop overhead
     4. Memory access patterns: Use vload/vstore for contiguous access
     5. Instruction scheduling: Avoid dependencies, maximize ILP
-  files:
-    - "kernel_builder.py"
-  seed:
-    - "kernel_builder.py"
   tips: |
     - Eval timeout is 120s. The kernel itself should run in under a second.
     - Correctness is mandatory — incorrect output scores 0.

--- a/examples/kernel_engineering/trimul/task.yaml
+++ b/examples/kernel_engineering/trimul/task.yaml
@@ -118,8 +118,6 @@ task:
 
     Correctness tolerances: rtol=2e-2, atol=2e-2.
     Score = 1000 / geometric_mean(runtime_us). Higher score is better.
-  files:
-    - submission.py
   tips: |
     - IMPORTANT: Always use `/usr/bin/python3` to run and test code — do NOT use `python` or `python3`, as the venv Python does not have torch/triton installed.
     - Use @triton.jit kernels for fused operations

--- a/examples/math/circle_packing/task.yaml
+++ b/examples/math/circle_packing/task.yaml
@@ -24,10 +24,6 @@ task:
     - Multi-start local optimization with perturbation
     - Gradient descent on a smooth penalty formulation
     - Quasi-Newton methods (L-BFGS-B) with constraint handling
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks: all circles within the unit square, no overlaps, and measures sum of radii.

--- a/examples/math/circle_packing_rect/task.yaml
+++ b/examples/math/circle_packing_rect/task.yaml
@@ -17,10 +17,6 @@ task:
       4. sum(radii) is maximized
 
     Your score is based on how close your sum of radii is to the best known result (2.3658321334167627).
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator computes the minimum circumscribing rectangle and checks its perimeter <= 4.

--- a/examples/math/erdos_min_overlap/task.yaml
+++ b/examples/math/erdos_min_overlap/task.yaml
@@ -24,10 +24,6 @@ task:
     - FFT-based correlation computation for speed
     - Penalty methods for the integral constraint
     - Multi-start optimization with different initializations
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks: h in [0,1], integral of h = 1 (atol=1e-3), recomputes C5 via np.correlate and verifies consistency (atol=1e-4).

--- a/examples/math/first_autocorr_ineq/task.yaml
+++ b/examples/math/first_autocorr_ineq/task.yaml
@@ -25,10 +25,6 @@ task:
     - Varying discretization resolution
     - Smart initialization strategies
     - Learning rate schedules with warmup
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator verifies: f is non-negative, shape matches n_points, recomputes C1 independently.

--- a/examples/math/heilbronn_convex_13/task.yaml
+++ b/examples/math/heilbronn_convex_13/task.yaml
@@ -12,10 +12,6 @@ task:
     where BENCHMARK = 0.030936889034895654.
 
     A score of 1.0 means matching the best known result; above 1.0 is a new record.
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks all C(13,3) = 286 triangles formed by point triples.

--- a/examples/math/heilbronn_convex_14/task.yaml
+++ b/examples/math/heilbronn_convex_14/task.yaml
@@ -12,10 +12,6 @@ task:
     where BENCHMARK = 0.027835571458482138.
 
     A score of 1.0 means matching the best known result; above 1.0 is a new record.
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks all C(14,3) = 364 triangles formed by point triples.

--- a/examples/math/heilbronn_triangle/task.yaml
+++ b/examples/math/heilbronn_triangle/task.yaml
@@ -14,10 +14,6 @@ task:
     where BENCHMARK = 0.036529889880030156.
 
     A score of 1.0 means matching the best known result; above 1.0 is a new record.
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks all C(11,3) = 165 triangles formed by point triples.

--- a/examples/math/hexagon_packing_11/task.yaml
+++ b/examples/math/hexagon_packing_11/task.yaml
@@ -19,10 +19,6 @@ task:
 
     Your score is based on how close 1/outer_hex_side_length is to the best known result
     (1/3.930092 ~ 0.2544).
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator uses the Separating Axis Theorem (SAT) for disjointness checks.

--- a/examples/math/hexagon_packing_12/task.yaml
+++ b/examples/math/hexagon_packing_12/task.yaml
@@ -19,10 +19,6 @@ task:
 
     Your score is based on how close 1/outer_hex_side_length is to the best known result
     (1/3.9419123 ~ 0.2537).
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator uses the Separating Axis Theorem (SAT) for disjointness checks.

--- a/examples/math/matmul/task.yaml
+++ b/examples/math/matmul/task.yaml
@@ -34,10 +34,6 @@ task:
     - Different initialization strategies and learning rate schedules
     - Constraint enforcement to keep solutions in a valid space
     - Grid-based search in the space of half-integer or integer decompositions
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks EXACT equality of the reconstructed tensor vs ground truth — approximate solutions score 0.

--- a/examples/math/minimizing_max_min_dist_2d/task.yaml
+++ b/examples/math/minimizing_max_min_dist_2d/task.yaml
@@ -12,10 +12,6 @@ task:
     where BENCHMARK = 1 / 12.889266112.
 
     A score of 1.0 means matching the best known result; above 1.0 is a new record.
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator computes all pairwise distances using scipy.spatial.distance.pdist.

--- a/examples/math/minimizing_max_min_dist_3d/task.yaml
+++ b/examples/math/minimizing_max_min_dist_3d/task.yaml
@@ -21,10 +21,6 @@ task:
     - Force-directed methods (repulsion between close points)
     - Known polyhedra and geometric constructions for 14 points
     - Gradient descent on smooth objective formulations
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks: shape is (14, 3), computes pairwise distances via scipy.spatial.distance.pdist.

--- a/examples/math/second_autocorr_ineq/task.yaml
+++ b/examples/math/second_autocorr_ineq/task.yaml
@@ -28,10 +28,6 @@ task:
     - Varying discretization resolution
     - Smart initialization strategies
     - Learning rate schedules with warmup
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator verifies: f is non-negative, shape matches n_points, recomputes C2 using the piecewise linear integral method.

--- a/examples/math/signal_processing/task.yaml
+++ b/examples/math/signal_processing/task.yaml
@@ -36,10 +36,6 @@ task:
     - Exponential moving averages with adaptive weighting
     - Savitzky-Golay filtering for trend preservation
     - Median filtering for impulse noise rejection
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. Each of 5 test signals has a 10s per-signal timeout.
     - The evaluator generates 5 test signals with different characteristics and noise levels.

--- a/examples/math/sums_diffs_finite_sets/task.yaml
+++ b/examples/math/sums_diffs_finite_sets/task.yaml
@@ -24,10 +24,6 @@ task:
     - Genetic algorithms exploring set compositions
     - Greedy construction with local search refinement
     - Multi-start approaches with different random seeds
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator checks: U is a 1D array, contains 0, all non-negative integers, recomputes C6 and verifies consistency.

--- a/examples/math/third_autocorr_ineq/task.yaml
+++ b/examples/math/third_autocorr_ineq/task.yaml
@@ -28,10 +28,6 @@ task:
     - Allowing f to take negative values for better C3 bounds
     - Multi-start optimization to escape local minima
     - Learning rate schedules with warmup
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator verifies: shape matches n_points, integral is non-zero, recomputes C3 independently.

--- a/examples/math/uncertainty_ineq/task.yaml
+++ b/examples/math/uncertainty_ineq/task.yaml
@@ -26,10 +26,6 @@ task:
     - Multiple restarts with small perturbations around known good solutions
     - Careful numerical root-finding after optimization
     - Using scipy.special.hermite for polynomial construction
-  files:
-    - "initial_program.py"
-  seed:
-    - "initial_program.py"
   tips: |
     - Eval timeout is 600s. If your solution takes longer, it scores as a timeout.
     - The evaluator uses sympy for exact symbolic verification of P(0)=0, positivity at +inf, and root finding.

--- a/examples/mnist/task.yaml
+++ b/examples/mnist/task.yaml
@@ -22,8 +22,6 @@ task:
 
     **Environment:** GPU 0 is a H200 available for use.
 
-  files:
-    - "solution.py"
   tips: |
     - Metric is classification accuracy (higher is better, 0–1 scale)
     - A random baseline scores ~0.10, a simple logistic regression scores ~0.92

--- a/examples/spaceship_titanic/task.yaml
+++ b/examples/spaceship_titanic/task.yaml
@@ -62,8 +62,6 @@ task:
 
     **Environment:** GPU 0 is a H200 available for use.
 
-  files:
-    - "solution.py"
   tips: |
     - Metric is classification accuracy (higher is better, 0–1 scale)
     - Kaggle leaderboard (2288 teams): top score 0.82815, gold ≥ 0.821, silver ≥ 0.814, bronze ≥ 0.810. You are aiming to beat the top score.

--- a/examples/stanford_covid_vaccine/task.yaml
+++ b/examples/stanford_covid_vaccine/task.yaml
@@ -57,8 +57,6 @@ task:
 
     **Environment:** GPU 0 is a H200 available for use.
 
-  files:
-    - "solution.py"
   tips: |
     - Metric is MCRMSE (lower is better) over 3 scored columns: reactivity, deg_Mg_pH10, deg_Mg_50C
     - NOTE: This eval uses an MLEBench re-split (10% of original training data as test), NOT the original Kaggle private test set. Scores are not directly comparable to the Kaggle leaderboard.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ from coral.config import (
 
 def test_config_roundtrip():
     config = CoralConfig(
-        task=TaskConfig(name="test", description="A test", files=["main.py"], tips="Be fast"),
+        task=TaskConfig(name="test", description="A test", tips="Be fast"),
         grader=GraderConfig(type="function", module="my_module", args={"k": 1}),
         agents=AgentConfig(count=2, model="opus"),
     )
@@ -26,7 +26,6 @@ def test_config_roundtrip():
         restored = CoralConfig.from_yaml(f.name)
 
     assert restored.task.name == "test"
-    assert restored.task.files == ["main.py"]
     assert restored.grader.type == "function"
     assert restored.agents.count == 2
     assert restored.agents.model == "opus"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,7 +31,7 @@ def test_full_workspace_creation():
 
         # Create project
         config = CoralConfig(
-            task=TaskConfig(name="optimize", description="Make it fast", files=["main.py"], tips="Profile first"),
+            task=TaskConfig(name="optimize", description="Make it fast", tips="Profile first"),
             grader=GraderConfig(type="function"),
             agents=AgentConfig(count=2),
             workspace=WorkspaceConfig(results_dir=str(base / "results"), repo_path=str(repo)),
@@ -109,7 +109,6 @@ def test_coral_md_generation():
         task=TaskConfig(
             name="Kernel Optimization",
             description="Optimize the VLIW kernel for minimum cycle count.",
-            files=["kernel_builder.py", "helpers.py"],
             tips="- Use SIMD vectorization\n- Minimize memory stalls",
         ),
         grader=GraderConfig(type="kernel_builder"),
@@ -121,10 +120,6 @@ def test_coral_md_generation():
     # Must contain task info
     assert "Kernel Optimization" in md
     assert "VLIW kernel" in md
-
-    # Must list key files
-    assert "kernel_builder.py" in md
-    assert "helpers.py" in md
 
     # Must include tips
     assert "SIMD vectorization" in md

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -9,7 +9,6 @@ def test_generate_coral_md_has_required_sections():
         task=TaskConfig(
             name="Kernel Optimization",
             description="Optimize the kernel for speed.",
-            files=["kernel_builder.py"],
             tips="Profile first!",
         ),
         grader=GraderConfig(type="kernel_builder"),
@@ -21,7 +20,6 @@ def test_generate_coral_md_has_required_sections():
     # Task info
     assert "Kernel Optimization" in md
     assert "Optimize the kernel for speed" in md
-    assert "kernel_builder.py" in md
 
     # Tips
     assert "Profile first!" in md
@@ -78,7 +76,6 @@ def test_generate_coral_md_single_agent():
         task=TaskConfig(
             name="Solo Task",
             description="Optimize alone.",
-            files=["target.py"],
             tips="Be thorough.",
         ),
         grader=GraderConfig(type="function"),
@@ -90,7 +87,6 @@ def test_generate_coral_md_single_agent():
     # Core content present
     assert "Solo Task" in md
     assert "Optimize alone." in md
-    assert "target.py" in md
     assert "Be thorough." in md
     assert "agent-1" in md
     assert "fully autonomous" in md


### PR DESCRIPTION
## Summary
- **Remove `task.seed`**: redundant with `workspace.repo_path`, which already copies the entire seed directory into each agent's worktree
- **Remove `task.files`**: only rendered a "Key Files" section in CORAL.md and populated unused task metadata — the same information belongs in `task.description`
- **Add `examples/README.md`**: documents the task directory structure and all available `task.yaml` configuration fields

## Test plan
- [x] All 79 tests pass (`uv run pytest tests/ -v`)
- [ ] Verify `coral start` still works end-to-end with an example task

🤖 Generated with [Claude Code](https://claude.com/claude-code)