### PR TITLE
feat: auto-restart stalled agents via timeout

### DIFF
--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -749,6 +749,34 @@ class AgentManager:
                     self.handles[i] = self._restart_agent(i, prompt=prompt)
                     self._write_agent_pids()
 
+            # Check for stalled agents (alive but no output for > timeout)
+            timeout = self.config.agents.timeout
+            if timeout > 0:
+                for i, handle in enumerate(self.handles):
+                    if handle.alive and self._running:
+                        try:
+                            age = time.time() - handle.log_path.stat().st_mtime
+                        except OSError:
+                            continue
+                        if age > timeout:
+                            logger.warning(
+                                f"Agent {handle.agent_id} stalled "
+                                f"({int(age)}s since last output), restarting"
+                            )
+                            if self.verbose:
+                                print(
+                                    f"[coral] {handle.agent_id} stalled "
+                                    f"({int(age)}s with no output), restarting..."
+                                )
+                            self.handles[i] = self._interrupt_and_resume(
+                                i,
+                                "You were automatically restarted because you "
+                                "produced no output for an extended period. "
+                                "Continue working on the task.",
+                                prompt_source="timeout",
+                            )
+                            self._write_agent_pids()
+
             # Interruptible sleep
             if self._stop_event.wait(timeout=check_interval):
                 break


### PR DESCRIPTION
## Summary

- Wire up the existing but unused `agents.timeout` config (default 3600s) to actually restart stalled agents
- In the monitor loop, check each alive agent's log file mtime — if no output for longer than `timeout`, interrupt and resume the agent
- Uses `_interrupt_and_resume` (SIGINT + session resume) for graceful recovery, preserving the agent's session

**Motivation:** In a recent circle-packing run, agent-2 hung mid-step ~40 seconds after starting and was never restarted because the process didn't exit — it just stopped producing output. The existing dead-process detection (`process.poll()`) couldn't catch this. Set `agents.timeout: 0` to disable.

## Test plan

- [x] All 88 existing tests pass
- [x] Ruff lint clean (no new issues)
- [ ] Manual: run `coral start` with `agents.timeout: 60` and verify a stalled agent gets restarted after ~60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)