### PR TITLE
fix: agent-context coral cmds respect .coral_dir breadcrumb

### DIFF
--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -493,6 +493,10 @@ def cmd_resume(args: argparse.Namespace) -> None:
     run = getattr(args, "run", None)
     if task or run or in_docker():
         coral_dir = find_coral_dir(task, run)
+    elif (Path.cwd() / ".coral_dir").exists():
+        # Agent in a worktree: lock to the current run via the breadcrumb
+        # instead of showing all stopped runs in a picker.
+        coral_dir = find_coral_dir(None, None)
     else:
         coral_dir = pick_run(status_filter="stopped", allow_cancel=True)
     if coral_dir is None:
@@ -686,6 +690,10 @@ def cmd_stop(args: argparse.Namespace) -> None:
         run = getattr(args, "run", None)
         if task or run:
             coral_dir = find_coral_dir(task, run)
+        elif (Path.cwd() / ".coral_dir").exists() or in_docker():
+            # Agent in a worktree (or Docker run): lock to the current run
+            # via the breadcrumb instead of showing all running runs.
+            coral_dir = find_coral_dir(None, None)
         else:
             coral_dir = pick_run(status_filter="running", allow_cancel=True)
         if coral_dir is None:
@@ -705,6 +713,10 @@ def cmd_status(args: argparse.Namespace) -> None:
     run = getattr(args, "run", None)
     if task or run:
         coral_dir = find_coral_dir(task, run)
+    elif (Path.cwd() / ".coral_dir").exists() or in_docker():
+        # Agent in a worktree (or Docker run): lock to the current run
+        # via the .coral_dir breadcrumb instead of showing all runs.
+        coral_dir = find_coral_dir(None, None)
     else:
         coral_dir = pick_run()
 


### PR DESCRIPTION
## Summary

- `coral status`, `coral resume`, and `coral stop` previously fell through to `pick_run()` whenever neither `--task` nor `--run` was passed, ignoring the `.coral_dir` breadcrumb that every agent worktree carries.
- For an agent calling `coral status` mid-run, that meant it could see (or auto-select) a stale unrelated task, or hang waiting on an interactive picker that an agent subprocess cannot answer.
- Add a breadcrumb / Docker short-circuit before the picker so these three commands lock to the agent's own current run when invoked from a worktree. Operator behavior from the repo root is unchanged — picker still shows when there's no breadcrumb.

The other CLI commands (`log`/`show`/`notes`/`skills`/`ui`/`heartbeat`/`eval`/`wait`/`checkout`) already routed through `find_coral_dir`, which has breadcrumb priority, so they were unaffected. `coral runs` is intentionally cross-task.

## Test plan

- [x] Synthetic two-task results tree: from `worktree-b/` (with `.coral_dir` → task-b run), `coral status` shows task-b only — no picker, no task-a leak.
- [x] From repo root with no breadcrumb, `coral status` still drops into the picker.
- [x] `coral stop` from worktree-b targets task-b's run (correctly reports "No running CORAL manager found"); from repo root it still goes through the running-only picker.
- [x] `coral resume` from worktree-b resolves to task-b's path (verified by removing config.yaml and observing the error path references task-b).
- [x] `uv run pytest tests/` — 117/117 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)