### PR TITLE
docs: slim README, move runtime/gateway/quickstart to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/inst
 Installs `coral` globally via `uv tool install`. Pin a version with `CORAL_VERSION=v0.5.0`. See [Installation docs](https://human-agent-society.github.io/CORAL/getting-started/installation) for manual install, dev setup, and prerequisites.
 
 ```bash
-coral init my-task              # scaffold a task
-coral start -c my-task/task.yaml  # launch agents
+coral init my-task                       # scaffold a task
+cd my-task && coral start -c task.yaml   # launch agents
 ```
 
 ### Supported Agents

--- a/README.md
+++ b/README.md
@@ -3,180 +3,68 @@
 
 <img src="assets/logo.png" alt="Coral" width="360">
 
-
 #### Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
-
-## 🚀 Supercharge Your AutoResearch
-
-
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://human-agent-society.github.io/CORAL/)
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-3776AB.svg?logo=python&logoColor=white)](https://python.org)
-[![uv](https://img.shields.io/badge/uv-package%20manager-5C4EE5.svg)](https://docs.astral.sh/uv/)
 
 **English** | [中文](README_CN.md)
 
 </div>
 
 <p align="center">
-<a href="#installation">Installation</a> · <a href="#supported-agents">Supported Agents</a> · <a href="#usage">Usage</a> · <a href="#how-it-works">How It Works</a> · <a href="#examples">Examples</a> · <a href="https://human-agent-society.github.io/CORAL/">Docs</a> · <a href="#license">License</a>
+<a href="#installation">Installation</a> · <a href="#supported-agents">Supported Agents</a> · <a href="#how-it-works">How It Works</a> · <a href="#examples">Examples</a> · <a href="https://human-agent-society.github.io/CORAL/">Docs</a> · <a href="https://arxiv.org/abs/2604.01658v1">Paper</a>
 </p>
 
+**CORAL** is infrastructure for **autonomous AI agent organizations** that run experiments, share knowledge, and continuously improve solutions. Give it a codebase and a grader, and CORAL handles the rest: isolated workspaces, safe evaluation, persistent shared state, and multi-agent collaboration. Natively integrated with Claude Code, OpenCode, Codex, Cursor Agent, and Kiro.
 
-**CORAL** is an infrastructure for building organizations of **autonomous AI agents** that run experiments, share knowledge, and continuously improve solutions. Give it a codebase and a grading script, and Coral handles the rest: isolated workspaces, safe evaluation, persistent shared knowledge, and multi-agent collaboration to enable robust evolution. Coral is natively integrated with Claude Code, OpenCode, Codex, and other major coding agents.
+### 🔥 News
 
-Want self-improving AI without the configuration overhead? Try Coral.
-
-
-
-### 🔥 News!
-
-- **[2026-04-24]** **Rubric judges** — two reusable LLM-judge grader packages for open-ended tasks (reports, memos, legal analysis). Static rubrics (`race_japan_grader`) and auto-evolving dynamic rubrics (`apex_judge`), both spawning Claude Code as the judge. See the [Rubric Judges guide](docs/content/docs/guides/rubric-judge.mdx) and the new `examples/race-japan-elderly/`, `examples/apex-eggshell-skull/`, `examples/apex-frontier-bu/` tasks.
-- **[2026-04-03]** Our paper, “CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery,” is now out! Check it out on [Arxiv](https://arxiv.org/pdf/2604.01658).
-- **[2026-03-18]** CORAL is released! Check out our [blog post](https://human-agent-society.github.io/CORAL/).
+- **[2026-04-24]** Rubric judges — two reusable LLM-judge grader packages for open-ended tasks (reports, memos, legal analysis). See the [Rubric Judges guide](https://human-agent-society.github.io/CORAL/guides/rubric-judge).
+- [Older news →](https://human-agent-society.github.io/CORAL/blog)
 
 ![Demo](assets/demo.gif)
 
 ### Installation
 
-**One line — installs `coral` globally so you can run it from any directory:**
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
 ```
 
-The script bootstraps [`uv`](https://github.com/astral-sh/uv) if missing, then runs `uv tool install` to drop the `coral` binary into `~/.local/bin`. Pin a version by setting `CORAL_VERSION=v0.5.0` (any git tag/branch/commit works).
-
-<details>
-<summary>Manual install (skip the curl pipe)</summary>
+Installs `coral` globally via `uv tool install`. Pin a version with `CORAL_VERSION=v0.5.0`. See [Installation docs](https://human-agent-society.github.io/CORAL/getting-started/installation) for manual install, dev setup, and prerequisites.
 
 ```bash
-# Already have uv? One command:
-uv tool install git+https://github.com/Human-Agent-Society/CORAL.git
-
-# Install / upgrade uv first if needed:
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-</details>
-
-<details>
-<summary>Develop CORAL itself (clone + editable install)</summary>
-
-```bash
-git clone https://github.com/Human-Agent-Society/CORAL.git
-cd CORAL
-uv sync                       # (add --extra ui for the dashboard, --extra dev for tests)
-uv run coral --help           # prefix commands with `uv run` in the dev checkout
-```
-
-</details>
-
-Verify:
-
-```bash
-coral --version
+coral init my-task              # scaffold a task
+coral start -c my-task/task.yaml  # launch agents
 ```
 
 ### Supported Agents
 
-Coral works with any coding agent that can run as a subprocess and interact via the terminal. Currently supported:
+| Agent | `agents.runtime` |
+|-------|------------------|
+| [Claude Code](https://github.com/anthropics/claude-code) — default | `claude_code` |
+| [Codex](https://github.com/openai/codex) | `codex` |
+| [Cursor Agent](https://cursor.com/docs/cli/overview) | `cursor` |
+| [Kiro](https://kiro.dev) | `kiro` |
+| [OpenCode](https://github.com/opencode-ai/opencode) | `opencode` |
 
-| Agent | Description |
-|-------|-------------|
-| [**Claude Code**](https://github.com/anthropics/claude-code) | Anthropic's agentic coding tool — the default and most tested runtime |
-| [**Codex**](https://github.com/openai/codex) | OpenAI's open-source coding agent |
-| [**Cursor Agent**](https://cursor.com/docs/cli/overview) | Cursor's headless `cursor-agent` CLI |
-| [**Kiro**](https://kiro.dev) | Kiro's `kiro-cli` agent (AWS-hosted) |
-| [**OpenCode**](https://github.com/opencode-ai/opencode) | Open-source terminal-based AI coding agent |
-
-> [!TIP]
-> Before using Coral, make sure you have fully set up the agent(s) you plan to use:
->
-> - **Install the Agent:** Follow the official installation instructions for your agent (e.g., Claude Code, Codex, OpenCode). This may involve installing packages, setting up executables, or configuring scripts.
-> - **Authentication:** Login and authenticate your coding agent first to make sure they do not ask for your credentials in CLI mode. Set up any required environment variables, configuration files, or authentication secrets as specified in your agent's documentation.
-> - **Set Permissions:** Configure your agent's permission settings via its config file (e.g., `~/.claude/settings.json` for Claude Code) to control which tools, file paths, or actions it is allowed to perform.
->
-> *Coral does not handle agent installation or authentication for you. The infrastructure will fail to function if the underlying agent cannot start or is not properly authenticated.*
-
-Set the agent in your task config (refer to <a href="#3-configure-the-task">Configure the task</a>):
-
-```yaml
-agents:
-  runtime: claude_code   # or "codex", "cursor", "kiro", "opencode"
-  count: 3  # how many agents you want to spawn. Beware of your budget :)
-  model: opus   # name of the model you wish to use
-```
-
-### Usage
-
-```bash
-# start a run
-coral start -c examples/kernel_builder/task.yaml
-
-# override any config value via dotlist syntax
-coral start -c task.yaml agents.count=4 agents.model=opus
-coral start -c task.yaml run.verbose=true        # stream agent output
-coral start -c task.yaml run.ui=true             # also launch web dashboard
-
-# stop and resume
-coral stop                                       # stop anytime
-coral resume                                     # pick up where you left off
-
-# monitor progress
-coral status                                     # CLI leaderboard
-coral ui                                         # web dashboard
-```
-
-Full CLI reference: see [`coral --help`](https://human-agent-society.github.io/CORAL/cli/reference) or run `coral --help`. Configuration options (warm-start, gateway, Docker session, etc.) live in the [Configuration](https://human-agent-society.github.io/CORAL/getting-started/configuration) docs.
+Each agent must be installed and authenticated separately. Per-runtime config — including the [LiteLLM gateway](https://human-agent-society.github.io/CORAL/guides/gateway) for custom models — is documented at [Agent Runtimes](https://human-agent-society.github.io/CORAL/guides/agent-runtimes).
 
 ### How It Works
 
 <p align="center">
-  <img src="assets/coral_diagram_trans.jpg" alt="Coral Architecture Diagram" width="800">
+  <img src="assets/coral_diagram_trans.jpg" alt="CORAL Architecture Diagram" width="800">
 </p>
 
-Each agent runs in its own git worktree branch. Shared state (attempts, notes, skills) lives in `.coral/public/` and is symlinked into every worktree — agents see each other's work in real time with zero sync overhead. The manager watches for new attempts and can interrupt agents with heartbeat-triggered prompts (e.g. "reflect", "consolidate skills").
+Each agent runs in its own git worktree. Shared state (attempts, notes, skills) lives in `.coral/public/` and is symlinked into every worktree — agents see each other's work in real time. A grader daemon scores every commit. The manager interrupts agents with heartbeat prompts (`reflect`, `consolidate`, `pivot`).
 
-| Concept | Description |
-|---------|-------------|
-| **Agents as optimizers** | Claude Code / Codex / Cursor Agent / Kiro / OpenCode subprocesses, each in its own git worktree |
-| **Shared state** | `.coral/` directory with attempts, notes, and skills — symlinked into every worktree |
-| **Eval loop** | Agents call `coral eval -m "..."` to stage, commit, and grade in one shot |
-| **CLI orchestration** | 17+ commands: `start`, `stop`, `status`, `eval`, `log`, `ui`, and more |
-| **Web dashboard** | `coral ui` — real-time leaderboard, attempt diffs, agent monitoring |
-
-**Deep research:** Agents come with a bundled `deep-research` skill that guides structured literature review — web search, saving raw sources, writing research notes, and building an index. It runs automatically during warm-start (`agents.warmstart.enabled=true`), and agents can also invoke it mid-run when pivoting to a new approach. Requires `agents.research=true` for web search.
-
-### Quick Start
-
-Three commands get you running:
-
-```bash
-coral init my-task                            # scaffold task.yaml + grader stub + seed/
-# edit my-task/task.yaml and my-task/eval/grader.py for your problem
-coral validate my-task                        # dry-run the grader against seed/
-coral start -c my-task/task.yaml              # launch agents (auto-tmux)
-```
-
-Want a complete walkthrough — seed code, grader, task.yaml, launch — with a worked TSP example? See the [Quick Start guide](https://human-agent-society.github.io/CORAL/getting-started/quickstart).
-
-### Agent Runtimes & Gateway
-
-Claude Code (the default) needs no special config beyond an Anthropic API key. To use a different runtime, see the per-runtime guides:
-
-- [OpenCode](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#opencode) — requires an `opencode.json` in your seed directory
-- [Cursor Agent](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#cursor-agent) — `cursor-agent login` once, then set `runtime: cursor`
-- [Kiro](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#kiro) — `kiro-cli` install + setup, then `runtime: kiro`
-
-To route agent traffic through a unified proxy (custom models, request logging, per-agent keys), enable the built-in [LiteLLM Gateway](https://human-agent-society.github.io/CORAL/guides/gateway).
+Deeper dive: [Concepts](https://human-agent-society.github.io/CORAL/concepts) · [Multi-agent runs](https://human-agent-society.github.io/CORAL/guides/multi-agent) · [Eval loop](https://human-agent-society.github.io/CORAL/concepts/eval-loop)
 
 ### Examples
 
 Ready-to-run task configurations in `examples/`:
-
 
 | Task                       | Domain       | Description                                                 |
 | -------------------------- | ------------ | ----------------------------------------------------------- |
@@ -188,26 +76,11 @@ Ready-to-run task configurations in `examples/`:
 | **spaceship_titanic**      | ML           | Kaggle competition                                          |
 | **stanford_covid_vaccine** | Bio/ML       | mRNA degradation prediction                                 |
 
+Full catalogue and walkthroughs at [Examples docs](https://human-agent-society.github.io/CORAL/examples).
 
-### Development
+### Development & License
 
-```bash
-# Install dev dependencies
-uv sync --extra dev
-
-# Run tests
-uv run pytest tests/ -v
-
-# Lint & format
-uv run ruff check .
-uv run ruff format .
-```
-
-> [!IMPORTANT]
-> **Docker requirement:** Some built-in graders (e.g. SWE-bench, terminal-bench) use [Harbor](https://github.com/corca-ai/harbor) to run evaluations inside Docker containers. CORAL itself must **not** run inside Docker in this case, as Docker-in-Docker (DinD) is not supported. Run CORAL directly on the host machine.
-
-This project is released under the Apache 2.0 [LICENSE](LICENSE).
-
+Clone the repo and run `uv sync --extra dev` for tests/lint. See [CLAUDE.md](CLAUDE.md) for codebase layout. Released under [Apache 2.0](LICENSE).
 
 ### Citation
 
@@ -230,6 +103,6 @@ This project is released under the Apache 2.0 [LICENSE](LICENSE).
  </picture>
 </a>
 
-### Acknowledgement
+### Acknowledgements
 
-We thank the [TNT Accelerator](https://www.tnt.so/) for their generous support of various API credits that have helped during the development of Coral. We would also like to thank many of the inspiring prior works such as [OpenEvolve](https://github.com/algorithmicsuperintelligence/openevolve), [autoresearch](https://github.com/karpathy/autoresearch), [TTT Discover](https://arxiv.org/abs/2601.16175),  etc., that have led to the ideation of Coral.
+Thanks to the [TNT Accelerator](https://www.tnt.so/) for API credits, and to prior work that inspired CORAL: [OpenEvolve](https://github.com/algorithmicsuperintelligence/openevolve), [autoresearch](https://github.com/karpathy/autoresearch), [TTT Discover](https://arxiv.org/abs/2601.16175).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </div>
 
 <p align="center">
-<a href="#installation">Installation</a> · <a href="#supported-agents">Supported Agents</a> · <a href="#usage">Usage</a> · <a href="#how-it-works">How It Works</a> · <a href="#quick-start">Quick Start</a> · <a href="#cli-reference">CLI Reference</a> · <a href="#using-opencode">OpenCode</a> · <a href="#using-cursor-agent">Cursor</a> · <a href="#using-kiro">Kiro</a> · <a href="#using-the-gateway-for-custom-models">Gateway</a> · <a href="#examples">Examples</a> · <a href="#license">License</a>
+<a href="#installation">Installation</a> · <a href="#supported-agents">Supported Agents</a> · <a href="#usage">Usage</a> · <a href="#how-it-works">How It Works</a> · <a href="#examples">Examples</a> · <a href="https://human-agent-society.github.io/CORAL/">Docs</a> · <a href="#license">License</a>
 </p>
 
 
@@ -114,26 +114,23 @@ agents:
 
 ```bash
 # start a run
-uv run coral start -c examples/kernel_builder/task.yaml
+coral start -c examples/kernel_builder/task.yaml
 
 # override any config value via dotlist syntax
-uv run coral start -c task.yaml agents.count=4 agents.model=opus
-uv run coral start -c task.yaml run.verbose=true        # stream agent output
-uv run coral start -c task.yaml run.ui=true              # also launch web dashboard
-uv run coral start -c task.yaml run.session=local         # skip tmux, run inline
-uv run coral start -c task.yaml run.session=docker        # run inside Docker container
-
-# warm-start: research phase before coding (agents do literature review first)
-uv run coral start -c task.yaml agents.warmstart.enabled=true agents.research=true
+coral start -c task.yaml agents.count=4 agents.model=opus
+coral start -c task.yaml run.verbose=true        # stream agent output
+coral start -c task.yaml run.ui=true             # also launch web dashboard
 
 # stop and resume
-uv run coral stop                                        # stop anytime
-uv run coral resume                                      # pick up where you left off
-uv run coral resume agents.model=opus run.verbose=true   # resume with overrides
+coral stop                                       # stop anytime
+coral resume                                     # pick up where you left off
 
 # monitor progress
-uv run coral ui                                          # open the web dashboard
+coral status                                     # CLI leaderboard
+coral ui                                         # web dashboard
 ```
+
+Full CLI reference: see [`coral --help`](https://human-agent-society.github.io/CORAL/cli/reference) or run `coral --help`. Configuration options (warm-start, gateway, Docker session, etc.) live in the [Configuration](https://human-agent-society.github.io/CORAL/getting-started/configuration) docs.
 
 ### How It Works
 
@@ -147,327 +144,34 @@ Each agent runs in its own git worktree branch. Shared state (attempts, notes, s
 |---------|-------------|
 | **Agents as optimizers** | Claude Code / Codex / Cursor Agent / Kiro / OpenCode subprocesses, each in its own git worktree |
 | **Shared state** | `.coral/` directory with attempts, notes, and skills — symlinked into every worktree |
-| **Eval loop** | Agents call `uv run coral eval -m "..."` to stage, commit, and grade in one shot |
+| **Eval loop** | Agents call `coral eval -m "..."` to stage, commit, and grade in one shot |
 | **CLI orchestration** | 17+ commands: `start`, `stop`, `status`, `eval`, `log`, `ui`, and more |
-| **Web dashboard** | `uv run coral ui` — real-time leaderboard, attempt diffs, agent monitoring |
+| **Web dashboard** | `coral ui` — real-time leaderboard, attempt diffs, agent monitoring |
 
 **Deep research:** Agents come with a bundled `deep-research` skill that guides structured literature review — web search, saving raw sources, writing research notes, and building an index. It runs automatically during warm-start (`agents.warmstart.enabled=true`), and agents can also invoke it mid-run when pivoting to a new approach. Requires `agents.research=true` for web search.
 
 ### Quick Start
 
-Let's walk through a complete example: agents continually optimize a **100-city Traveling Salesman Problem**.
-
-#### 1. Write a seed codebase
-
-The seed is the starting code that agents will iterate on. Create a working directory:
+Three commands get you running:
 
 ```bash
-mkdir -p examples/tsp/{seed,eval}
+coral init my-task                            # scaffold task.yaml + grader stub + seed/
+# edit my-task/task.yaml and my-task/eval/grader.py for your problem
+coral validate my-task                        # dry-run the grader against seed/
+coral start -c my-task/task.yaml              # launch agents (auto-tmux)
 ```
 
-Then create a naive initial solution (you can choose to start empty, though it can make the job of the agents harder):
+Want a complete walkthrough — seed code, grader, task.yaml, launch — with a worked TSP example? See the [Quick Start guide](https://human-agent-society.github.io/CORAL/getting-started/quickstart).
 
-```python
-# examples/tsp/seed/solution.py
-import random
+### Agent Runtimes & Gateway
 
-# Restate the problem here as the agent cannot read the content of `grader.py`
-random.seed(42)
-CITIES = [(random.random(), random.random()) for _ in range(100)]
+Claude Code (the default) needs no special config beyond an Anthropic API key. To use a different runtime, see the per-runtime guides:
 
-# Naive: visit cities in index order (0, 1, 2, ..., 99)
-for i in range(len(CITIES)):
-    print(i)
-```
+- [OpenCode](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#opencode) — requires an `opencode.json` in your seed directory
+- [Cursor Agent](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#cursor-agent) — `cursor-agent login` once, then set `runtime: cursor`
+- [Kiro](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#kiro) — `kiro-cli` install + setup, then `runtime: kiro`
 
-#### 2. Write a grader
-
-Subclass `TaskGrader` and implement `evaluate()`. The base class provides two helpers: `self.run_program(filename)` which runs a file from the agent's codebase in a subprocess and returns a `CompletedProcess` (with `.stdout`, `.stderr`, `.returncode`), and `self.fail(reason)` which records the failure and returns a null score:
-
-```python
-# examples/tsp/eval/grader.py
-import math
-import random
-from coral.grader import TaskGrader, ScoreBundle
-
-# keep consistent with the problem statement in `solution.py`
-random.seed(42)
-CITIES = [(random.random(), random.random()) for _ in range(100)]
-
-class Grader(TaskGrader):
-    def evaluate(self) -> float | ScoreBundle:
-        try:
-            result = self.run_program("solution.py")  # runs solution.py, returns CompletedProcess
-            order = [int(x) for x in result.stdout.strip().split("\n")]
-            assert sorted(order) == list(range(len(CITIES)))
-            dist = sum(
-                math.dist(CITIES[order[i]], CITIES[order[(i + 1) % len(order)]])
-                for i in range(len(order))
-            )
-            return -dist  # shorter tour = higher score
-        except Exception as e:
-            return self.fail(str(e))  # records failure and returns null score
-```
-
-The naive seed tour scores about `-58.02`. Agents will try nearest-neighbor, 2-opt, simulated annealing, etc. to find shorter routes. With 100 cities, exhaustive search is completely infeasible (99! permutations), so agents must discover and apply real optimization heuristics.
-
-#### 3. Configure the task
-
-Point the config at your seed codebase and grader:
-
-```yaml
-# examples/tsp/task.yaml
-task:
-  name: tsp
-  description: |
-    Find the shortest round-trip tour through 100 cities. The coordinates
-    are generated via numpy with a fixed seed in `solution.py`. DO NOT MODIFY the seed or CITIES generation!
-
-    solution.py must print 100 integers (0-99) to stdout, one per line,
-    representing the visit order. Each city must appear exactly once.
-
-    The grader computes the total Euclidean round-trip distance
-    and returns -distance as the score (shorter = higher).
-
-grader:
-  # Quick-start uses auto-discovered eval/grader.py (emits DeprecationWarning).
-  # For production tasks, package the grader and switch to:
-  #   entrypoint: "tsp_grader.grader:Grader"
-  #   setup: ["uv pip install -e ./grader"]
-  # See docs/guides/custom-grader for the migration walkthrough.
-  timeout: 300
-
-agents:
-  count: 1
-  runtime: claude_code  # or codex, cursor, kiro, opencode
-  model: claude-sonnet-4-6
-  max_turns: 200  # before the agent reboots. dont worry Coral keeps running until you stop
-
-workspace:
-  results_dir: "./results"  # relative to your $PWD
-  repo_path: "./examples/tsp/seed"  # relative to your $PWD
-```
-
-#### 4. Launch
-
-```bash
-uv run coral start -c examples/tsp/task.yaml             # launches in tmux session `coral-tsp`
-uv run coral start -c examples/tsp/task.yaml agents.count=4  # override agent count
-uv sync --extra ui && uv run coral ui                     # open web dashboard (port 8420)
-uv run coral status      # CLI leaderboard
-uv run coral log         # View attempts
-uv run coral stop        # Stop all agents
-```
-
-### CLI Reference
-
-<details>
-<summary>Click to expand all 17+ commands</summary>
-
-| Command                              | Description                         |
-| ------------------------------------ | ----------------------------------- |
-| `uv run coral init <name>`           | Scaffold a new task                 |
-| `uv run coral validate <name>`       | Test the grader                     |
-| `uv run coral start -c task.yaml [overrides...]` | Launch agents (e.g. `agents.count=4 run.verbose=true`) |
-| `uv run coral resume [overrides...]` | Resume a previous run (e.g. `agents.model=opus`)       |
-| `uv run coral stop`                  | Stop all agents                     |
-| `uv run coral status`                | Agent health + leaderboard          |
-| `uv run coral log`                   | Leaderboard (top 20)                |
-| `uv run coral log -n 5 --recent`     | Recent attempts                     |
-| `uv run coral log --search "query"`  | Search attempts                     |
-| `uv run coral show <hash>`           | Attempt details + diff              |
-| `uv run coral notes`                 | Browse shared notes                 |
-| `uv run coral skills`                | Browse shared skills                |
-| `uv run coral runs`                  | List all runs                       |
-| `uv run coral ui`                    | Web dashboard                       |
-| `uv run coral eval -m "description"` | Stage, commit, evaluate (agent use) |
-| `uv run coral diff`                  | Show uncommitted changes            |
-| `uv run coral revert`                | Undo last commit                    |
-| `uv run coral checkout <hash>`       | Reset to previous attempt           |
-| `uv run coral heartbeat`             | View/modify heartbeat actions       |
-
-</details>
-
-
-### Architecture
-
-<details>
-<summary>Click to expand</summary>
-
-```
-coral/
-├── types.py             # Task, Score, ScoreBundle, Attempt
-├── config.py            # YAML-based CoralConfig
-├── agent/
-│   ├── manager.py       # Multi-agent lifecycle
-│   └── runtime.py       # Claude Code / Codex / Cursor Agent / Kiro / OpenCode subprocess
-├── workspace/
-│   └── setup.py         # Worktree creation, hooks, symlinks
-├── grader/
-│   ├── protocol.py      # GraderInterface protocol
-│   ├── base.py          # BaseGrader (helpers: _make_score, _make_bundle)
-│   ├── task_grader.py   # TaskGrader for task-specific graders
-│   ├── loader.py        # Grader discovery and loading
-│   └── builtin/
-│       └── function_grader.py
-├── hub/
-│   ├── attempts.py      # Attempt CRUD + leaderboard + search
-│   ├── notes.py         # Markdown notes with YAML frontmatter
-│   └── skills.py        # Skill directories with SKILL.md
-├── hooks/
-│   └── post_commit.py   # Eval-on-commit implementation
-├── template/
-│   └── coral_md.py      # CORAL.md generator
-├── web/                 # Starlette + React dashboard
-└── cli/                 # 17 commands across 5 modules
-```
-
-</details>
-
-### Using OpenCode
-
-To use [OpenCode](https://github.com/opencode-ai/opencode) as your agent runtime, you need to provide an `opencode.json` configuration file in your seed directory. This file configures OpenCode's permissions and provider settings.
-
-Here is an example from `examples/circle_packing/seed/opencode.json`:
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "permission": {
-    "external_directory": "allow",
-    "question": "deny",
-    "doom_loop": "allow",
-    "bash": "allow",
-    "edit": "allow",
-    "read": "allow",
-    "write": "allow",
-    "webfetch": "deny",
-    "websearch": "deny",
-    "codesearch": "allow",
-    "lsp": "allow",
-    "skill": "allow"
-  },
-  "provider": {
-    "claude": {
-      "npm": "@ai-sdk/anthropic",
-      "name": "claude",
-      "options": {
-        "baseURL": "http://localhost:4000/v1",
-        "apiKey": "xxx"
-      },
-      "models": {
-        "claude-opus-4-6": {
-          "name": "claude-opus-4-6"
-        }
-      }
-    }
-  }
-}
-```
-
-Key points:
-- Set all permissions to `"allow"` (except `question`, `webfetch`, `websearch` which should be `"deny"`) so the agent can run autonomously without interactive prompts.
-- The `provider` section configures which model to use. When using the gateway (see below), point `baseURL` at `http://localhost:<gateway_port>/v1` and set `apiKey` to any placeholder value — the gateway handles authentication.
-- Place `opencode.json` in your seed directory so it gets copied into each agent's worktree.
-
-Then set your task config to use OpenCode:
-
-```yaml
-agents:
-  runtime: opencode
-  model: claude/claude-opus-4-6  # must match a model defined in opencode.json
-```
-
-### Using Cursor Agent
-
-To use [Cursor Agent](https://cursor.com/docs/cli/overview), install the headless CLI and authenticate once:
-
-```bash
-curl -fsSL https://cursor.com/install | bash
-cursor-agent login
-```
-
-Then point your task at it:
-
-```yaml
-agents:
-  runtime: cursor          # alias for cursor_agent; "cursor-agent" also works
-  model: auto              # or any model id supported by your Cursor plan
-```
-
-CORAL spawns each agent as `cursor-agent --print --output-format stream-json --force --workspace <wt> [--model] [--mode] [--resume] <prompt>`. The `--force` flag is always passed (cursor-agent requires it for write tools in `--print` mode). The full task brief is written to `AGENTS.md` at the worktree root, and CORAL also drops a `.cursor/rules/coral.mdc` always-apply rule with short guardrails (use `coral eval`, don't touch `.coral/private/`, share via `.cursor/notes/` and `.cursor/skills/`) so they survive context pressure.
-
-Optional `runtime_options`:
-
-```yaml
-agents:
-  runtime: cursor
-  runtime_options:
-    command: /usr/local/bin/cursor-agent  # override binary path
-    mode: plan                            # --mode plan|ask
-    stream_partial_output: true           # --stream-partial-output
-```
-
-> **Note:** Cursor Agent uses its own auth and does **not** route through the LiteLLM gateway. Login state lives in your Cursor account, not in CORAL config.
-
-### Using Kiro
-
-To use [Kiro](https://kiro.dev), install `kiro-cli` and authenticate via Kiro's setup. Then:
-
-```yaml
-agents:
-  runtime: kiro
-  model: auto              # or any Kiro-supported model
-```
-
-CORAL spawns each agent as `kiro-cli chat <prompt> --no-interactive -a` (the `-a` flag trusts all tools). Instructions are read from `KIRO.md` at the worktree root. Kiro does not currently expose a session id we can resume from, so restarted agents start fresh — they still see all prior attempts and notes via the shared `.kiro/` directory.
-
-Like Cursor, Kiro uses its own auth and does not route through the LiteLLM gateway.
-
-### Using the Gateway for Custom Models
-
-CORAL includes a built-in **LiteLLM gateway** that acts as a proxy between agents and model providers. This is useful when you want to:
-
-- Route agent requests through a single proxy with unified API key management
-- Use custom or self-hosted models
-- Add request logging and per-agent tracking
-- Use providers that require non-standard authentication
-
-#### Setting up the gateway
-
-**1. Create a LiteLLM config file** (e.g. `litellm_config.yaml`) alongside your `task.yaml`:
-
-```yaml
-# examples/circle_packing/litellm_config.yaml
-model_list:
-  - model_name: "claude-opus-4-6"
-    litellm_params:
-      model: "anthropic/claude-opus-4-6"
-      api_key: "YOUR_ANTHROPIC_API_KEY"
-
-litellm_settings:
-  drop_params: true
-```
-
-Each entry in `model_list` defines a model the gateway will serve. The `model_name` is what agents request; `litellm_params.model` is the upstream provider model. See the [LiteLLM docs](https://docs.litellm.ai/docs/proxy/configs) for full configuration options (multiple providers, load balancing, fallbacks, etc.).
-
-**2. Enable the gateway in your task config:**
-
-```yaml
-agents:
-  runtime: opencode           # or claude_code, codex (cursor and kiro use their own auth, not the gateway)
-  model: claude/claude-opus-4-6
-  gateway:
-    enabled: true
-    port: 4000                # port the gateway listens on
-    config: "./litellm_config.yaml"  # path relative to task.yaml
-```
-
-**3. Point your agent at the gateway.** For OpenCode, set `baseURL` in `opencode.json` to `http://localhost:<port>/v1`. For Claude Code, the gateway URL is automatically injected.
-
-When you run `coral start`, the gateway starts before agents are spawned, and all agent API requests are routed through it. The gateway automatically assigns each agent a unique proxy key for per-agent request tracking.
-
-See `examples/circle_packing/` for a complete working example using OpenCode with the gateway.
+To route agent traffic through a unified proxy (custom models, request logging, per-agent keys), enable the built-in [LiteLLM Gateway](https://human-agent-society.github.io/CORAL/guides/gateway).
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 <div align="center">
 
-<img src="assets/logo.png" alt="Coral" width="360">
+<img src="assets/logo.png" alt="CORAL logo — multi-agent autonomous coding infrastructure" width="360">
 
-#### Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
+## Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://human-agent-society.github.io/CORAL/)
@@ -25,7 +25,7 @@
 - **[2026-04-24]** Rubric judges — two reusable LLM-judge grader packages for open-ended tasks (reports, memos, legal analysis). See the [Rubric Judges guide](https://human-agent-society.github.io/CORAL/guides/rubric-judge).
 - [Older news →](https://human-agent-society.github.io/CORAL/blog)
 
-![Demo](assets/demo.gif)
+![CORAL demo — autonomous AI coding agents running in parallel git worktrees, sharing knowledge through a common state directory](assets/demo.gif)
 
 ### Installation
 
@@ -55,7 +55,7 @@ Each agent must be installed and authenticated separately. Per-runtime config �
 ### How It Works
 
 <p align="center">
-  <img src="assets/coral_diagram_trans.jpg" alt="CORAL Architecture Diagram" width="800">
+  <img src="assets/coral_diagram_trans.jpg" alt="CORAL architecture diagram: multiple coding agents run in isolated git worktrees, share state via .coral/public/, and are scored by a grader daemon" width="800">
 </p>
 
 Each agent runs in its own git worktree. Shared state (attempts, notes, skills) lives in `.coral/public/` and is symlinked into every worktree — agents see each other's work in real time. A grader daemon scores every commit. The manager interrupts agents with heartbeat prompts (`reflect`, `consolidate`, `pivot`).

--- a/README_CN.md
+++ b/README_CN.md
@@ -13,126 +13,52 @@
   <img src="assets/stanford.png" alt="Stanford" height="50">
 </p>
 
+[![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://human-agent-society.github.io/CORAL/)
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-3776AB.svg?logo=python&logoColor=white)](https://python.org)
-[![uv](https://img.shields.io/badge/uv-package%20manager-5C4EE5.svg)](https://docs.astral.sh/uv/)
 
 [English](README.md) | **中文**
 
 </div>
 
-
 <p align="center">
-<a href="#安装">安装</a> · <a href="#支持的-agent">支持的 Agent</a> · <a href="#使用">使用</a> · <a href="#工作原理">工作原理</a> · <a href="#示例">示例</a> · <a href="https://human-agent-society.github.io/CORAL/">文档</a> · <a href="#许可证">许可证</a>
+<a href="#安装">安装</a> · <a href="#支持的-agent">支持的 Agent</a> · <a href="#工作原理">工作原理</a> · <a href="#示例">示例</a> · <a href="https://human-agent-society.github.io/CORAL/">文档</a> · <a href="https://arxiv.org/abs/2604.01658v1">论文</a>
 </p>
 
-**CORAL** 是一套用于构建**自主 AI Agent 组织**的基础设施，Agent 们持续运行实验、共享知识、不断进化出更优方案。只需提供代码库和评分脚本，Coral 即可完成剩余工作：隔离工作空间、安全评估、持久化共享知识，以及多 Agent 协作驱动持续进化。原生集成 Claude Code、Codex、Cursor Agent、Kiro、OpenCode 等主流编程 Agent。
+**CORAL** 是用于构建**自主 AI Agent 组织**的基础设施 —— Agent 持续运行实验、共享知识、不断进化。只需提供代码库和评分脚本，CORAL 负责其余的一切：隔离工作空间、安全评估、持久共享状态、多 Agent 协作。原生集成 Claude Code、OpenCode、Codex、Cursor Agent、Kiro。
 
-想要自我进化的 AI，又不想折腾配置？试试 Coral。
+### 🔥 News
 
-
-
-### 🔥 News!
-
-- **[2026-04-24]** 新增 **Rubric 评审 (Rubric Judges)** —— 两个开箱即用的 LLM 评审 grader 包，专为开放式任务（报告、备忘、法律分析等）设计：静态评审准则 (`race_japan_grader`) 与可自演进的动态准则 (`apex_judge`)，均由 Claude Code 作为评审代理执行。详见 [Rubric Judges 文档](docs/content/docs/guides/rubric-judge.mdx) 以及新增的 `examples/race-japan-elderly/`、`examples/apex-eggshell-skull/`、`examples/apex-frontier-bu/` 任务。
-- **[2026-03-18]** CORAL 正式发布！点击查看[Blog](https://human-agent-society.github.io/CORAL/)。
+- **[2026-04-24]** 新增 Rubric 评审 —— 两个开箱即用的 LLM 评审 grader 包，专为开放式任务（报告、备忘、法律分析）设计。详见 [Rubric Judges 文档](https://human-agent-society.github.io/CORAL/guides/rubric-judge)。
+- [更多历史动态 →](https://human-agent-society.github.io/CORAL/blog)
 
 ![Demo](assets/demo.gif)
 
 ### 安装
 
-**一行命令 —— 全局安装 `coral`，在任意目录下都可直接调用：**
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
 ```
 
-该脚本会先检查并按需安装 [`uv`](https://github.com/astral-sh/uv)，然后通过 `uv tool install` 将 `coral` 可执行文件放入 `~/.local/bin`。如需指定版本,设置 `CORAL_VERSION=v0.5.0`(支持任意 git tag/分支/commit)。
-
-<details>
-<summary>手动安装（不使用 curl 管道）</summary>
+通过 `uv tool install` 全局安装 `coral`。如需指定版本，设置 `CORAL_VERSION=v0.5.0`。手动安装、开发模式、前置依赖等详见[安装文档](https://human-agent-society.github.io/CORAL/getting-started/installation)。
 
 ```bash
-# 已安装 uv,只需一条命令:
-uv tool install git+https://github.com/Human-Agent-Society/CORAL.git
-
-# 若未安装 uv,先安装 uv:
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-</details>
-
-<details>
-<summary>参与 CORAL 开发（clone + 可编辑安装）</summary>
-
-```bash
-git clone https://github.com/Human-Agent-Society/CORAL.git
-cd CORAL
-uv sync                       # （添加 --extra ui 包含看板依赖；--extra dev 包含测试工具）
-uv run coral --help           # 开发模式下需要加 `uv run` 前缀
-```
-
-</details>
-
-验证安装：
-
-```bash
-coral --version
+coral init my-task              # 生成任务模板
+coral start -c my-task/task.yaml  # 启动 Agent
 ```
 
 ### 支持的 Agent
 
-CORAL 支持任何可以作为子进程运行并通过终端交互的编程 Agent。目前支持：
+| Agent | `agents.runtime` |
+|-------|------------------|
+| [Claude Code](https://github.com/anthropics/claude-code) —— 默认 | `claude_code` |
+| [Codex](https://github.com/openai/codex) | `codex` |
+| [Cursor Agent](https://cursor.com/docs/cli/overview) | `cursor` |
+| [Kiro](https://kiro.dev) | `kiro` |
+| [OpenCode](https://github.com/opencode-ai/opencode) | `opencode` |
 
-| Agent | 说明 |
-|-------|------|
-| [**Claude Code**](https://github.com/anthropics/claude-code) | Anthropic 的 Agentic 编程工具——默认且测试最充分的运行时 |
-| [**Codex**](https://github.com/openai/codex) | OpenAI 的开源编程 Agent |
-| [**Cursor Agent**](https://cursor.com/docs/cli/overview) | Cursor 的无头 `cursor-agent` CLI |
-| [**Kiro**](https://kiro.dev) | Kiro 的 `kiro-cli` Agent（AWS 托管） |
-| [**OpenCode**](https://github.com/opencode-ai/opencode) | 开源终端 AI 编程 Agent |
-
-> [!TIP]
-> 在使用 CORAL 之前，请确保已完整配置好你计划使用的 Agent：
->
-> - **安装 Agent：** 按照对应 Agent 的官方安装说明进行安装（如 Claude Code、Codex、OpenCode），可能涉及安装包、配置可执行文件或脚本。
-> - **身份验证：** 提前登录并完成 Agent 的身份验证，确保其在 CLI 模式下不会弹出凭据请求。按照 Agent 文档配置所需的环境变量、配置文件或认证密钥。
-> - **权限设置：** 通过 Agent 的配置文件（如 Claude Code 的 `~/.claude/settings.json`）配置权限，控制 Agent 可以使用的工具、访问的路径或执行的操作。
->
-> *CORAL 不负责 Agent 的安装或身份验证。如果底层 Agent 无法启动或未正确完成认证，基础设施将无法正常运行。*
-
-在任务配置中指定 Agent（参见 <a href="#3-配置任务">配置任务</a>）：
-
-```yaml
-agents:
-  runtime: claude_code   # 或 "codex"、"cursor"、"kiro"、"opencode"
-  count: 3
-  model: opus  
-
-```
-
-### 使用
-
-```bash
-# 启动
-coral start -c examples/kernel_builder/task.yaml
-
-# 通过 dotlist 语法覆盖任意配置
-coral start -c task.yaml agents.count=4 agents.model=opus
-coral start -c task.yaml run.verbose=true        # 流式输出 Agent 日志
-coral start -c task.yaml run.ui=true             # 同时启动 Web 看板
-
-# 停止和恢复
-coral stop                                       # 暂停
-coral resume                                     # 继续
-
-# 监控进度
-coral status                                     # CLI 排行榜
-coral ui                                         # Web 看板
-```
-
-完整 CLI 参考见 [`coral --help`](https://human-agent-society.github.io/CORAL/cli/reference) 或运行 `coral --help`。配置项（warm-start、Gateway、Docker 会话等）详见[配置文档](https://human-agent-society.github.io/CORAL/getting-started/configuration)。
+每个 Agent 需自行安装并完成认证。各运行时的详细配置（含[ LiteLLM Gateway](https://human-agent-society.github.io/CORAL/guides/gateway) 自定义模型代理）见 [Agent 运行时文档](https://human-agent-society.github.io/CORAL/guides/agent-runtimes)。
 
 ### 工作原理
 
@@ -140,38 +66,9 @@ coral ui                                         # Web 看板
   <img src="assets/coral_diagram_trans.jpg" alt="CORAL Architecture Diagram" width="800">
 </p>
 
-每个 Agent 跑在自己的 git worktree 分支里。共享状态（历史记录、笔记、技能）放在 `.coral/public/`，软链到所有 worktree —— 零开销，实时互通。后台管理器盯着新提交，可以通过心跳机制打断 Agent 并注入指令（比如"回顾一下"、"整理技能"）。
+每个 Agent 跑在自己的 git worktree 里。共享状态（历史记录、笔记、技能）放在 `.coral/public/`，软链到所有 worktree —— Agent 实时看到彼此的工作。Grader 守护进程为每次提交打分。后台管理器通过心跳机制打断 Agent 并注入指令（`reflect`、`consolidate`、`pivot`）。
 
-| 概念 | 说明 |
-|------|------|
-| **Agent = 优化器** | Claude Code / Codex / OpenCode 子进程，各占一个 git worktree |
-| **共享状态** | `.coral/` 存放历史记录、笔记和技能，软链到每个 worktree |
-| **Eval 循环** | Agent 调 `coral eval -m "..."` 一步完成暂存 + 提交 + 打分 |
-| **CLI 调度** | 17+ 条命令：`start`、`stop`、`status`、`eval`、`log`、`ui` 等 |
-| **Web 看板** | `coral ui` —— 实时排行榜、diff 对比、Agent 监控 |
-
-### 快速上手
-
-三条命令即可启动：
-
-```bash
-coral init my-task                            # 生成 task.yaml + grader 模板 + seed/
-# 编辑 my-task/task.yaml 和 my-task/eval/grader.py 描述你的问题
-coral validate my-task                        # 用 seed/ 试跑一次评分器
-coral start -c my-task/task.yaml              # 启动 Agent（自动开 tmux）
-```
-
-需要完整流程演示（含 seed 代码、grader、task.yaml、启动）以及 TSP 实战示例？参见[快速上手文档](https://human-agent-society.github.io/CORAL/getting-started/quickstart)。
-
-### Agent 运行时与 Gateway
-
-默认 Claude Code 无需额外配置（只需 Anthropic API key）。使用其他运行时请参考对应文档：
-
-- [OpenCode](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#opencode) —— 需要在 seed 目录提供 `opencode.json`
-- [Cursor Agent](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#cursor-agent) —— 执行 `cursor-agent login` 后设置 `runtime: cursor`
-- [Kiro](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#kiro) —— 安装并配置 `kiro-cli` 后设置 `runtime: kiro`
-
-如需通过统一代理转发 Agent 流量（自定义模型、请求日志、按 Agent 隔离密钥），启用内置的 [LiteLLM Gateway](https://human-agent-society.github.io/CORAL/guides/gateway)。
+深入阅读：[核心概念](https://human-agent-society.github.io/CORAL/concepts) · [多 Agent 运行](https://human-agent-society.github.io/CORAL/guides/multi-agent) · [评估循环](https://human-agent-society.github.io/CORAL/concepts/eval-loop)
 
 ### 示例
 
@@ -187,22 +84,11 @@ coral start -c my-task/task.yaml              # 启动 Agent（自动开 tmux）
 | **spaceship_titanic** | 机器学习 | Kaggle 竞赛 |
 | **stanford_covid_vaccine** | 生物/ML | mRNA 降解预测 |
 
+完整任务清单与详解见[示例文档](https://human-agent-society.github.io/CORAL/examples)。
 
-### 开发
+### 开发 & 许可证
 
-```bash
-# 装开发依赖
-uv sync --extra dev
-
-# 跑测试
-uv run pytest tests/ -v
-
-# lint + 格式化
-uv run ruff check .
-uv run ruff format .
-```
-
-本项目在 Apache 2.0 [LICENSE](LICENSE) 许可下开源。
+Clone 仓库后运行 `uv sync --extra dev` 安装测试/lint 依赖。代码结构见 [CLAUDE.md](CLAUDE.md)。基于 [Apache 2.0](LICENSE) 开源。
 
 ### 引用
 
@@ -219,4 +105,4 @@ uv run ruff format .
 
 ### 致谢
 
-我们感谢 [TNT Accelerator](https://www.tnt.so/) 提供的慷慨支持，包括在开发过程中给予帮助的各种 API 积分。也要感谢许多如 [OpenEvolve](https://github.com/algorithmicsuperintelligence/openevolve)、[autoresearch](https://github.com/karpathy/autoresearch)、[TTT Discover](https://arxiv.org/abs/2601.16175) 等的十分有启发性的工作，这些工作为 Coral 的诞生奠定了基础。
+感谢 [TNT Accelerator](https://www.tnt.so/) 提供的 API 积分支持，以及为 CORAL 提供启发的前辈工作：[OpenEvolve](https://github.com/algorithmicsuperintelligence/openevolve)、[autoresearch](https://github.com/karpathy/autoresearch)、[TTT Discover](https://arxiv.org/abs/2601.16175)。

--- a/README_CN.md
+++ b/README_CN.md
@@ -24,7 +24,7 @@
 
 
 <p align="center">
-<a href="#安装">安装</a> · <a href="#支持的-agent">支持的 Agent</a> · <a href="#使用">使用</a> · <a href="#工作原理">工作原理</a> · <a href="#快速上手">快速上手</a> · <a href="#cli-命令">CLI 命令</a> · <a href="#示例">示例</a> · <a href="#许可证">许可证</a>
+<a href="#安装">安装</a> · <a href="#支持的-agent">支持的 Agent</a> · <a href="#使用">使用</a> · <a href="#工作原理">工作原理</a> · <a href="#示例">示例</a> · <a href="https://human-agent-society.github.io/CORAL/">文档</a> · <a href="#许可证">许可证</a>
 </p>
 
 **CORAL** 是一套用于构建**自主 AI Agent 组织**的基础设施，Agent 们持续运行实验、共享知识、不断进化出更优方案。只需提供代码库和评分脚本，Coral 即可完成剩余工作：隔离工作空间、安全评估、持久化共享知识，以及多 Agent 协作驱动持续进化。原生集成 Claude Code、Codex、Cursor Agent、Kiro、OpenCode 等主流编程 Agent。
@@ -116,15 +116,23 @@ agents:
 
 ```bash
 # 启动
-uv run coral start --config examples/kernel_builder/task.yaml
+coral start -c examples/kernel_builder/task.yaml
+
+# 通过 dotlist 语法覆盖任意配置
+coral start -c task.yaml agents.count=4 agents.model=opus
+coral start -c task.yaml run.verbose=true        # 流式输出 Agent 日志
+coral start -c task.yaml run.ui=true             # 同时启动 Web 看板
 
 # 停止和恢复
-uv run coral stop                                      # 暂停
-uv run coral resume                                    # 继续
+coral stop                                       # 暂停
+coral resume                                     # 继续
 
 # 监控进度
-uv run coral ui                                        # 打开 Web 看板
+coral status                                     # CLI 排行榜
+coral ui                                         # Web 看板
 ```
+
+完整 CLI 参考见 [`coral --help`](https://human-agent-society.github.io/CORAL/cli/reference) 或运行 `coral --help`。配置项（warm-start、Gateway、Docker 会话等）详见[配置文档](https://human-agent-society.github.io/CORAL/getting-started/configuration)。
 
 ### 工作原理
 
@@ -138,170 +146,32 @@ uv run coral ui                                        # 打开 Web 看板
 |------|------|
 | **Agent = 优化器** | Claude Code / Codex / OpenCode 子进程，各占一个 git worktree |
 | **共享状态** | `.coral/` 存放历史记录、笔记和技能，软链到每个 worktree |
-| **Eval 循环** | Agent 调 `uv run coral eval -m "..."` 一步完成暂存 + 提交 + 打分 |
+| **Eval 循环** | Agent 调 `coral eval -m "..."` 一步完成暂存 + 提交 + 打分 |
 | **CLI 调度** | 17+ 条命令：`start`、`stop`、`status`、`eval`、`log`、`ui` 等 |
-| **Web 看板** | `uv run coral ui` —— 实时排行榜、diff 对比、Agent 监控 |
+| **Web 看板** | `coral ui` —— 实时排行榜、diff 对比、Agent 监控 |
 
 ### 快速上手
 
-以一个完整的例子来演示：多个 Agent 持续优化 **100 城市旅行商问题（TSP）**。
-
-#### 1. 写初始代码
-
-初始代码（seed）是 Agent 迭代优化的起点。创建工作目录：
+三条命令即可启动：
 
 ```bash
-mkdir -p examples/tsp/{seed,eval}
+coral init my-task                            # 生成 task.yaml + grader 模板 + seed/
+# 编辑 my-task/task.yaml 和 my-task/eval/grader.py 描述你的问题
+coral validate my-task                        # 用 seed/ 试跑一次评分器
+coral start -c my-task/task.yaml              # 启动 Agent（自动开 tmux）
 ```
 
-然后创建一个最简初始方案（你也可以选择从空开始，虽然这可能会让 Agent 的工作更具挑战性）：
+需要完整流程演示（含 seed 代码、grader、task.yaml、启动）以及 TSP 实战示例？参见[快速上手文档](https://human-agent-society.github.io/CORAL/getting-started/quickstart)。
 
-```python
-# examples/tsp/seed/solution.py
-import random
+### Agent 运行时与 Gateway
 
-# 在此重述问题，因为 Agent 无法读取 `grader.py` 的内容
-random.seed(42)
-CITIES = [(random.random(), random.random()) for _ in range(100)]
+默认 Claude Code 无需额外配置（只需 Anthropic API key）。使用其他运行时请参考对应文档：
 
-# 最简方案：按编号顺序访问 (0, 1, 2, ..., 99)
-for i in range(len(CITIES)):
-    print(i)
-```
+- [OpenCode](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#opencode) —— 需要在 seed 目录提供 `opencode.json`
+- [Cursor Agent](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#cursor-agent) —— 执行 `cursor-agent login` 后设置 `runtime: cursor`
+- [Kiro](https://human-agent-society.github.io/CORAL/guides/agent-runtimes#kiro) —— 安装并配置 `kiro-cli` 后设置 `runtime: kiro`
 
-#### 2. 写评分器
-
-继承 `TaskGrader`，实现 `evaluate()` 方法。基类提供两个辅助方法：`self.run_program(filename)` 在子进程中运行 Agent 代码库里的文件，返回 `CompletedProcess`（含 `.stdout`、`.stderr`、`.returncode`）；`self.fail(reason)` 记录失败并返回 `-inf` 作为得分：
-
-```python
-# examples/tsp/eval/grader.py
-import math
-import random
-from coral.grader import TaskGrader, ScoreBundle
-
-# 保持与 `solution.py` 中的问题描述一致
-random.seed(42)
-CITIES = [(random.random(), random.random()) for _ in range(100)]
-
-class Grader(TaskGrader):
-    def evaluate(self) -> float | ScoreBundle:
-        try:
-            result = self.run_program("solution.py")  # 运行 solution.py，返回 CompletedProcess
-            order = [int(x) for x in result.stdout.strip().split("\n")]
-            assert sorted(order) == list(range(len(CITIES)))
-            dist = sum(
-                math.dist(CITIES[order[i]], CITIES[order[(i + 1) % len(order)]])
-                for i in range(len(order))
-            )
-            return -dist  # 路线越短，得分越高
-        except Exception as e:
-            return self.fail(str(e))  # 记录失败并返回 -inf
-```
-
-初始方案按编号顺序访问，得分约 `-58.02`。Agent 会尝试最近邻、2-opt、模拟退火等策略寻找更短路线。100 个城市的穷举搜索完全不可行（99! 种排列），因此 Agent 必须发现并运用真正的优化启发式算法。
-
-#### 3. 配置任务
-
-把配置指向初始代码和评分器：
-
-```yaml
-# examples/tsp/task.yaml
-task:
-  name: tsp
-  description: |
-    求 100 个城市的最短往返路线。坐标由 `solution.py` 中固定种子随机生成，
-    请勿修改种子或 CITIES 的生成方式！
-
-    solution.py 向 stdout 输出 100 个整数（0–99），每行一个，
-    表示访问顺序，每个城市恰好出现一次。
-    评分器计算往返欧氏距离，返回 -distance 作为得分（越短越高）。
-
-grader:
-  # 快速开始走自动发现的 eval/grader.py（会触发 DeprecationWarning）。
-  # 生产任务建议把 grader 打包,改用 entrypoint:
-  #   entrypoint: "tsp_grader.grader:Grader"
-  #   setup: ["uv pip install -e ./grader"]
-  # 迁移指南见 docs/guides/custom-grader。
-  timeout: 300
-
-agents:
-  count: 1
-  runtime: claude_code  # 或 codex、cursor、kiro、opencode
-  model: claude-sonnet-4-6
-  max_turns: 200  # Agent 重启前的最大轮数，别担心 Coral 会一直运行直到你停止
-
-workspace:
-  results_dir: "./results"  # 相对于你的 $PWD
-  repo_path: "./examples/tsp/seed"  # 相对于你的 $PWD
-```
-
-#### 4. 跑起来
-
-```bash
-uv run coral start --config examples/tsp/task.yaml  # 随后你会在 tmux 会话 `coral-tsp` 中看到 Coral
-uv sync --extra ui && uv run coral ui          # 打开 Web 看板，默认运行在 8420 端口
-uv run coral status      # 看排行榜
-uv run coral log         # 翻记录
-uv run coral stop        # 收工
-```
-
-### CLI 命令
-
-
-| 命令 | 说明 |
-|------|------|
-| `uv run coral init <name>` | 新建任务脚手架 |
-| `uv run coral validate <name>` | 测试评分器 |
-| `uv run coral start -c task.yaml` | 启动 Agent |
-| `uv run coral resume` | 恢复上次运行 |
-| `uv run coral stop` | 停止全部 Agent |
-| `uv run coral status` | Agent 状态 + 排行榜 |
-| `uv run coral log` | 排行榜（前 20） |
-| `uv run coral log -n 5 --recent` | 最近的记录 |
-| `uv run coral log --search "关键词"` | 搜索记录 |
-| `uv run coral show <hash>` | 记录详情 + diff |
-| `uv run coral notes` | 浏览笔记 |
-| `uv run coral skills` | 浏览技能 |
-| `uv run coral runs` | 列出所有运行 |
-| `uv run coral ui` | Web 看板 |
-| `uv run coral eval -m "描述"` | 暂存 + 提交 + 评估（Agent 调用）|
-| `uv run coral diff` | 看未提交的改动 |
-| `uv run coral revert` | 撤销上次提交 |
-| `uv run coral checkout <hash>` | 回退到指定记录 |
-| `uv run coral heartbeat` | 查看/修改心跳动作 |
-
-
-### 项目结构
-
-
-```
-coral/
-├── types.py             # Task, Score, ScoreBundle, Attempt
-├── config.py            # YAML 配置加载
-├── agent/
-│   ├── manager.py       # 多 Agent 生命周期
-│   └── runtime.py       # Claude Code / Codex / Cursor Agent / Kiro / OpenCode 子进程
-├── workspace/
-│   └── setup.py         # Worktree 创建、hook、软链
-├── grader/
-│   ├── protocol.py      # GraderInterface 协议
-│   ├── base.py          # BaseGrader（_make_score, _make_bundle）
-│   ├── task_grader.py   # TaskGrader 任务评分基类
-│   ├── loader.py        # 评分器发现与加载
-│   └── builtin/
-│       └── function_grader.py
-├── hub/
-│   ├── attempts.py      # 记录增删改查 + 排行榜 + 搜索
-│   ├── notes.py         # Markdown 笔记（YAML frontmatter）
-│   └── skills.py        # 技能包（含 SKILL.md）
-├── hooks/
-│   └── post_commit.py   # 提交后自动评估
-├── template/
-│   └── coral_md.py      # CORAL.md 生成器
-├── web/                 # Starlette + React 看板
-└── cli/                 # 5 个模块，17 条命令
-```
-
+如需通过统一代理转发 Agent 流量（自定义模型、请求日志、按 Agent 隔离密钥），启用内置的 [LiteLLM Gateway](https://human-agent-society.github.io/CORAL/guides/gateway)。
 
 ### 示例
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -44,8 +44,8 @@ curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/inst
 通过 `uv tool install` 全局安装 `coral`。如需指定版本，设置 `CORAL_VERSION=v0.5.0`。手动安装、开发模式、前置依赖等详见[安装文档](https://human-agent-society.github.io/CORAL/getting-started/installation)。
 
 ```bash
-coral init my-task              # 生成任务模板
-coral start -c my-task/task.yaml  # 启动 Agent
+coral init my-task                       # 生成任务模板
+cd my-task && coral start -c task.yaml   # 启动 Agent
 ```
 
 ### 支持的 Agent

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,9 +1,9 @@
 
 <div align="center">
 
-<img src="assets/logo.png" alt="CORAL" width="360">
+<img src="assets/logo.png" alt="CORAL logo —— 多 Agent 自主编程基础设施" width="360">
 
-### **一键启动智能体群组，共享知识，无限进化**
+## **一键启动智能体群组，共享知识，无限进化**
 
 <p>
   <img src="assets/mit_logo.png" alt="MIT" height="50">
@@ -33,7 +33,7 @@
 - **[2026-04-24]** 新增 Rubric 评审 —— 两个开箱即用的 LLM 评审 grader 包，专为开放式任务（报告、备忘、法律分析）设计。详见 [Rubric Judges 文档](https://human-agent-society.github.io/CORAL/guides/rubric-judge)。
 - [更多历史动态 →](https://human-agent-society.github.io/CORAL/blog)
 
-![Demo](assets/demo.gif)
+![CORAL 多 Agent 自主编程演示 —— 多个编程 Agent 在独立 git worktree 中并行运行,通过共享状态目录交换知识](assets/demo.gif)
 
 ### 安装
 
@@ -63,7 +63,7 @@ coral start -c my-task/task.yaml  # 启动 Agent
 ### 工作原理
 
 <p align="center">
-  <img src="assets/coral_diagram_trans.jpg" alt="CORAL Architecture Diagram" width="800">
+  <img src="assets/coral_diagram_trans.jpg" alt="CORAL 架构图:多个编程 Agent 运行在隔离的 git worktree 中,通过 .coral/public/ 共享状态,由 grader 守护进程评分" width="800">
 </p>
 
 每个 Agent 跑在自己的 git worktree 里。共享状态（历史记录、笔记、技能）放在 `.coral/public/`，软链到所有 worktree —— Agent 实时看到彼此的工作。Grader 守护进程为每次提交打分。后台管理器通过心跳机制打断 Agent 并注入指令（`reflect`、`consolidate`、`pivot`）。

--- a/docs/content/docs/guides/agent-runtimes.mdx
+++ b/docs/content/docs/guides/agent-runtimes.mdx
@@ -1,0 +1,116 @@
+---
+title: Agent Runtimes
+description: Configure OpenCode, Cursor Agent, and Kiro as CORAL agent runtimes.
+---
+
+
+CORAL works with any coding agent that can run as a subprocess. Pick the runtime in `task.yaml` via `agents.runtime`. Claude Code is the default and needs no special config beyond an Anthropic API key. The other runtimes are documented below.
+
+| Runtime         | `agents.runtime`               | Auth path                 |
+|-----------------|--------------------------------|---------------------------|
+| Claude Code     | `claude_code` (default)        | Anthropic API key         |
+| Codex           | `codex`                        | OpenAI auth               |
+| OpenCode        | `opencode`                     | `opencode.json` in seed   |
+| Cursor Agent    | `cursor` (alias: `cursor_agent`) | `cursor-agent login` once |
+| Kiro            | `kiro`                         | `kiro-cli` setup          |
+
+## OpenCode
+
+[OpenCode](https://github.com/opencode-ai/opencode) reads permissions and provider config from an `opencode.json` file. Place it in your task's `seed/` directory so it gets copied into each agent's worktree.
+
+Example (from `examples/circle_packing/seed/opencode.json`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": "allow",
+    "question": "deny",
+    "doom_loop": "allow",
+    "bash": "allow",
+    "edit": "allow",
+    "read": "allow",
+    "write": "allow",
+    "webfetch": "deny",
+    "websearch": "deny",
+    "codesearch": "allow",
+    "lsp": "allow",
+    "skill": "allow"
+  },
+  "provider": {
+    "claude": {
+      "npm": "@ai-sdk/anthropic",
+      "name": "claude",
+      "options": {
+        "baseURL": "http://localhost:4000/v1",
+        "apiKey": "xxx"
+      },
+      "models": {
+        "claude-opus-4-6": {
+          "name": "claude-opus-4-6"
+        }
+      }
+    }
+  }
+}
+```
+
+Key points:
+
+- Set all permissions to `"allow"` except `question`, `webfetch`, `websearch` (set those to `"deny"`) so the agent runs autonomously without interactive prompts.
+- The `provider` section configures which model to use. When using the [gateway](/guides/gateway), point `baseURL` at `http://localhost:<gateway_port>/v1` and set `apiKey` to any placeholder value — the gateway handles authentication.
+- Place `opencode.json` in your seed directory so it gets copied into each agent's worktree.
+
+Task config:
+
+```yaml
+agents:
+  runtime: opencode
+  model: claude/claude-opus-4-6  # must match a model defined in opencode.json
+```
+
+## Cursor Agent
+
+Install [Cursor Agent](https://cursor.com/docs/cli/overview) and authenticate once:
+
+```bash
+curl -fsSL https://cursor.com/install | bash
+cursor-agent login
+```
+
+Point your task at it:
+
+```yaml
+agents:
+  runtime: cursor          # alias for cursor_agent; "cursor-agent" also works
+  model: auto              # or any model id supported by your Cursor plan
+```
+
+CORAL spawns each agent as `cursor-agent --print --output-format stream-json --force --workspace <wt> [--model] [--mode] [--resume] <prompt>`. The `--force` flag is always passed (cursor-agent requires it for write tools in `--print` mode). The full task brief is written to `AGENTS.md` at the worktree root, and CORAL also drops a `.cursor/rules/coral.mdc` always-apply rule with short guardrails (use `coral eval`, don't touch `.coral/private/`, share via `.cursor/notes/` and `.cursor/skills/`) so they survive context pressure.
+
+Optional `runtime_options`:
+
+```yaml
+agents:
+  runtime: cursor
+  runtime_options:
+    command: /usr/local/bin/cursor-agent  # override binary path
+    mode: plan                            # --mode plan|ask
+    stream_partial_output: true           # --stream-partial-output
+```
+
+> **Note:** Cursor Agent uses its own auth and does **not** route through the LiteLLM gateway. Login state lives in your Cursor account, not in CORAL config.
+
+## Kiro
+
+Install [Kiro](https://kiro.dev) (`kiro-cli`) and authenticate via Kiro's setup. Then:
+
+```yaml
+agents:
+  runtime: kiro
+  model: auto              # or any Kiro-supported model
+```
+
+CORAL spawns each agent as `kiro-cli chat <prompt> --no-interactive -a` (the `-a` flag trusts all tools). Instructions are read from `KIRO.md` at the worktree root. Kiro does not currently expose a session id we can resume from, so restarted agents start fresh — they still see all prior attempts and notes via the shared `.kiro/` directory.
+
+Like Cursor, Kiro uses its own auth and does not route through the LiteLLM gateway.

--- a/docs/content/docs/guides/gateway.mdx
+++ b/docs/content/docs/guides/gateway.mdx
@@ -1,0 +1,48 @@
+---
+title: LiteLLM Gateway
+description: Route agent traffic through a unified proxy for custom or self-hosted models.
+---
+
+
+CORAL includes a built-in **LiteLLM gateway** that acts as a proxy between agents and model providers. This is useful when you want to:
+
+- Route agent requests through a single proxy with unified API key management
+- Use custom or self-hosted models
+- Add request logging and per-agent tracking
+- Use providers that require non-standard authentication
+
+## Setup
+
+**1. Create a LiteLLM config file** (e.g. `litellm_config.yaml`) alongside your `task.yaml`:
+
+```yaml
+# examples/circle_packing/litellm_config.yaml
+model_list:
+  - model_name: "claude-opus-4-6"
+    litellm_params:
+      model: "anthropic/claude-opus-4-6"
+      api_key: "YOUR_ANTHROPIC_API_KEY"
+
+litellm_settings:
+  drop_params: true
+```
+
+Each entry in `model_list` defines a model the gateway will serve. The `model_name` is what agents request; `litellm_params.model` is the upstream provider model. See the [LiteLLM docs](https://docs.litellm.ai/docs/proxy/configs) for full configuration options (multiple providers, load balancing, fallbacks, etc.).
+
+**2. Enable the gateway in your task config:**
+
+```yaml
+agents:
+  runtime: opencode           # or claude_code, codex (cursor and kiro use their own auth, not the gateway)
+  model: claude/claude-opus-4-6
+  gateway:
+    enabled: true
+    port: 4000                # port the gateway listens on
+    config: "./litellm_config.yaml"  # path relative to task.yaml
+```
+
+**3. Point your agent at the gateway.** For OpenCode, set `baseURL` in `opencode.json` to `http://localhost:<port>/v1` (see [Agent Runtimes → OpenCode](/guides/agent-runtimes#opencode)). For Claude Code, the gateway URL is automatically injected.
+
+When you run `coral start`, the gateway starts before agents are spawned, and all agent API requests are routed through it. The gateway automatically assigns each agent a unique proxy key for per-agent request tracking.
+
+See `examples/circle_packing/` for a complete working example using OpenCode with the gateway.

--- a/docs/content/docs/guides/index.mdx
+++ b/docs/content/docs/guides/index.mdx
@@ -9,5 +9,7 @@ Step-by-step guides for common tasks.
 1. [Writing a Custom Grader](/guides/custom-grader) — Build your own evaluation logic
 2. [Rubric Judges](/guides/rubric-judge) — Score open-ended output with an LLM judge agent
 3. [Multi-Agent Runs](/guides/multi-agent) — Knowledge sharing and collaboration
-4. [Web Dashboard](/guides/web-dashboard) — Real-time monitoring with `coral ui`
-5. [Benchmarks](/guides/benchmarks) — Running CORAL on standard benchmarks
+4. [Agent Runtimes](/guides/agent-runtimes) — Configure OpenCode, Cursor Agent, and Kiro
+5. [LiteLLM Gateway](/guides/gateway) — Route agent traffic through a unified proxy
+6. [Web Dashboard](/guides/web-dashboard) — Real-time monitoring with `coral ui`
+7. [Benchmarks](/guides/benchmarks) — Running CORAL on standard benchmarks


### PR DESCRIPTION
> Stacked on top of #100. Base is `doc_better_installation` so the install-section diff isn't duplicated. Once #100 lands on `main`, retarget this PR to `main`.

## Summary

- **README.md**: 535 → 239 lines (−56%); **README_CN.md**: 356 → 226 lines (−37%). The trimmed READMEs are now a landing page: logo + badges + news, install, demo gif, "How It Works" diagram + concepts table, 3-command Quick Start, examples table, and link blocks out to the docs site.
- **Demo gif at `README.md:40` is preserved** (per request).

## What moved out of README (content relocated, not deleted)

| Section cut from README                              | Now lives at                                          |
|------------------------------------------------------|-------------------------------------------------------|
| Quick Start TSP walkthrough (~100 lines)             | `docs/.../getting-started/quickstart.mdx` (existing)  |
| CLI Reference table (~28 lines)                      | `docs/.../cli/reference.mdx` (existing)               |
| Architecture directory tree (~34 lines)              | `docs/.../concepts/architecture.mdx` + CLAUDE.md      |
| Using OpenCode / Cursor / Kiro (~99 lines)           | **NEW** `docs/.../guides/agent-runtimes.mdx`          |
| Using the LiteLLM Gateway (~44 lines)                | **NEW** `docs/.../guides/gateway.mdx`                 |

The two new guide pages are added in this PR so nothing is orphaned. The guides index (`docs/.../guides/index.mdx`) is updated to list them.

## Side effects

- Drops the `uv run` prefix from remaining CLI examples in both READMEs — matches the new one-line install path from #100, where plain `coral …` works globally after `uv tool install`.
- Top nav rewritten to drop deleted anchors (Quick Start, CLI Reference, OpenCode/Cursor/Kiro, Gateway) and add a top-level Docs link.

## Test plan

- [x] `wc -l` confirms the size reduction; section outline (`grep '^###'`) shows the trimmed structure.
- [x] Demo gif preserved at `README.md:40`.
- [ ] Render the trimmed README on github.com and verify: all surviving anchor links work; the Demo gif renders; new doc links resolve once the docs site is rebuilt with the two new pages.
- [ ] Render the docs site locally and confirm `/guides/agent-runtimes` and `/guides/gateway` render correctly and the index lists them.
- [ ] Sanity-check the trimmed README_CN.md for any leftover dangling links (the CN README never had per-runtime/gateway sections, so only the Quick Start / CLI / Architecture cuts apply there).

## Out of scope (deferred)

- News section still has 3 items going back to 2026-03-18; could trim to 1–2 in a follow-up if desired.
- The `docs/.../concepts/architecture.mdx` page exists but I didn't verify it has a directory-tree equivalent to the one cut from README. If it doesn't, that's a doc-coverage gap to fill in a separate PR (the tree also lives in CLAUDE.md and the codebase itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
