### PR TITLE
docs: one-line installer (curl | sh) via uv tool install

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,43 @@ Want self-improving AI without the configuration overhead? Try Coral.
 
 ### Installation
 
+**One line — installs `coral` globally so you can run it from any directory:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
+```
+
+The script bootstraps [`uv`](https://github.com/astral-sh/uv) if missing, then runs `uv tool install` to drop the `coral` binary into `~/.local/bin`. Pin a version by setting `CORAL_VERSION=v0.5.0` (any git tag/branch/commit works).
+
+<details>
+<summary>Manual install (skip the curl pipe)</summary>
+
+```bash
+# Already have uv? One command:
+uv tool install git+https://github.com/Human-Agent-Society/CORAL.git
+
+# Install / upgrade uv first if needed:
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+</details>
+
+<details>
+<summary>Develop CORAL itself (clone + editable install)</summary>
+
 ```bash
 git clone https://github.com/Human-Agent-Society/CORAL.git
 cd CORAL
-# install uv from https://github.com/astral-sh/uv
-uv sync                   # (optionally add --extra ui to include dashboard dependencies)
+uv sync                       # (add --extra ui for the dashboard, --extra dev for tests)
+uv run coral --help           # prefix commands with `uv run` in the dev checkout
+```
+
+</details>
+
+Verify:
+
+```bash
+coral --version
 ```
 
 ### Supported Agents

--- a/README_CN.md
+++ b/README_CN.md
@@ -42,11 +42,43 @@
 
 ### 安装
 
+**一行命令 —— 全局安装 `coral`，在任意目录下都可直接调用：**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
+```
+
+该脚本会先检查并按需安装 [`uv`](https://github.com/astral-sh/uv)，然后通过 `uv tool install` 将 `coral` 可执行文件放入 `~/.local/bin`。如需指定版本,设置 `CORAL_VERSION=v0.5.0`(支持任意 git tag/分支/commit)。
+
+<details>
+<summary>手动安装（不使用 curl 管道）</summary>
+
+```bash
+# 已安装 uv,只需一条命令:
+uv tool install git+https://github.com/Human-Agent-Society/CORAL.git
+
+# 若未安装 uv,先安装 uv:
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+</details>
+
+<details>
+<summary>参与 CORAL 开发（clone + 可编辑安装）</summary>
+
 ```bash
 git clone https://github.com/Human-Agent-Society/CORAL.git
 cd CORAL
-# 从 https://github.com/astral-sh/uv 安装 uv
-uv sync                   # （可选：添加 --extra ui 以包含看板依赖）
+uv sync                       # （添加 --extra ui 包含看板依赖；--extra dev 包含测试工具）
+uv run coral --help           # 开发模式下需要加 `uv run` 前缀
+```
+
+</details>
+
+验证安装：
+
+```bash
+coral --version
 ```
 
 ### 支持的 Agent

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -4,58 +4,92 @@ description: Install CORAL and its dependencies.
 ---
 
 
-## Prerequisites
+## Quick install (recommended)
 
-- **Python 3.11+**
-- **uv** — fast Python package manager ([install uv](https://docs.astral.sh/uv/getting-started/installation/))
-- **git** — for worktree management
-- **tmux** — recommended for session management (CORAL auto-wraps in tmux by default)
-
-You'll also need at least one supported agent runtime:
-- **Claude Code** (default) — requires an Anthropic API key
-- **Codex** — OpenAI's coding agent
-- **OpenCode** — open-source alternative
-
-For Harbor-based benchmarks (SWE-bench, terminal-bench), you additionally need:
-- **Docker** — installed and running on the host
-- **Harbor CLI** — invoked via `uvx harbor` (no separate install needed if you have `uv`)
-
-## Install from source
+One line — installs the `coral` CLI globally so you can run it from any directory:
 
 ```bash
-git clone https://github.com/yanyh528/CORAL.git
-cd CORAL
+curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
 ```
 
-### Basic install
+The script:
+
+1. Installs [`uv`](https://docs.astral.sh/uv/) if missing.
+2. Runs `uv tool install git+https://github.com/Human-Agent-Society/CORAL.git` — drops the `coral` binary into `~/.local/bin` inside an isolated venv.
+3. Ensures `~/.local/bin` is on `PATH` for future shells.
+
+Pin a version (any git tag, branch, or commit):
 
 ```bash
-uv sync
+curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | CORAL_VERSION=v0.5.0 sh
 ```
 
-### With development tools
-
-```bash
-uv sync --extra dev        # pytest, ruff, mypy
-```
-
-### Everything
-
-```bash
-uv sync --all-extras       # All optional dependencies
-```
-
-## Verify installation
+Verify:
 
 ```bash
 coral --version
 ```
 
-You should see something like `coral 0.2.0`.
+Upgrade in place at any time:
 
-## Optional dependencies
+```bash
+uv tool upgrade coral
+```
 
-CORAL currently exposes two optional extras:
+## Prerequisites
+
+The installer handles `uv` for you. You still need:
+
+- **Python 3.11+** (uv will fetch one if you don't have it)
+- **git** — CORAL uses git worktrees for agent isolation
+- **curl** — used by the installer to bootstrap uv
+
+Recommended:
+
+- **tmux** — CORAL auto-wraps runs in a tmux session (use `run.session=local` to skip)
+
+At least one supported agent runtime:
+
+- **Claude Code** (default) — requires an Anthropic API key
+- **Codex** — OpenAI's coding agent
+- **OpenCode** — open-source alternative
+
+For Harbor-based benchmarks (SWE-bench, terminal-bench):
+
+- **Docker** — installed and running on the host
+- **Harbor CLI** — invoked via `uvx harbor` (no separate install if you have `uv`)
+
+## Manual install (no curl pipe)
+
+If you'd rather not pipe a remote script into a shell:
+
+```bash
+# Install uv first (skip if already installed):
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install coral as a uv tool (isolated venv, on PATH):
+uv tool install git+https://github.com/Human-Agent-Society/CORAL.git
+
+# Pin a version:
+uv tool install git+https://github.com/Human-Agent-Society/CORAL.git@v0.5.0
+```
+
+## Develop CORAL itself
+
+If you're modifying CORAL's source rather than just using it, clone the repo and use an editable install. In this mode, prefix commands with `uv run`:
+
+```bash
+git clone https://github.com/Human-Agent-Society/CORAL.git
+cd CORAL
+uv sync                       # basic
+uv sync --extra dev           # with pytest, ruff, mypy
+uv sync --extra ui            # with web dashboard
+uv sync --all-extras          # everything
+
+uv run coral --version
+```
+
+### Optional extras
 
 | Extra  | Install                  | Purpose                              |
 |--------|--------------------------|--------------------------------------|

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+# CORAL installer — installs the `coral` CLI globally via uv.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
+#
+# Pin a version (any git tag, branch, or commit):
+#   curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | CORAL_VERSION=v0.5.0 sh
+#
+# What it does:
+#   1. Installs `uv` if missing (via https://astral.sh/uv/install.sh)
+#   2. Runs `uv tool install --force git+https://github.com/Human-Agent-Society/CORAL.git`
+#      — places `coral` in ~/.local/bin (an isolated venv, on PATH)
+#   3. Ensures ~/.local/bin is on PATH in future shells
+set -eu
+
+REPO="https://github.com/Human-Agent-Society/CORAL.git"
+VERSION="${CORAL_VERSION:-main}"
+
+say()  { printf '\033[1;36m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33m!!\033[0m  %s\n' "$1" >&2; }
+die()  { printf '\033[1;31mxx\033[0m  %s\n' "$1" >&2; exit 1; }
+
+command -v git >/dev/null 2>&1 || die "git is required (CORAL uses git worktrees). Install git and retry."
+command -v curl >/dev/null 2>&1 || die "curl is required to bootstrap uv. Install curl and retry."
+
+if ! command -v uv >/dev/null 2>&1; then
+  say "uv not found — installing from astral.sh"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # uv's installer writes shell rc entries but doesn't update this shell
+  PATH="$HOME/.local/bin:$PATH"
+  export PATH
+  command -v uv >/dev/null 2>&1 || die "uv install completed but 'uv' is still not on PATH. Open a new shell and retry."
+fi
+
+say "Installing coral from ${REPO}@${VERSION}"
+uv tool install --force "git+${REPO}@${VERSION}"
+
+# Make sure ~/.local/bin is on PATH for future shells (idempotent)
+uv tool update-shell >/dev/null 2>&1 || true
+
+if command -v coral >/dev/null 2>&1; then
+  INSTALLED="$(coral --version 2>/dev/null || echo coral)"
+  say "Installed: ${INSTALLED}"
+  cat <<'EOF'
+
+Next steps:
+  coral --help                          List commands
+  coral init my-task                    Scaffold a new task
+  coral start -c my-task/task.yaml      Launch agents
+
+Docs:  https://human-agent-society.github.io/CORAL/
+EOF
+else
+  warn "Install succeeded, but 'coral' is not on PATH in this shell."
+  warn "Open a new terminal — or run:  export PATH=\"\$HOME/.local/bin:\$PATH\""
+fi


### PR DESCRIPTION
## Summary

- Adds `install.sh` — a ~50-line POSIX sh installer that bootstraps `uv` if missing, then runs `uv tool install --force git+https://github.com/Human-Agent-Society/CORAL.git@${CORAL_VERSION:-main}`. The `coral` binary lands in `~/.local/bin`, so `coral start …` works from any directory without the `uv run` prefix and without a CORAL checkout.
- Rewrites the installation sections of `README.md`, `README_CN.md`, and `docs/content/docs/getting-started/installation.mdx` to lead with the one-liner. The `git clone + uv sync` path is preserved as a collapsible "develop CORAL itself" section for contributors.
- Drive-by fix: stale repo URL in `installation.mdx` (`yanyh528/CORAL` → `Human-Agent-Society/CORAL`).

No code under `coral/` changes; this is docs + a new top-level shell script.

## Why this design (vs. PyPI / single binary)

- We don't need PyPI: `uv tool install` reads `git+https://…` URLs natively, and CORAL already needs `git` (worktrees). Pinning via git tag/branch/commit is supported via `CORAL_VERSION=…`.
- We can't ship a single binary like opencode does — CORAL is pure Python with heavy optional deps. `uv tool install` gives us the same "global CLI, isolated venv, version pin, upgrade in place" UX with zero release infrastructure.

## Test plan

- [x] `sh -n install.sh` and `bash -n install.sh` — syntax clean
- [x] Dry-run with shimmed `uv`/`curl` — verified the script calls `uv tool install --force git+https://github.com/Human-Agent-Society/CORAL.git@<version>` and prints the right fallback when `coral` isn't on PATH afterwards
- [ ] End-to-end run on a fresh shell:
  ```bash
  curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/doc_better_installation/install.sh | sh
  coral --version
  ```
- [ ] End-to-end with version pinning:
  ```bash
  curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/doc_better_installation/install.sh | CORAL_VERSION=main sh
  ```
- [ ] Verify README / `installation.mdx` render correctly on github.com and the docs site

## Follow-ups (not in this PR)

- README "Usage" section and the bottom CLI table still show `uv run coral …`. After this lands, do a sweep to drop the `uv run` prefix for the install-from-curl path (keeping it only in the "develop CORAL itself" section).
- `coral doctor` (env check) and `coral examples clone <name>` (so users without a checkout can grab example tasks) — both mentioned during design discussion, deferred to separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)