### PR TITLE
User defined skills in task.yaml

### DIFF
--- a/coral/config.py
+++ b/coral/config.py
@@ -154,6 +154,7 @@ class AgentConfig:
             HeartbeatActionConfig(name="lint_wiki", every=10, is_global=True),
         ]
     )
+    skills: list[str] = field(default_factory=list)  # skill dirs copied to .coral/public/skills/
     research: bool = True  # enable web search / literature review step in workflow
     stagger_seconds: int = 0  # delay between spawning each agent (rate-limit backpressure)
 

--- a/coral/config.py
+++ b/coral/config.py
@@ -82,6 +82,7 @@ class HeartbeatActionConfig:
     every: int = MISSING  # trigger every N evals (interval) or stall threshold (plateau)
     is_global: bool = False  # True = use global eval count, False = per-agent
     trigger: str = "interval"  # "interval" or "plateau"
+    prompt: str = ""  # custom prompt; if empty, falls back to built-in DEFAULT_PROMPTS
 
 
 @dataclass
@@ -317,12 +318,18 @@ def _preprocess(data: dict[str, Any]) -> dict[str, Any]:
     old_heartbeat = agents_data.pop("heartbeat_every", None)
 
     if heartbeat_raw is not None:
+        specified = {h["name"] for h in heartbeat_raw}
+        for dflt in AgentConfig().heartbeat:
+            if dflt.name not in specified:
+                heartbeat_raw.append({"name": dflt.name, "every": dflt.every,
+                                      "global": dflt.is_global, "trigger": dflt.trigger})
         agents_data["heartbeat"] = [
             {
                 "name": h["name"],
                 "every": h["every"],
                 "is_global": h.get("global", False),
                 "trigger": h.get("trigger", "interval"),
+                "prompt": h.get("prompt", ""),
             }
             for h in heartbeat_raw
         ]

--- a/coral/hub/heartbeat.py
+++ b/coral/hub/heartbeat.py
@@ -154,7 +154,7 @@ def default_local_actions(config) -> list[dict]:
             actions.append({
                 "name": action_cfg.name,
                 "every": action_cfg.every,
-                "prompt": DEFAULT_PROMPTS.get(action_cfg.name, ""),
+                "prompt": action_cfg.prompt or DEFAULT_PROMPTS.get(action_cfg.name, ""),
                 "trigger": trigger,
             })
     return actions
@@ -170,7 +170,7 @@ def default_global_actions(config) -> list[dict]:
             actions.append({
                 "name": action_cfg.name,
                 "every": action_cfg.every,
-                "prompt": DEFAULT_PROMPTS.get(action_cfg.name, ""),
+                "prompt": action_cfg.prompt or DEFAULT_PROMPTS.get(action_cfg.name, ""),
                 "trigger": trigger,
             })
     return actions

--- a/coral/workspace/project.py
+++ b/coral/workspace/project.py
@@ -161,6 +161,9 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
     # Initialize checkpoint repo for shared state versioning
     init_checkpoint_repo(str(coral_dir))
 
+    # Resolve task directory for relative path resolution
+    effective_config_dir = config.task_dir or config_dir or Path.cwd()
+
     # Seed bundled skills from coral/template/skills/
     seed_skills_dir = _SEED_SKILLS_DIR
     if seed_skills_dir.is_dir():
@@ -170,6 +173,20 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
                 if not dst.exists():
                     shutil.copytree(skill_dir, dst)
                     logger.info(f"Seeded skill: {skill_dir.name}")
+
+    # Seed user-provided skills from agents.skills config
+    for skill_path in config.agents.skills:
+        src = Path(skill_path)
+        if not src.is_absolute():
+            src = (effective_config_dir / src).resolve()
+        if src.is_dir():
+            dst = coral_dir / "public" / "skills" / src.name
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst)
+            logger.info(f"Seeded user skill: {src.name}")
+        else:
+            logger.warning(f"Skill directory not found: {src}")
 
     # Seed bundled agent templates from coral/template/agents/
     seed_agents_dir = _SEED_AGENTS_DIR
@@ -185,7 +202,6 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
     config.to_yaml(coral_dir / "config.yaml")
 
     # Save config_dir so resume can restore task_dir for relative path resolution
-    effective_config_dir = config.task_dir or config_dir or Path.cwd()
     (coral_dir / "config_dir").write_text(str(effective_config_dir))
 
     # Create/update "latest" symlink at task_dir/latest -> this run directory

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -328,3 +328,23 @@ def test_warmstart_dotlist_override():
         ],
     )
     assert merged.agents.warmstart.enabled is True
+
+
+def test_skills_config_roundtrip():
+    """agents.skills survives a YAML to_yaml/from_yaml roundtrip."""
+    skills = ["./skills/test-skill", "./skills/other"]
+    config = CoralConfig(
+        task=TaskConfig(name="t", description="d"),
+        agents=AgentConfig(skills=skills),
+    )
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+        config.to_yaml(f.name)
+        restored = CoralConfig.from_yaml(f.name)
+
+    assert restored.agents.skills == skills
+
+
+def test_skills_config_defaults_empty():
+    data = {"task": {"name": "t", "description": "d"}}
+    config = CoralConfig.from_dict(data)
+    assert config.agents.skills == []

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -578,3 +578,50 @@ def test_setup_shared_state_migrates_real_identities_dir():
         link = worktree / ".claude" / "identities"
         assert link.is_symlink()
         assert (coral_dir / "public" / "identities" / "agent-1.md").read_text() == "local content"
+
+
+def test_create_project_seeds_user_skills():
+    """agents.skills directories are copied into .coral/public/skills/."""
+    with tempfile.TemporaryDirectory() as d:
+        _git_init(d)
+        root = Path(d)
+
+        skill_name = "test-skill"
+        skill_dir = root / "skills" / skill_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "run.sh").write_text("#!/bin/bash\necho hello")
+
+        config = CoralConfig(
+            task=TaskConfig(name="Test Task", description="Test task"),
+            grader=GraderConfig(),
+            agents=AgentConfig(count=1, skills=[f"./skills/{skill_name}"]),
+            workspace=WorkspaceConfig(results_dir=str(root / "results"), repo_path=d),
+        )
+        paths = create_project(config, config_dir=root)
+
+        seeded = paths.coral_dir / "public" / "skills" / skill_name / "run.sh"
+        assert seeded.is_file()
+        assert "echo hello" in seeded.read_text()
+
+
+def test_create_project_user_skills_override_builtin():
+    """User skills with the same name as a built-in skill take precedence."""
+    with tempfile.TemporaryDirectory() as d:
+        _git_init(d)
+        root = Path(d)
+
+        skill_name = "coral-workflow"
+        skill_dir = root / "skills" / skill_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "custom.txt").write_text("user version")
+
+        config = CoralConfig(
+            task=TaskConfig(name="Test Task", description="Test task"),
+            grader=GraderConfig(),
+            agents=AgentConfig(count=1, skills=[f"./skills/{skill_name}"]),
+            workspace=WorkspaceConfig(results_dir=str(root / "results"), repo_path=d),
+        )
+        paths = create_project(config, config_dir=root)
+
+        dst = paths.coral_dir / "public" / "skills" / skill_name
+        assert (dst / "custom.txt").read_text() == "user version"


### PR DESCRIPTION
Support user-defined skills in task.yaml to help manage skills in git rather than manually copying them into the agents workspace.