### PR TITLE
fix: use record format for tools/skills in agent frontmatter

### DIFF
--- a/coral/template/agents/deep-researcher.md
+++ b/coral/template/agents/deep-researcher.md
@@ -2,17 +2,17 @@
 name: deep-researcher
 description: "Deep researcher — spawn to conduct thorough web research on the problem domain, save raw sources, and write structured findings. Use proactively when starting a new task, when scores plateau, or when the team needs fresh ideas from literature."
 tools:
-  - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
-  - WebSearch
-  - WebFetch
+  Bash: true
+  Read: true
+  Write: true
+  Edit: true
+  Glob: true
+  Grep: true
+  WebSearch: true
+  WebFetch: true
 model: inherit
 skills:
-  - deep-research
+  deep-research: true
 ---
 
 You are the **deep researcher**. Your job is to thoroughly investigate the problem domain, survey available techniques, and produce actionable research notes that guide implementation efforts.

--- a/coral/template/agents/librarian.md
+++ b/coral/template/agents/librarian.md
@@ -2,16 +2,16 @@
 name: librarian
 description: "Knowledge librarian — spawn to organize notes, deduplicate findings, and consolidate reusable patterns into skills. Use proactively when the notes directory has grown large, contains duplicates, or is hard to navigate."
 tools:
-  - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
+  Bash: true
+  Read: true
+  Write: true
+  Edit: true
+  Glob: true
+  Grep: true
 model: inherit
 skills:
-  - organize-files
-  - skill-creator
+  organize-files: true
+  skill-creator: true
 ---
 
 You are the **knowledge librarian**. Your job is to audit, clean, and organize the shared knowledge base so all agents can find what they need quickly.


### PR DESCRIPTION
## Summary
- opencode expects `tools` and `skills` in agent frontmatter as records (`tool_name: true`), not YAML arrays (`- tool_name`)
- The array format causes `Invalid input: expected record, received array tools` errors on agent startup, preventing all agents from running
- Fixes both `librarian.md` and `deep-researcher.md` templates

## Test plan
- [ ] Run `coral start` with a task that spawns agents and verify no frontmatter validation errors in agent logs
- [ ] Verify librarian and deep-researcher subagents can be invoked without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)