### PR TITLE
docs/init: clean up stale grader fields after #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,12 @@ task:
     and returns -distance as the score (shorter = higher).
 
 grader:
-  type: function
-  module: eval.grader
+  # Quick-start uses auto-discovered eval/grader.py (emits DeprecationWarning).
+  # For production tasks, package the grader and switch to:
+  #   entrypoint: "tsp_grader.grader:Grader"
+  #   setup: ["uv pip install -e ./grader"]
+  # See docs/guides/custom-grader for the migration walkthrough.
+  timeout: 300
 
 agents:
   count: 1

--- a/README_CN.md
+++ b/README_CN.md
@@ -182,8 +182,12 @@ task:
     评分器计算往返欧氏距离，返回 -distance 作为得分（越短越高）。
 
 grader:
-  type: function
-  module: eval.grader
+  # 快速开始走自动发现的 eval/grader.py（会触发 DeprecationWarning）。
+  # 生产任务建议把 grader 打包,改用 entrypoint:
+  #   entrypoint: "tsp_grader.grader:Grader"
+  #   setup: ["uv pip install -e ./grader"]
+  # 迁移指南见 docs/guides/custom-grader。
+  timeout: 300
 
 agents:
   count: 1

--- a/coral/cli/author.py
+++ b/coral/cli/author.py
@@ -31,7 +31,6 @@ def cmd_init(args: argparse.Namespace) -> None:
         f'  name: "{task_name}"\n'
         f"  description: |\n"
         f"    Describe your task here.\n"
-        f"  files: []\n"
         f"\n"
         f"grader:\n"
         f"  # Quick start: this scaffold ships an eval/grader.py (deprecated path).\n"

--- a/docs/content/docs/api/config.mdx
+++ b/docs/content/docs/api/config.mdx
@@ -54,8 +54,8 @@ class TaskConfig:
 ```python
 @dataclass
 class GraderConfig:
-    type: str              # Grader type (empty = auto-discover)
-    module: str            # Python module path
+    entrypoint: str        # "module.path:ClassName" — empty falls back to eval/grader.py (deprecated)
+    setup: list[str]       # Shell commands run in .coral/private/grader_venv/ at start time
     timeout: int           # Eval timeout in seconds (default: 300)
     args: dict[str, Any]   # Extra grader arguments
     private: list[str]     # Files hidden from agents

--- a/docs/content/docs/examples/tasks.mdx
+++ b/docs/content/docs/examples/tasks.mdx
@@ -16,8 +16,6 @@ task:
   description: |
     Pack N = 26 circles into a unit square (side length 1)
     to maximize the sum of radii.
-  files:
-    - "initial_program.py"
 
 grader:
   timeout: 600

--- a/docs/content/docs/getting-started/configuration.mdx
+++ b/docs/content/docs/getting-started/configuration.mdx
@@ -12,13 +12,7 @@ Every CORAL task is defined by a `task.yaml` file. This page documents all avail
 task:
   name: "my-task"
   description: "Optimize solution.py to maximize accuracy."
-  files:
-    - "solution.py"
-    - "utils.py"
   tips: "numpy and scipy are available. Timeout is 300s."
-  seed:
-    - "solution.py"
-    - "data/"
 
 grader:
   entrypoint: "my_task_grader.grader:Grader"
@@ -61,9 +55,7 @@ workspace:
 |-------|------|---------|-------------|
 | `name` | string | *required* | Task identifier |
 | `description` | string | *required* | What agents should do — included in CORAL.md |
-| `files` | list[string] | `[]` | Key files agents should focus on |
 | `tips` | string | `""` | Additional hints shown to agents |
-| `seed` | list[string] | `[]` | Files/directories copied into each agent's workspace |
 
 ## `grader` section
 

--- a/docs/content/docs/getting-started/quickstart.mdx
+++ b/docs/content/docs/getting-started/quickstart.mdx
@@ -30,8 +30,6 @@ Edit `my-task/task.yaml`:
 task:
   name: my-task
   description: "Optimize the function in solution.py to run as fast as possible."
-  files:
-    - "solution.py"
 
 grader:
   direction: maximize
@@ -118,3 +116,11 @@ Each agent autonomously:
 6. Repeats until stopped
 
 Check [Concepts](/concepts) to understand the full architecture, or [CLI Reference](/cli/reference) for all available commands.
+
+## Graduating from `eval/grader.py`
+
+The `eval/grader.py` form scaffolded above is a deprecated quick-start
+path — it auto-loads in-process and emits a `DeprecationWarning`. Once
+your grader is non-trivial or you want to share it across tasks, package
+it and switch `task.yaml` to use `grader.entrypoint` instead. See
+[Writing a Custom Grader → Recommended: package your grader](/guides/custom-grader#recommended-package-your-grader).


### PR DESCRIPTION
Follow-up to #63 (entrypoint refactor). Two small cleanups:

## Summary

- **`docs: drop stale grader.type/module references in README + api/config`** — the TSP quick-start in `README.md`/`README_CN.md` and the `GraderConfig` field reference in `docs/api/config.mdx` still listed the removed `grader.type` / `grader.module` fields, which now raise a migration error from `_preprocess()`. Replace with a comment block pointing at the entrypoint workflow.
- **`fix: drop obsolete task.files / task.seed from init template + docs`** — `task.files` and `task.seed` were removed from `TaskConfig` back in #44, but `coral init`, `docs/getting-started/{quickstart,configuration}.mdx`, and `docs/examples/tasks.mdx` still wrote them. The init template was actually broken: `coral init my-task && coral validate my-task` failed with `ConfigKeyError: Key 'files' not in 'TaskConfig'`. Drop the field from the template + docs and verify the scaffolded task validates cleanly.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/test_grader_env.py` — 111 pass
- [x] `coral init /tmp/init_test --name "Test Task" && coral validate /tmp/init_test` succeeds (returns 0.0 from the scaffolded `evaluate()`, as expected)
- [x] grep for any remaining `grader.type` / `grader.module` in YAML/MDX/MD that isn't part of an explicit "deprecated / removed" doc block — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)