### PR TITLE
feat(eval): parallel grader daemon (issue #81)

### DIFF
--- a/coral/config.py
+++ b/coral/config.py
@@ -20,6 +20,21 @@ class TaskConfig:
 
 
 @dataclass
+class ParallelGraderConfig:
+    """Parallel evaluation in the grader daemon.
+
+    The daemon always routes pending attempts through a worker pool of this
+    size. ``max_workers=1`` (the default) is serial — same behavior as before
+    the pool existed. Set higher only when the grader is concurrency-safe
+    (pure Python, sandboxed swebench runs, etc.); the daemon does not enforce
+    safety, so a misconfigured value with a non-safe grader is the user's
+    responsibility.
+    """
+
+    max_workers: int = 1
+
+
+@dataclass
 class GraderConfig:
     """Grader configuration."""
 
@@ -38,11 +53,22 @@ class GraderConfig:
     # Default 1: an agent can only enqueue a fresh attempt once the prior one
     # is graded, which prevents runaway pending floods when the grader is slow.
     max_pending_per_agent: int = 1
+    parallel: ParallelGraderConfig = field(default_factory=ParallelGraderConfig)
 
     def __post_init__(self) -> None:
         if self.max_pending_per_agent < 0:
             raise ValueError(
                 f"grader.max_pending_per_agent must be >= 0, got {self.max_pending_per_agent}"
+            )
+        # SubprocessGrader serializes GraderConfig via dataclasses.asdict and
+        # rebuilds with `GraderConfig(**payload)`, which leaves `parallel` as a
+        # plain dict. Coerce here so validation and downstream attribute access
+        # work for both real callers and the worker reconstruction path.
+        if isinstance(self.parallel, dict):
+            self.parallel = ParallelGraderConfig(**self.parallel)
+        if self.parallel.max_workers < 1:
+            raise ValueError(
+                f"grader.parallel.max_workers must be >= 1, got {self.parallel.max_workers}"
             )
 
 

--- a/coral/grader/daemon.py
+++ b/coral/grader/daemon.py
@@ -6,8 +6,11 @@ inside an isolated `git worktree add --detach <commit>` checkout, so agent
 commits during grading do not perturb the codebase the grader sees.
 
 Design invariants:
-- Each pending attempt is processed serially (most graders are not concurrency-safe:
-  Docker port conflicts, GPU contention, shared scratch dirs, etc.).
+- Pending attempts are dispatched through a thread pool of size
+  `grader.parallel.max_workers` (default 1 = serial). Bumping the value is
+  just configuration; safety is the operator's call — most graders are NOT
+  concurrency-safe (Docker port conflicts, GPU contention, shared scratch
+  dirs, etc.).
 - Writes are atomic via hub.attempts.write_attempt (tmp + rename).
 - Daemon is idempotent: re-seeing an already-scored attempt is a no-op.
 """
@@ -19,8 +22,11 @@ import logging
 import multiprocessing
 import shutil
 import subprocess
+import threading
 import time
 import traceback
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -38,6 +44,11 @@ from coral.types import Attempt, Task
 logger = logging.getLogger(__name__)
 
 _POLL_INTERVAL_SEC = 0.5
+
+# Guards `increment_eval_count` (read-modify-write on .coral/public/eval_count).
+# The daemon is the sole writer; this lock is only needed because pending
+# attempts can be drained in parallel by multiple worker threads.
+_eval_count_lock = threading.Lock()
 
 
 # --------------------------------------------------------------------------- #
@@ -297,7 +308,8 @@ def _grade_one(
         metadata=metadata,
     )
     write_attempt(str(coral_dir), finalized)
-    count = increment_eval_count(coral_dir)
+    with _eval_count_lock:
+        count = increment_eval_count(coral_dir)
     logger.info(
         "Graded #%d %s -> score=%s status=%s",
         count, attempt.commit_hash[:12],
@@ -319,6 +331,100 @@ def _find_pending(coral_dir: Path) -> list[Attempt]:
     return pending
 
 
+def _safe_grade_one(
+    attempt: Attempt,
+    config_path: Path,
+    coral_dir: Path,
+    config: CoralConfig,
+) -> Attempt | None:
+    """Grade an attempt, swallowing truly unexpected errors as `crashed`.
+
+    Per-attempt failures (timeout, grader exception) are already turned into
+    `crashed`/`timeout` Attempts inside `_grade_one`. This wrapper is the last
+    line of defense so a thread in the pool can't take the daemon down.
+    Returns the finalized Attempt, or None if even the crash-record write
+    failed.
+    """
+    try:
+        return _grade_one(attempt, config_path, coral_dir, config)
+    except Exception:
+        logger.exception(
+            "Unhandled error grading %s; marking crashed", attempt.commit_hash[:12]
+        )
+        try:
+            crashed = Attempt(
+                commit_hash=attempt.commit_hash,
+                agent_id=attempt.agent_id,
+                title=attempt.title,
+                score=None,
+                status="crashed",
+                parent_hash=attempt.parent_hash,
+                timestamp=attempt.timestamp,
+                feedback="Grader daemon hit an unexpected error; see logs.",
+                shared_state_hash=attempt.shared_state_hash,
+                parent_shared_state_hash=attempt.parent_shared_state_hash,
+            )
+            write_attempt(str(coral_dir), crashed)
+            with _eval_count_lock:
+                increment_eval_count(coral_dir)
+            return crashed
+        except Exception:
+            logger.exception("Failed to record crash for %s", attempt.commit_hash[:12])
+            return None
+
+
+def _drain_pending(
+    pending: list[Attempt],
+    config_path: Path,
+    coral_dir: Path,
+    config: CoralConfig,
+    *,
+    max_workers: int,
+    heartbeat_file: Path | None = None,
+    should_stop: Callable[[], bool] = lambda: False,
+) -> list[Attempt]:
+    """Grade `pending` attempts via a worker pool of size `max_workers`.
+
+    `max_workers=1` is serial — same behavior as the pre-pool daemon. Larger
+    values let the daemon overlap grades when the operator has set
+    `grader.parallel.max_workers` higher (only safe for concurrency-safe
+    graders).
+
+    Stop semantics: when `should_stop()` becomes true, queued (not-yet-running)
+    futures are cancelled. Already-running grades finish — same as the old
+    serial loop, where a stop signal mid-attempt waited for that attempt.
+    """
+    finalized: list[Attempt] = []
+    if not pending:
+        return finalized
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(_safe_grade_one, attempt, config_path, coral_dir, config): attempt
+            for attempt in pending
+        }
+        try:
+            for fut in as_completed(futures):
+                if heartbeat_file is not None:
+                    try:
+                        heartbeat_file.write_text(datetime.now(UTC).isoformat())
+                    except OSError:
+                        pass
+                result = fut.result()
+                if result is not None:
+                    finalized.append(result)
+                if should_stop():
+                    for queued in futures:
+                        queued.cancel()
+                    break
+        finally:
+            # ThreadPoolExecutor.__exit__ waits for in-flight grades (their
+            # subprocesses already own the work and will return on their own
+            # timeout). We don't kill mid-grade workers from a stop signal.
+            pass
+    return finalized
+
+
 def process_pending_once(coral_dir: str | Path) -> list[Attempt]:
     """Drain all currently-pending attempts synchronously and return finalized records.
 
@@ -328,10 +434,13 @@ def process_pending_once(coral_dir: str | Path) -> list[Attempt]:
     coral_dir = Path(coral_dir).resolve()
     config_path = coral_dir / "config.yaml"
     config = CoralConfig.from_yaml(config_path)
-    finalized = []
-    for attempt in _find_pending(coral_dir):
-        finalized.append(_grade_one(attempt, config_path, coral_dir, config))
-    return finalized
+    return _drain_pending(
+        _find_pending(coral_dir),
+        config_path,
+        coral_dir,
+        config,
+        max_workers=config.grader.parallel.max_workers,
+    )
 
 
 def run_daemon(coral_dir: str | Path, stop_event: Any = None) -> None:
@@ -349,8 +458,12 @@ def run_daemon(coral_dir: str | Path, stop_event: Any = None) -> None:
         raise FileNotFoundError(f"No config.yaml at {config_path}")
 
     config = CoralConfig.from_yaml(config_path)
+    max_workers = config.grader.parallel.max_workers
 
-    logger.info("Grader daemon started (coral_dir=%s)", coral_dir)
+    logger.info(
+        "Grader daemon started (coral_dir=%s, max_workers=%d)",
+        coral_dir, max_workers,
+    )
     started_at = datetime.now(UTC).isoformat()
     heartbeat_file = coral_dir / "public" / "grader_daemon_heartbeat"
     heartbeat_file.write_text(started_at)
@@ -374,43 +487,14 @@ def run_daemon(coral_dir: str | Path, stop_event: Any = None) -> None:
             time.sleep(_POLL_INTERVAL_SEC)
             continue
 
-        for attempt in pending:
-            if _should_stop():
-                break
-            # Refresh the heartbeat before each attempt so external readers
-            # of `grader_daemon_heartbeat` (separate from the manager's
-            # stall-watchdog exemption, which uses live `_grader_proc.is_alive()`
-            # checks) still see a fresh timestamp during long grades.
-            try:
-                heartbeat_file.write_text(datetime.now(UTC).isoformat())
-            except OSError:
-                pass
-            try:
-                _grade_one(attempt, config_path, coral_dir, config)
-            except Exception:
-                # Catch-all: never let a bad grade kill the daemon. The per-attempt
-                # handler already finalized the record as "crashed" on any known
-                # failure mode; this only fires for truly unexpected errors.
-                logger.exception(
-                    "Unhandled error grading %s; marking crashed",
-                    attempt.commit_hash[:12],
-                )
-                try:
-                    crashed = Attempt(
-                        commit_hash=attempt.commit_hash,
-                        agent_id=attempt.agent_id,
-                        title=attempt.title,
-                        score=None,
-                        status="crashed",
-                        parent_hash=attempt.parent_hash,
-                        timestamp=attempt.timestamp,
-                        feedback="Grader daemon hit an unexpected error; see logs.",
-                        shared_state_hash=attempt.shared_state_hash,
-                        parent_shared_state_hash=attempt.parent_shared_state_hash,
-                    )
-                    write_attempt(str(coral_dir), crashed)
-                    increment_eval_count(coral_dir)
-                except Exception:
-                    logger.exception("Failed to record crash for %s", attempt.commit_hash[:12])
+        _drain_pending(
+            pending,
+            config_path,
+            coral_dir,
+            config,
+            max_workers=max_workers,
+            heartbeat_file=heartbeat_file,
+            should_stop=_should_stop,
+        )
 
     logger.info("Grader daemon stopped")

--- a/tests/test_grader_daemon.py
+++ b/tests/test_grader_daemon.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from coral.config import CoralConfig
 from coral.grader.daemon import (
     _find_pending,
     _is_git_repo,
@@ -22,7 +23,7 @@ from coral.grader.daemon import (
     run_daemon,
 )
 from coral.hooks.post_commit import submit_eval
-from coral.hub.attempts import read_attempt, write_attempt
+from coral.hub.attempts import read_attempt, read_eval_count, write_attempt
 from coral.types import Attempt
 
 # The fixture below uses the deprecated eval/grader.py loading path on
@@ -339,3 +340,168 @@ def test_run_daemon_subprocess_grades_pending():
         finally:
             sys.path.pop(0)
             _ = env_shim  # silence linter
+
+
+# --------------------------------------------------------------------------- #
+# Parallel drain (issue #81)                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_default_max_workers_is_1():
+    """Configs without `grader.parallel` get max_workers=1 (legacy behavior)."""
+    cfg = CoralConfig.from_dict(
+        {"task": {"name": "x", "description": "y"}, "agents": {"count": 1}}
+    )
+    assert cfg.grader.parallel.max_workers == 1
+
+
+def _install_concurrency_probe_grader(repo: Path, sleep_seconds: float) -> Path:
+    """Overwrite eval/grader.py with one that reports peak concurrent executions.
+
+    Each grade increments a shared counter on entry, sleeps, decrements on
+    exit. The counter is in a JSON file under private_dir, mutated under
+    fcntl.flock so concurrent grades can't lose updates. Returns the path to
+    that file so the test can read `max` after the drain.
+    """
+    coral_dir = repo / ".coral"
+    log_path = coral_dir / "private" / "concurrency.json"
+    grader_src = (
+        "import fcntl, json, time\n"
+        "from pathlib import Path\n"
+        "from coral.grader.task_grader import TaskGrader\n"
+        "\n"
+        f"LOG_PATH = {str(log_path)!r}\n"
+        f"SLEEP = {sleep_seconds!r}\n"
+        "\n"
+        "def _bump(delta):\n"
+        "    p = Path(LOG_PATH)\n"
+        "    p.touch(exist_ok=True)\n"
+        "    with open(p, 'r+') as f:\n"
+        "        fcntl.flock(f, fcntl.LOCK_EX)\n"
+        "        text = f.read() or '{}'\n"
+        "        try: data = json.loads(text)\n"
+        "        except Exception: data = {}\n"
+        "        data['current'] = data.get('current', 0) + delta\n"
+        "        if delta > 0:\n"
+        "            data['max'] = max(data.get('max', 0), data['current'])\n"
+        "        f.seek(0); f.truncate()\n"
+        "        f.write(json.dumps(data))\n"
+        "        f.flush()\n"
+        "        fcntl.flock(f, fcntl.LOCK_UN)\n"
+        "\n"
+        "class Grader(TaskGrader):\n"
+        "    def evaluate(self):\n"
+        "        _bump(1)\n"
+        "        try:\n"
+        "            time.sleep(SLEEP)\n"
+        "        finally:\n"
+        "            _bump(-1)\n"
+        "        return 1.0\n"
+    )
+    (coral_dir / "private" / "eval" / "grader.py").write_text(grader_src)
+    return log_path
+
+
+def _set_config(repo: Path, **grader_overrides) -> None:
+    """Patch grader fields in .coral/config.yaml in-place."""
+    cfg_path = repo / ".coral" / "config.yaml"
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f)
+    cfg.setdefault("grader", {}).update(grader_overrides)
+    with open(cfg_path, "w") as f:
+        yaml.dump(cfg, f)
+
+
+def _submit_n(repo: Path, n: int) -> list[str]:
+    """Make N distinct commits and submit each as a pending attempt."""
+    hashes = []
+    for i in range(n):
+        (repo / "main.py").write_text(f"print('v{i}')\n")
+        attempt = submit_eval(
+            message=f"v{i}", agent_id="agent-1", workdir=str(repo), wait=False,
+        )
+        hashes.append(attempt.commit_hash)
+    return hashes
+
+
+def test_drain_runs_in_parallel_when_max_workers_gt_1():
+    """With max_workers=4, four 0.4s grades overlap (peak concurrency > 1)."""
+    with tempfile.TemporaryDirectory() as d:
+        repo = _init_repo_and_coral(Path(d))
+        log_path = _install_concurrency_probe_grader(repo, sleep_seconds=0.4)
+        _set_config(
+            repo,
+            max_pending_per_agent=0,  # allow stacking 4 pending from one agent
+            parallel={"max_workers": 4},
+        )
+
+        sys.path.insert(0, str(repo))
+        try:
+            _submit_n(repo, 4)
+            finalized = process_pending_once(repo / ".coral")
+            assert len(finalized) == 4
+            assert all(a.score == 1.0 for a in finalized)
+
+            data = json.loads(log_path.read_text())
+            assert data["max"] >= 2, (
+                f"Expected overlapping grades with max_workers=4, got max={data['max']}"
+            )
+            assert data["current"] == 0  # all grades finished
+        finally:
+            sys.path.pop(0)
+
+
+def test_drain_serializes_when_max_workers_is_1():
+    """max_workers=1 keeps the legacy serial behavior — peak concurrency stays 1."""
+    with tempfile.TemporaryDirectory() as d:
+        repo = _init_repo_and_coral(Path(d))
+        log_path = _install_concurrency_probe_grader(repo, sleep_seconds=0.2)
+        _set_config(
+            repo,
+            max_pending_per_agent=0,
+            parallel={"max_workers": 1},
+        )
+
+        sys.path.insert(0, str(repo))
+        try:
+            _submit_n(repo, 3)
+            finalized = process_pending_once(repo / ".coral")
+            assert len(finalized) == 3
+
+            data = json.loads(log_path.read_text())
+            assert data["max"] == 1, (
+                f"Expected serial grading with max_workers=1, got max={data['max']}"
+            )
+        finally:
+            sys.path.pop(0)
+
+
+def test_eval_count_correct_under_parallel_grading():
+    """Race-prone increment_eval_count stays correct when grades run in parallel."""
+    with tempfile.TemporaryDirectory() as d:
+        repo = _init_repo_and_coral(Path(d))
+        _install_concurrency_probe_grader(repo, sleep_seconds=0.1)
+        _set_config(
+            repo,
+            max_pending_per_agent=0,
+            parallel={"max_workers": 4},
+        )
+
+        sys.path.insert(0, str(repo))
+        try:
+            _submit_n(repo, 5)
+            process_pending_once(repo / ".coral")
+            assert read_eval_count(repo / ".coral") == 5
+        finally:
+            sys.path.pop(0)
+
+
+def test_invalid_max_workers_rejected():
+    """grader.parallel.max_workers must be >= 1."""
+    with pytest.raises(ValueError, match="max_workers"):
+        CoralConfig.from_dict(
+            {
+                "task": {"name": "x", "description": "y"},
+                "grader": {"parallel": {"max_workers": 0}},
+            }
+        )


### PR DESCRIPTION
Closes #81.

## Summary
- Route the grader daemon's pending-attempt queue through a thread pool sized by `grader.parallel.max_workers` (default `1`, preserving today's serial behavior).
- The daemon doesn't enforce safety — whoever sets `max_workers > 1` is asserting their grader can handle it (pure Python, sandboxed swebench runs, etc.).
- `_grade_one`'s call to `increment_eval_count` now runs under `_eval_count_lock` so parallel grades can't lose increments.

## Why this shape
The issue raised an `concurrency_safe` ClassVar / `grader.parallel.safe` flag as candidate opt-in mechanisms. Per discussion on the plan, we collapsed both into the single config knob: default `1` is identical to the old serial path, and any value `> 1` is the operator declaring their grader is concurrency-safe. No probe, no second axis to misconfigure.

## What changed
- `coral/config.py`: new nested `ParallelGraderConfig`; `__post_init__` validates `>= 1` and coerces dict→dataclass so `SubprocessGrader`'s `asdict(cfg) → GraderConfig(**dict)` round-trip in the worker keeps working.
- `coral/grader/daemon.py`: shared `_drain_pending` helper used by both `run_daemon` and `process_pending_once`; `_safe_grade_one` absorbs the unhandled-error path that previously lived inline; module-level `_eval_count_lock`. Stop-event still cancels queued futures; in-flight grades finish on their subprocess timeout (same as before).

## Test plan
- [x] `uv run pytest tests/ -q` — 187 passed (5 new in `test_grader_daemon.py`).
- [x] `uv run ruff check coral/grader/daemon.py coral/config.py tests/test_grader_daemon.py` — clean.
- [x] New tests cover: parallel overlap probe (`max_workers=4` → peak concurrency ≥ 2), serial regression (`max_workers=1` → peak == 1), eval-count race under parallel grading, default value, and validation rejection (`max_workers=0` raises).

## Out of scope
- Cross-machine / distributed grading.
- Per-grader `concurrency_safe` ClassVar or `max_concurrency` cap.
- Per-worker accounting in the stall-watchdog / circuit-breaker (#77) — those track the daemon process, which remains a single process regardless of internal threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)