### PR TITLE
fix(codex): emit web_search as top-level config

### DIFF
--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -338,6 +338,7 @@ def setup_codex_settings(
         'approval_policy = "never"',
         'sandbox_mode = "danger-full-access"',
         'personality = "pragmatic"',
+        f'web_search = "{web_search}"',
     ]
 
     if gateway_url:
@@ -349,11 +350,6 @@ def setup_codex_settings(
             'wire_api = "responses"',
             'env_key = "OPENAI_API_KEY"',
         ]
-
-    lines += [
-        '\n[tools]',
-        f'web_search = "{web_search}"',
-    ]
 
     config_toml = "\n".join(lines) + "\n"
 
@@ -469,4 +465,3 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
                 logger.warning(
                     f"Failed to install coral in worktree: {result.stderr.strip()}"
                 )
-

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import tempfile
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ import pytest
 from coral.config import AgentConfig, CoralConfig, GraderConfig, TaskConfig, WorkspaceConfig
 from coral.workspace import (
     create_project,
+    setup_codex_settings,
     setup_gitignore,
     setup_worktree_env,
     write_agent_id,
@@ -129,6 +131,31 @@ def test_setup_gitignore_idempotent():
         assert content.count(".claude/") == 1
 
 
+@pytest.mark.parametrize(
+    ("research", "expected"),
+    [
+        (True, "live"),
+        (False, "disabled"),
+    ],
+)
+def test_setup_codex_settings_writes_top_level_web_search(
+    research: bool, expected: str,
+):
+    """Codex expects web_search as a top-level mode, not under [tools]."""
+    with tempfile.TemporaryDirectory() as d:
+        worktree = Path(d) / "worktree"
+        coral_dir = Path(d) / ".coral"
+        worktree.mkdir()
+        coral_dir.mkdir()
+
+        setup_codex_settings(worktree, coral_dir, research=research)
+
+        config_toml = (worktree / ".codex" / "config.toml").read_text()
+        config = tomllib.loads(config_toml)
+        assert config["web_search"] == expected
+        assert "tools" not in config
+
+
 def test_create_project_runs_setup_commands():
     """Setup commands execute in the worktree directory."""
     with tempfile.TemporaryDirectory() as d:
@@ -200,5 +227,4 @@ def test_setup_worktree_env_runs_when_venv_missing():
         setup_worktree_env(worktree, [f"touch {marker}"])
 
         assert marker.exists(), "Setup should have run on first launch"
-
 


### PR DESCRIPTION
## Summary

Fixes the Codex runtime worktree config generated by CORAL so `web_search` is emitted as the supported top-level Codex setting instead of under `[tools]`.

Reference: https://developers.openai.com/codex/config-reference

CORAL still preserves the existing `agents.research` behavior:

- `research: true` -> `web_search = "live"`
- `research: false` -> `web_search = "disabled"`

## Problem

`setup_codex_settings()` previously generated:

```toml
[tools]
web_search = "live"
```

or:

```toml
[tools]
web_search = "disabled"
```

Current Codex config expects the mode-valued setting at the top level:

```toml
web_search = "live"
```

The old shape can cause newer Codex CLI versions to reject CORAL-generated `.codex/config.toml`, preventing Codex agents from starting cleanly in CORAL worktrees.

## What changed

- Move `web_search = "live" | "disabled"` into the top-level Codex config emitted by `setup_codex_settings()`.
- Remove the generated `[tools]` block for Codex web search.
- Add a parametrized regression test covering both `research=True` and `research=False`.
- The test parses generated TOML with `tomllib` and asserts:
  - `web_search` has the expected top-level value.
  - no `tools` table is generated.

## Why this shape

This keeps CORAL's existing research toggle semantics while matching Codex's current config schema.

## Test plan

- [x] `uv run python -m pytest tests/test_workspace.py -q`
  - `13 passed`
- [x] `uv run python -m ruff check coral/workspace/worktree.py tests/test_workspace.py`
  - clean
- [x] `uv run python -m pytest tests/ -q`
  - `184 passed, 2 warnings`

## Notes

The warnings in the full test run are pre-existing `datetime.utcnow()` deprecation warnings in `coral/agent/state.py` and are unrelated to this change.
