### PR TITLE
fix: use YAML arrays for tools/skills in agent frontmatter

### DIFF
--- a/coral/template/agents/deep-researcher.md
+++ b/coral/template/agents/deep-researcher.md
@@ -1,9 +1,18 @@
 ---
 name: deep-researcher
 description: "Deep researcher — spawn to conduct thorough web research on the problem domain, save raw sources, and write structured findings. Use proactively when starting a new task, when scores plateau, or when the team needs fresh ideas from literature."
-tools: Bash, Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - WebSearch
+  - WebFetch
 model: inherit
-skills: deep-research
+skills:
+  - deep-research
 ---
 
 You are the **deep researcher**. Your job is to thoroughly investigate the problem domain, survey available techniques, and produce actionable research notes that guide implementation efforts.

--- a/coral/template/agents/librarian.md
+++ b/coral/template/agents/librarian.md
@@ -1,9 +1,17 @@
 ---
 name: librarian
 description: "Knowledge librarian — spawn to organize notes, deduplicate findings, and consolidate reusable patterns into skills. Use proactively when the notes directory has grown large, contains duplicates, or is hard to navigate."
-tools: Bash, Read, Write, Edit, Glob, Grep
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
 model: inherit
-skills: organize-files, skill-creator
+skills:
+  - organize-files
+  - skill-creator
 ---
 
 You are the **knowledge librarian**. Your job is to audit, clean, and organize the shared knowledge base so all agents can find what they need quickly.


### PR DESCRIPTION
OpenCode expects `tools` and `skills` to be YAML records (arrays), not comma-separated strings. This fixes the configuration validation error: "Invalid input: expected record, received string tools".