### PR TITLE
feat(init): scaffold packaged grader instead of legacy eval/grader.py

### DIFF
--- a/coral/cli/author.py
+++ b/coral/cli/author.py
@@ -3,12 +3,41 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
 
+def _module_identifier(name: str) -> str:
+    """Sanitize a task directory name into a valid Python module identifier.
+
+    'my-task'      -> 'my_task_grader'
+    'My.Task!'     -> 'my_task_grader'
+    '123-foo'      -> 'task_123_foo_grader'  (avoid leading digit)
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9_]+", "_", name).lower().strip("_")
+    cleaned = re.sub(r"_+", "_", cleaned)
+    if not cleaned:
+        cleaned = "task"
+    if cleaned[0].isdigit():
+        cleaned = f"task_{cleaned}"
+    return f"{cleaned}_grader"
+
+
+def _distribution_name(name: str) -> str:
+    """Sanitize a task directory name into a PEP 503 distribution name.
+
+    'my-task'  -> 'my-task-grader'
+    'My.Task!' -> 'my-task-grader'
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "-", name).lower().strip("-")
+    if not cleaned:
+        cleaned = "task"
+    return f"{cleaned}-grader"
+
+
 def cmd_init(args: argparse.Namespace) -> None:
-    """Create a new task directory.
+    """Create a new task directory with a packaged grader.
 
     Examples:
       coral init my-task            Scaffold at ./my-task/
@@ -16,6 +45,8 @@ def cmd_init(args: argparse.Namespace) -> None:
     """
     task_path = Path(args.path).resolve()
     task_name = args.name or task_path.name
+    module_name = _module_identifier(task_path.name)
+    dist_name = _distribution_name(task_path.name)
 
     if task_path.exists() and any(task_path.iterdir()):
         print(f"Error: {task_path} already exists and is not empty.", file=sys.stderr)
@@ -23,51 +54,108 @@ def cmd_init(args: argparse.Namespace) -> None:
 
     task_path.mkdir(parents=True, exist_ok=True)
     (task_path / "seed").mkdir()
-    (task_path / "eval").mkdir()
+    grader_pkg_dir = task_path / "grader" / "src" / module_name
+    grader_pkg_dir.mkdir(parents=True)
 
-    task_yaml = task_path / "task.yaml"
-    task_yaml.write_text(
+    (task_path / "task.yaml").write_text(
         f"task:\n"
         f'  name: "{task_name}"\n'
         f"  description: |\n"
-        f"    Describe your task here.\n"
+        f"    Describe your task here. Agents read this verbatim from CORAL.md.\n"
+        f"    Reference the program file by name (solution.py) and describe what\n"
+        f"    it must do — e.g. \"solution.py must print a single float to stdout\".\n"
         f"\n"
         f"grader:\n"
-        f"  # Quick start: this scaffold ships an eval/grader.py (deprecated path).\n"
-        f"  # For a real task, package your grader and switch to:\n"
-        f"  #   entrypoint: \"my_pkg.grader:Grader\"\n"
-        f"  #   setup: [\"uv pip install -e ./grader\"]\n"
-        f"  # See docs/guides/custom-grader for the migration guide.\n"
+        f'  entrypoint: "{module_name}.grader:Grader"\n'
+        f"  setup:\n"
+        f'    - "uv pip install -e ./grader"\n'
         f"  timeout: 300\n"
-        f"  direction: maximize\n"
+        f"  direction: maximize          # or 'minimize'\n"
+        f"  args:\n"
+        f'    program_file: "solution.py"\n'
         f"\n"
         f"agents:\n"
         f"  count: 1\n"
+        f"  runtime: claude_code         # claude_code | codex | cursor | kiro | opencode\n"
+        f"\n"
+        f"workspace:\n"
+        f'  repo_path: "./seed"          # relative to where you run `coral start`\n'
     )
 
-    grader_py = task_path / "eval" / "grader.py"
-    grader_py.write_text(
-        "from coral.grader import TaskGrader\n"
+    (task_path / "seed" / "solution.py").write_text(
+        f'"""Baseline solution for the {task_name} task.\n'
         "\n"
+        "The grader runs this file and parses a single floating-point number\n"
+        "from stdout as the score. Replace with your real implementation.\n"
+        '"""\n'
         "\n"
-        "class Grader(TaskGrader):\n"
-        '    """Evaluate agent submissions."""\n'
-        "\n"
-        "    def evaluate(self) -> float:\n"
-        "        # self.codebase_path — path to agent's worktree\n"
-        "        # self.private_dir   — path to .coral/private/\n"
-        "        # self.args          — dict from config.grader.args\n"
-        "        #\n"
-        "        # Return a float score, or use self.score(value, explanation)\n"
-        "        # or self.fail(reason) for richer feedback.\n"
-        "        return 0.0\n"
+        "print(0.0)\n"
+    )
+
+    (task_path / "grader" / "pyproject.toml").write_text(
+        f"[project]\n"
+        f'name = "{dist_name}"\n'
+        f'version = "0.1.0"\n'
+        f'description = "CORAL grader for the {task_name} task."\n'
+        f'requires-python = ">=3.11"\n'
+        f"dependencies = [\n"
+        f'    "coral",\n'
+        f"]\n"
+        f"\n"
+        f"[build-system]\n"
+        f'requires = ["hatchling"]\n'
+        f'build-backend = "hatchling.build"\n'
+        f"\n"
+        f"[tool.hatch.build.targets.wheel]\n"
+        f'packages = ["src/{module_name}"]\n'
+    )
+
+    (grader_pkg_dir / "__init__.py").write_text(
+        f'"""{task_name} grader (entrypoint: {module_name}.grader:Grader)."""\n'
+        f"\n"
+        f"from .grader import Grader\n"
+        f"\n"
+        f'__all__ = ["Grader"]\n'
+    )
+
+    (grader_pkg_dir / "grader.py").write_text(
+        f'"""{task_name} grader."""\n'
+        f"\n"
+        f"from coral.grader import TaskGrader\n"
+        f"\n"
+        f"\n"
+        f"class Grader(TaskGrader):\n"
+        f'    """Evaluate agent submissions for the {task_name} task."""\n'
+        f"\n"
+        f"    def evaluate(self) -> float:\n"
+        f"        # self.codebase_path  — agent's worktree (read-only; writes are discarded)\n"
+        f"        # self.private_dir    — .coral/private/ (hidden answer keys, fixtures)\n"
+        f"        # self.args           — dict from task.yaml -> grader.args\n"
+        f"        # self.timeout        — eval timeout in seconds\n"
+        f"        #\n"
+        f"        # Return a float, or use self.score(value, explanation=...)\n"
+        f"        # or self.fail(reason) to record a failure with feedback.\n"
+        f'        program_file = self.args.get("program_file", "solution.py")\n'
+        f"        result = self.run_program(program_file)\n"
+        f"\n"
+        f"        if result.returncode != 0:\n"
+        f'            return self.fail(f"{{program_file}} crashed: {{result.stderr[:200]}}")\n'
+        f"\n"
+        f"        try:\n"
+        f"            return float(result.stdout.strip())\n"
+        f"        except ValueError:\n"
+        f'            return self.fail(f"Expected a single float on stdout, got: {{result.stdout[:80]!r}}")\n'
     )
 
     print(f"Created task at {task_path}/")
-    print("  task.yaml       — configure your task")
-    print("  eval/grader.py  — implement your grader")
-    print("  seed/           — add starting code (optional)")
-    print(f"\nNext: edit eval/grader.py, then run: coral validate {task_path}")
+    print("  task.yaml                 — task config + grader entrypoint")
+    print("  seed/solution.py          — baseline the agent will iterate on")
+    print(f"  grader/                   — packaged grader ({dist_name})")
+    print(f"  grader/src/{module_name}/grader.py")
+    print("\nNext:")
+    print(f"  cd {task_path.name}")
+    print("  coral validate .          # bootstraps grader venv + runs grader on seed/")
+    print("  coral start -c task.yaml  # launch agents")
 
 
 def cmd_validate(args: argparse.Namespace) -> None:

--- a/docs/content/docs/cli/reference.mdx
+++ b/docs/content/docs/cli/reference.mdx
@@ -8,7 +8,7 @@ description: Complete reference for all CORAL CLI commands.
 
 ### `coral init`
 
-Create a new task directory with scaffolded config and grader.
+Create a new task directory with a scaffolded packaged grader.
 
 ```bash
 coral init <path> [--name NAME]
@@ -23,6 +23,8 @@ coral init <path> [--name NAME]
 coral init my-task
 coral init my-task --name "My Task"
 ```
+
+Produces a self-contained layout: `task.yaml` wired to a packaged grader (`grader.entrypoint`), a baseline `seed/solution.py`, and a hatchling-built `grader/` package at `grader/src/<task>_grader/`. Run `coral validate <path>` next to bootstrap the grader venv and dry-run the grader against the seed.
 
 ### `coral validate`
 

--- a/docs/content/docs/getting-started/quickstart.mdx
+++ b/docs/content/docs/getting-started/quickstart.mdx
@@ -12,15 +12,22 @@ This guide walks you through creating a task, writing a grader, and launching ag
 coral init my-task
 ```
 
-This creates a directory with a starter `task.yaml` and `eval/grader.py`:
+This creates a self-contained task with a packaged grader:
 
 ```
 my-task/
-├── task.yaml          # Task configuration
-├── eval/
-│   └── grader.py      # Your evaluation logic
-└── seed/              # Add starting code here (optional)
+├── task.yaml                              # task config + grader entrypoint
+├── seed/
+│   └── solution.py                        # baseline the agent iterates on
+└── grader/                                # standalone Python package
+    ├── pyproject.toml                     # name: my-task-grader, deps: [coral]
+    └── src/
+        └── my_task_grader/
+            ├── __init__.py                # re-exports Grader
+            └── grader.py                  # class Grader(TaskGrader): ...
 ```
+
+The grader ships as a real Python package so it gets its own isolated venv at run time (created from `grader.setup` in `task.yaml`). This avoids the legacy `eval/grader.py` in-process load and the `DeprecationWarning` that came with it.
 
 ## 2. Define your task
 
@@ -29,40 +36,52 @@ Edit `my-task/task.yaml`:
 ```yaml
 task:
   name: my-task
-  description: "Optimize the function in solution.py to run as fast as possible."
+  description: "Optimize the function in solution.py to print a higher score."
 
 grader:
+  entrypoint: "my_task_grader.grader:Grader"
+  setup:
+    - "uv pip install -e ./grader"
+  timeout: 300
   direction: maximize
+  args:
+    program_file: "solution.py"
 
 agents:
   count: 2
+  runtime: claude_code
   model: claude-sonnet-4-6
-  max_turns: 200
+
+workspace:
+  repo_path: "./seed"
 ```
 
 ## 3. Write a grader
 
-Edit `my-task/eval/grader.py`:
+The scaffold already includes a working stub at `my-task/grader/src/my_task_grader/grader.py` that runs `solution.py` and parses a single float from stdout. Customise `evaluate()` for your scoring logic:
 
 ```python
 from coral.grader import TaskGrader
 from coral.types import ScoreBundle
 
+
 class Grader(TaskGrader):
     def evaluate(self) -> float | ScoreBundle:
-        # Run the agent's solution
-        result = self.run_program("solution.py")
+        program_file = self.args.get("program_file", "solution.py")
+        result = self.run_program(program_file)
 
         if result.returncode != 0:
             return self.fail(f"Program crashed: {result.stderr[:200]}")
 
-        # Parse output and return a score (higher is better)
         try:
-            score = float(result.stdout.strip())
-            return score
+            return float(result.stdout.strip())
         except ValueError:
             return self.fail("Could not parse output as a number")
 ```
+
+What you have on `self`: `codebase_path` (agent worktree), `private_dir` (`.coral/private/` for hidden answer keys), `args` (dict from `grader.args`), `timeout`, plus helpers `run_program(filename)`, `score(value, explanation=...)`, `fail(reason)`. See the [Custom Grader guide](/guides/custom-grader) for the full API.
+
+If the grader needs extra dependencies (`numpy`, `torch`, etc.), add them to `my-task/grader/pyproject.toml` under `dependencies` — they'll be installed into the grader's venv by `coral validate` and the daemon.
 
 ## 4. Validate the grader
 
@@ -117,10 +136,16 @@ Each agent autonomously:
 
 Check [Concepts](/concepts) to understand the full architecture, or [CLI Reference](/cli/reference) for all available commands.
 
-## Graduating from `eval/grader.py`
+## Legacy `eval/grader.py` form
 
-The `eval/grader.py` form scaffolded above is a deprecated quick-start
-path — it auto-loads in-process and emits a `DeprecationWarning`. Once
-your grader is non-trivial or you want to share it across tasks, package
-it and switch `task.yaml` to use `grader.entrypoint` instead. See
-[Writing a Custom Grader → Recommended: package your grader](/guides/custom-grader#recommended-package-your-grader).
+Older tasks under `examples/` (and any task you wrote before this release) use a different layout:
+
+```
+my-task/
+├── task.yaml
+├── eval/
+│   └── grader.py
+└── seed/
+```
+
+CORAL still auto-discovers `eval/grader.py` and loads it in-process — it just emits a `DeprecationWarning`. To migrate an existing task to the packaged form, see [Writing a Custom Grader → Migrating from `eval/grader.py`](/guides/custom-grader). New tasks scaffolded by `coral init` use the packaged form by default.


### PR DESCRIPTION
`coral init my-task` now produces a self-contained task with a hatchling-built grader package wired through `grader.entrypoint`, so new tasks pick up the daemon's isolated venv path by default and avoid the `DeprecationWarning` from the legacy in-process loader.

New layout:

  my-task/
  ├── task.yaml                         (grader.entrypoint + grader.setup)
  ├── seed/
  │   └── solution.py                   (prints "0.0" as a baseline)
  └── grader/
      ├── pyproject.toml                (name: <task>-grader, deps: [coral])
      └── src/<task>_grader/
          ├── __init__.py               (re-exports Grader)
          └── grader.py                 (runs solution.py, parses float)

The task path is sanitized into:
- a Python module identifier:  `my-task`  -> `my_task_grader`
- a PEP 503 distribution name: `my-task`  -> `my-task-grader` Edge cases handled: leading digit (`123-foo` -> `task_123_foo_grader`), non-identifier chars, empty residue. See `_module_identifier` / `_distribution_name` helpers.

`cmd_validate` was already polymorphic (it bootstraps the grader venv when `grader.entrypoint` is set, falls back to in-process for the legacy path) so it needs no changes — it just works against the new scaffold.

Existing examples that still use `eval/grader.py` are unaffected: the legacy auto-discovery path continues to work and only emits a deprecation warning. The migration path is documented at `docs/getting-started/quickstart.mdx` (the renamed "Legacy eval/grader.py form" section) and in the existing custom-grader guide.

Smoke test:
  coral init smoke-task
  cd smoke-task && coral validate .
  # -> Validation: OK
  # -> Setting up grader venv (.coral/private/grader_venv)...
  # -> Score: 0.0

All 250 existing tests still pass.

Docs updated:
- docs/getting-started/quickstart.mdx: sections 1-3 rewritten for new layout; old "Graduating from eval/grader.py" section becomes "Legacy eval/grader.py form" (the migration direction is reversed).
- docs/cli/reference.mdx: one paragraph added describing what `init` now produces.