### PR TITLE
WIP: heartbeat 'challenge' action — anti-drift audit of shared memory

### DIFF
--- a/coral/config.py
+++ b/coral/config.py
@@ -80,6 +80,9 @@ class AgentConfig:
             HeartbeatActionConfig(name="consolidate", every=10, is_global=True),
             HeartbeatActionConfig(name="pivot", every=5, trigger="plateau"),
             HeartbeatActionConfig(name="lint_wiki", every=10, is_global=True),
+            HeartbeatActionConfig(
+                name="challenge", every=10, is_global=True, trigger="plateau"
+            ),
         ]
     )
     research: bool = True  # enable web search / literature review step in workflow

--- a/coral/hub/heartbeat.py
+++ b/coral/hub/heartbeat.py
@@ -36,6 +36,7 @@ DEFAULT_PROMPTS: dict[str, str] = {
     "consolidate": _load_prompt("consolidate"),
     "pivot": _load_prompt("pivot"),
     "lint_wiki": _load_prompt("lint_wiki"),
+    "challenge": _load_prompt("challenge"),
 }
 
 # Which built-in actions default to global scope
@@ -44,6 +45,7 @@ DEFAULT_GLOBAL: dict[str, bool] = {
     "consolidate": True,
     "pivot": False,
     "lint_wiki": True,
+    "challenge": True,
 }
 
 # Which built-in actions use plateau trigger instead of interval
@@ -52,6 +54,7 @@ DEFAULT_TRIGGER: dict[str, str] = {
     "consolidate": "interval",
     "pivot": "plateau",
     "lint_wiki": "interval",
+    "challenge": "plateau",
 }
 
 # Protected actions: reflect is always local, consolidate is always global

--- a/coral/hub/prompts/challenge.md
+++ b/coral/hub/prompts/challenge.md
@@ -1,0 +1,56 @@
+## Heartbeat: Challenge — Audit Shared Memory for Drift
+
+**The run has plateaued and shared memory is older than it has been audited.** When agents stop improving while continuing to consult the same notes and skills, the working set has likely picked up assumptions that are unsupported, stale, or one-off accidents that got promoted to "common knowledge". Your job in this pass is to *act as the adversary* against shared memory.
+
+This is **not** lint_wiki — that pass merges duplicates and fixes orphan pages. This pass questions whether the surviving content is actually *true*.
+
+### Step 1: Identify high-impact shared content
+
+- List the most-cited notes in `{shared_dir}/notes/` (look at recent attempts in `coral log` and which notes they reference).
+- List the skills in `{shared_dir}/skills/` ranked by how often they appear in attempt commit messages or note bodies.
+- Prioritize the top ~5 notes and top ~3 skills. Low-traffic content is not the drift risk.
+
+### Step 2: For each high-impact item, attempt to falsify it
+
+Read the note/skill and ask, *adversarially*:
+
+- **Evidence check** — does this claim cite specific attempt hashes, scores, or measurements? Or is it a confident assertion with no receipts?
+- **Generalization check** — was this learned from one attempt, one task instance, or one narrow regime? Is it being applied beyond what the evidence supports?
+- **Staleness check** — when was it written? Has the codebase, grader, or task constraints changed since? (`git log` the file.)
+- **Counter-search** — find the top-scoring attempts that *did not* follow this note/skill. If high scores exist without it, the note is at best optional and at worst misleading.
+
+You are looking for confident-but-thin claims. "Always do X" with no evidence is a red flag. "We tried X and Y, X scored higher in cases A/B" is fine.
+
+### Step 3: Re-classify, do not delete
+
+Do **not** silently remove notes — that erases evidence of past reasoning. Instead, edit the frontmatter / heading to mark status:
+
+- **`status: validated`** — backed by attempt hashes that reproduce the claim.
+- **`status: hypothesis`** — plausible but unverified; downgrade confident language ("always" → "in cases X we observed").
+- **`status: stale`** — written against an earlier version of the codebase/grader and no longer applies. Add a one-line "superseded by …" note.
+- **`status: disputed`** — top attempts contradict it. Leave the original text but add a "Counter-evidence" section citing the contradicting hashes.
+
+For skills, the same applies: a one-off skill that has only ever been used by its author should be marked `status: experimental` rather than presented as general practice.
+
+### Step 4: Write a challenge note
+
+Append a single dated entry to `{shared_dir}/notes/challenge_log.md` summarizing:
+
+- Which items you re-classified and why (one line each).
+- Any *pattern* you noticed — e.g. "three of the top-cited notes all assume the grader weights latency, but the current grader does not."
+- What a future agent should be skeptical of going forward.
+
+This log is the institutional memory of *what we used to believe and why we stopped*.
+
+### Step 5: Hand back, do not pivot
+
+This action does **not** ask you to change your current strategy or run a counter-attempt. It only audits memory. After writing the challenge log, return to whatever you were doing. The signal will reach other agents through the re-classified notes.
+
+---
+
+**Heuristics:**
+
+- A note with no attempt-hash citations is suspicious by default.
+- A skill used only by its author is not yet a skill — it is a personal habit.
+- "Everyone agrees" inside a CORAL run is a *symptom*, not a *signal* — your job here is to make sure the agreement is earned.
+- Re-classification beats deletion. Future agents need to see what was once believed in order to evaluate whether to re-believe it.

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -117,3 +117,34 @@ def test_plateau_default_evals_since_improvement():
 
     # Default evals_since_improvement=0, should never fire
     assert runner.check(local_eval_count=5, global_eval_count=5) == []
+
+
+# --- Built-in 'challenge' action registration ---
+
+def test_challenge_action_registered_as_global_plateau():
+    """The 'challenge' built-in must default to global scope + plateau trigger.
+
+    Drift audits are a population property: one challenger pass across the run
+    is enough. Per-agent every-tick would burn turns and miss the point.
+    """
+    from coral.hub.heartbeat import (
+        DEFAULT_GLOBAL,
+        DEFAULT_PROMPTS,
+        DEFAULT_TRIGGER,
+    )
+
+    assert "challenge" in DEFAULT_PROMPTS
+    assert DEFAULT_PROMPTS["challenge"], "challenge prompt should not be empty"
+    assert DEFAULT_GLOBAL["challenge"] is True
+    assert DEFAULT_TRIGGER["challenge"] == "plateau"
+
+
+def test_challenge_default_in_config():
+    """The default heartbeat list should include 'challenge' as plateau+global."""
+    from coral.config import CoralConfig
+
+    config = CoralConfig()
+    by_name = {h.name: h for h in config.agents.heartbeat}
+    assert "challenge" in by_name, "challenge should ship in default heartbeat list"
+    assert by_name["challenge"].is_global is True
+    assert by_name["challenge"].trigger == "plateau"


### PR DESCRIPTION
## Status: WIP / draft

Skeleton only. Prompt + registration + tests. **No active counter-attempts** — review-half only, per maintainer scoping decision.

Refs #67 (shared-memory drift / memory poisoning)
Refs #49 (Coyote / mandatory adversarial dissent)

## Why

#67 raises that shared notes/skills can quietly homogenize agents over long runs (one agent's hallucination becomes group doctrine). #49 proposes a heavier governance stack but the one well-grounded primitive in it — a mandatory adversarial pass — fits CORAL's existing heartbeat machinery without buying the rest of that framework.

This PR adds that primitive and stops there.

## What this PR does

1. New prompt template `coral/hub/prompts/challenge.md` instructing an agent to:
   - Identify the highest-traffic notes/skills.
   - Adversarially try to falsify each (evidence check, generalization check, staleness check, counter-search against top attempts that didn't follow it).
   - **Re-classify, do not delete** — set `status: validated | hypothesis | stale | disputed` so future agents see what was once believed.
   - Append a dated entry to `challenge_log.md` summarizing the audit.
   - Hand back without changing the agent's current strategy.

2. Register `challenge` in `coral/hub/heartbeat.py`:
   - `DEFAULT_GLOBAL["challenge"] = True` — population-level concern, one pass per run is enough.
   - `DEFAULT_TRIGGER["challenge"] = "plateau"` — drift matters when scores stop improving, not on a fixed clock.

3. Add to default heartbeat list in `coral/config.py`: `every=10, is_global=True, trigger="plateau"`.

4. Tests asserting registration and default-config wiring.

## Why these defaults

- **Plateau trigger, not interval** — adversarial review pays off when the system has stopped finding gains. On a healthy upward trajectory it would just burn turns.
- **Global, not per-agent** — sycophantic convergence is a population property. One challenger pass across the run is the right granularity.
- **Re-classify, not delete** — preserves the institutional record of what was once believed, so future agents can re-evaluate rather than relearn from scratch.
- **Distinct from `lint_wiki`** — `lint_wiki` does janitorial work (merge duplicates, fix orphans). `challenge` questions whether the surviving content is *true*. The prompt explicitly calls this out.

## Out of scope (deliberately)

The "active" half of the anti-drift design — running attempts that deliberately violate consensus (a `agents.challenger_fraction` knob, or a sharing-disabled agent slot) — is not in this PR. Heartbeats interrupt an existing agent rather than spawn a divergent one, so that piece belongs to agent-spawning, not heartbeat. Tracked for a follow-up.

## Execution plan (for reviewers / next steps)

This PR is the skeleton; landing the full feature needs:

- [x] Prompt + registration (this PR)
- [x] Default-config entry (this PR)
- [x] Tests for registration + config defaults (this PR)
- [ ] **Field test on a real run** — verify the prompt produces useful re-classifications, not noise. Best validated on a long-running task config from `examples/`.
- [ ] Decide whether `challenge_log.md` should be schema'd (YAML frontmatter per entry) so the UI can render it; currently free-form markdown.
- [ ] Consider a `coral notes --status disputed` filter so disputed notes are easy to find.
- [ ] Active half: `agents.challenger_fraction` config knob to spawn a fraction of agents in sharing-disabled "challenger" mode. Separate PR.
- [ ] Eval whether `every=10` plateau threshold is reasonable across task types or needs to be task-specific.

## Test plan

- [x] `uv run pytest tests/test_heartbeat.py tests/test_config.py -v` — 33 passed
- [x] `uv run pytest tests/` — 119 passed
- [x] `uv run ruff check` on touched files — clean
- [ ] Smoke test on an actual `coral start` run to confirm the action surfaces in `coral heartbeat` listing and fires after a plateau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)