### PR TITLE
feat(examples): add Frontier-Smith algorithmic tasks

### DIFF
--- a/examples/frontier_smith/1/seed/solution.cpp
+++ b/examples/frontier_smith/1/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/1/seed/statement.txt
+++ b/examples/frontier_smith/1/seed/statement.txt
@@ -1,0 +1,192 @@
+# Scorched Bridges Campaign
+
+## Problem
+
+The enemy controls an archipelago of islands connected by bridges. Their headquarters is on island `1`.
+
+You have obtained a forecast of the next `m` days. On day `i`, several islands will contain energy depots. If an island with a depot is still connected to island `1`, the enemy harvests its energy that day. If it is disconnected from island `1`, that depot is denied.
+
+You may prepare a long-term demolition campaign:
+
+- A bridge can be **rigged** in advance, paying a one-time installation cost.
+- On any day, you may **detonate** any subset of rigged bridges, paying a per-use cost for each detonation.
+- Destroyed bridges are repaired by the enemy overnight, so each day starts from the original graph again.
+- Each rigged bridge has a limited number of times it can be detonated during the whole campaign.
+- Your demolition teams also have a daily limit on how many bridges they can blow up on each day.
+
+Your task is to output **any feasible campaign plan**. The judge will compute its total cost, combining your demolition expenses and the total energy still harvested by the enemy. Lower is better.
+
+Because the graph is general and decisions interact across many days, exact optimization is intended to be intractable; heuristic approaches are expected.
+
+## Input
+
+The first line contains two integers:
+
+- `n` — number of islands
+- `e` — number of bridges
+
+Islands are numbered from `1` to `n`.  
+Bridges are numbered from `1` to `e` in input order.
+
+The next `e` lines each contain five integers:
+
+- `u_j, v_j` — endpoints of bridge `j`
+- `a_j` — installation cost to rig bridge `j`
+- `b_j` — cost each time bridge `j` is detonated
+- `c_j` — maximum number of days bridge `j` may be detonated over the whole campaign
+
+Then follows one integer:
+
+- `m` — number of forecast days
+
+The next `m` lines describe the days.  
+Line `i` contains:
+
+- `r_i` — number of energy depots on day `i`
+- `L_i` — maximum number of bridges you may detonate on day `i`
+- then `2 * r_i` integers:
+  - `h_1, v_1, h_2, v_2, ..., h_{r_i}, v_{r_i}`
+
+meaning island `h_t` has a depot worth `v_t` energy on day `i`.
+
+### Guarantees
+
+- The bridge graph is connected.
+- `h_t != 1` for all depots.
+- Within one day, all depot islands are distinct.
+
+## Output
+
+Your output must describe one campaign plan.
+
+- First line: one integer `x` — number of rigged bridges.
+- Second line: `x` distinct integers — the IDs of the rigged bridges, in any order.  
+  If `x = 0`, this line should be empty.
+
+Then output `m` lines.  
+On day `i`, output:
+
+- `d_i` — number of bridges detonated on day `i`
+- followed by `d_i` distinct bridge IDs
+
+### Feasibility requirements
+
+Your output is **feasible** iff all of the following hold:
+
+1. Every listed bridge ID is between `1` and `e`.
+2. The rigged bridge list contains no duplicates.
+3. On each day, the detonated bridge list contains no duplicates.
+4. Every detonated bridge must be rigged.
+5. For each day `i`, `d_i <= L_i`.
+6. For each bridge `j`, it is detonated on at most `c_j` different days over the entire campaign.
+
+If your output is infeasible, the score for that test is `0`.
+
+## Objective
+
+For each day `i`:
+
+1. Start from the original graph.
+2. Remove all bridges detonated on day `i`.
+3. Any depot island still connected to island `1` contributes its value to the enemy's harvested energy that day.
+4. Any depot island disconnected from island `1` contributes `0`.
+
+Let:
+
+- `InstallCost = sum of a_j over all rigged bridges`
+- `BlastCost = sum of b_j over all detonations on all days`
+- `Harvested = sum of values of all depots that remain connected to island 1 on their respective days`
+
+Your objective value is
+
+`F = InstallCost + BlastCost + Harvested`
+
+You must **minimize** `F`.
+
+## Scoring
+
+For each test file, define the baseline solution as:
+
+- rig no bridges,
+- detonate no bridges on every day.
+
+Its objective value is
+
+`B = sum of all depot values on all days`.
+
+For a feasible submission with objective value `F`, the test score is
+
+`Score_test = min(1000, 100 * B / max(1, F))`
+
+An infeasible submission receives `Score_test = 0`.
+
+The final score is the arithmetic mean of `Score_test` over all test files.
+
+Notes:
+
+- The baseline always scores exactly `100` on every test.
+- Better solutions score higher than `100`.
+- A solution at least `10` times better than the baseline is capped at `1000` on that test.
+
+## Constraints
+
+- `2 <= n <= 2 * 10^5`
+- `n - 1 <= e <= 3 * 10^5`
+- `1 <= m <= 2 * 10^5`
+- `1 <= u_j, v_j <= n`, `u_j != v_j`
+- `1 <= a_j, b_j <= 10^6`
+- `1 <= c_j <= 20`
+- `1 <= r_i < n`
+- `0 <= L_i <= 20`
+- `1 <= v_t <= 10^6`
+- `sum r_i <= 5 * 10^5`
+- `sum L_i <= 5 * 10^5`
+
+## Constraints
+- Time limit: 8 seconds
+- Memory limit: 512 MB
+
+## Example
+
+### Input
+```text
+5 4
+1 2 5 2 2
+2 3 2 1 1
+2 4 2 1 1
+1 5 4 2 1
+2
+2 1 3 10 4 8
+2 2 5 12 3 5
+```
+
+### Output
+```text
+2
+1 4
+1 1
+2 1 4
+```
+
+### Explanation
+
+- Rig bridges `1` and `4`.
+- Day 1: detonate bridge `1` (`1-2`), disconnecting islands `3` and `4`.
+- Day 2: detonate bridges `1` and `4`, disconnecting islands `3` and `5`.
+
+Costs:
+
+- Installation: `5 + 4 = 9`
+- Detonation: day 1 uses bridge `1` (`2`), day 2 uses bridges `1` and `4` (`2 + 2`), total `6`
+- Harvested energy: `0`
+
+So `F = 9 + 6 + 0 = 15`.
+
+Baseline value:
+- Day 1: `10 + 8 = 18`
+- Day 2: `12 + 5 = 17`
+- `B = 35`
+
+Therefore this output gets
+
+`Score_test = 100 * 35 / 15 = 233.333...`

--- a/examples/frontier_smith/1/task.yaml
+++ b/examples/frontier_smith/1/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #1: Scorched Bridges Campaign'
+  description: |-
+    Solve algorithmic problem #1 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 8s per test case
+    - Uses at most 512MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 8s per test case. Memory limit: 512MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 380
+  direction: maximize
+  args:
+    problem_id: frontiersmith_1
+    problem_type: default
+    time_limit: 8
+    memory_mb: 512
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/1/seed
+run:
+  verbose: false
+  ui: false
+  session: local

--- a/examples/frontier_smith/10/seed/solution.cpp
+++ b/examples/frontier_smith/10/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/10/seed/statement.txt
+++ b/examples/frontier_smith/10/seed/statement.txt
@@ -1,0 +1,183 @@
+# Quadratic Witness Packing
+
+## Problem
+You are building a small library of reusable **quadratic witnesses**.
+
+A witness is a pair of integers \((A,B)\).  
+For a query \((p,x)\), the witness **matches** the query if
+
+\[
+A^2 + B^2 \equiv x \pmod p.
+\]
+
+You are given many weighted queries. Your task is to output at most \(K\) witnesses so that the total weight of matched queries is as large as possible.
+
+A single witness may match many queries, and a query is counted at most once even if several witnesses match it.
+
+The moduli are guaranteed to be odd and square-free, i.e. for every odd prime \(q\mid p\), we have \(q^2 \nmid p\).
+
+This is an optimization problem: any feasible solution is accepted and scored by how much total weight it covers.
+
+## Input
+The input contains one test instance.
+
+- The first line contains three integers:
+  \[
+  n\ \ K\ \ B
+  \]
+  where:
+  - \(n\) is the number of queries,
+  - \(K\) is the maximum number of witnesses you may output,
+  - \(B\) is the coordinate bound for every witness.
+
+- The next \(n\) lines each contain three integers:
+  \[
+  p_i\ \ x_i\ \ w_i
+  \]
+  meaning:
+  - \(p_i\) is the modulus,
+  - \(x_i\) is the target residue,
+  - \(w_i\) is the weight of the query.
+
+A query \(i\) is covered if there exists at least one output witness \((A,B)\) such that
+\[
+A^2 + B^2 \equiv x_i \pmod{p_i}.
+\]
+
+## Output
+Output a feasible witness set:
+
+- The first line contains one integer \(m\) \((0 \le m \le K)\), the number of witnesses you output.
+- The next \(m\) lines each contain two integers:
+  \[
+  A_j\ \ B_j
+  \]
+  satisfying
+  \[
+  0 \le A_j \le B,\qquad 0 \le B_j \le B.
+  \]
+
+### Feasibility rules
+- \(m\) must satisfy \(0 \le m \le K\).
+- Every printed coordinate must be an integer in \([0,B]\).
+- Duplicate witnesses are allowed, but usually useless.
+- If the output is invalid, the submission receives score \(0\) for that test file.
+
+## Objective
+Let \(C\) be the set of queries covered by at least one of your witnesses.
+
+Your objective value is
+
+\[
+V = \sum_{i \in C} w_i.
+\]
+
+You must **maximize** \(V\).
+
+## Scoring
+For each test file, the judge also computes a fixed **baseline solution**:
+
+- it outputs exactly \(K\) witnesses
+  \[
+  (0,0), (1,0), (2,0), \dots, (K-1,0),
+  \]
+- this is always feasible because \(B \ge K-1\).
+
+Let:
+
+- \(W = \sum_{i=1}^n w_i\) be the total weight,
+- \(V_{\text{base}}\) be the baseline objective value,
+- \(U = W - V\) be your uncovered weight,
+- \(U_{\text{base}} = W - V_{\text{base}}\) be the baseline uncovered weight.
+
+The per-file score is:
+
+- if \(U_{\text{base}} = 0\), then every feasible submission gets **1,000,000** points;
+- otherwise,
+  \[
+  \text{score} =
+  \left\lfloor
+  10^6 \cdot
+  \max\left(0,\ \min\left(1,\ \frac{U_{\text{base}} - U}{U_{\text{base}}}\right)\right)
+  \right\rfloor.
+  \]
+
+Equivalently,
+
+\[
+\text{score} =
+\left\lfloor
+10^6 \cdot
+\max\left(0,\ \min\left(1,\ \frac{V - V_{\text{base}}}{W - V_{\text{base}}}\right)\right)
+\right\rfloor
+\quad\text{when } V_{\text{base}} < W.
+\]
+
+So:
+- matching the baseline gives score \(0\),
+- covering all queries gives score \(1{,}000{,}000\),
+- intermediate improvements give proportionally higher scores.
+
+The final contest score is the sum of per-file scores over all test files.
+
+## Constraints
+- \(1 \le n \le 2 \times 10^5\)
+- \(1 \le K \le 60\)
+- \(K-1 \le B \le 10^9\)
+- \(1 \le p_i \le 10^7\)
+- \(p_i\) is odd
+- \(0 \le x_i < p_i\)
+- \(1 \le w_i \le 10^6\)
+- For every odd prime \(q\mid p_i\), \(q^2 \nmid p_i\)
+
+## Constraints
+- Time limit: 4 seconds
+- Memory limit: 512 MB
+
+## Example
+### Sample input
+```text
+6 2 100
+5 0 10
+5 1 8
+13 5 7
+13 8 6
+15 5 9
+15 8 4
+```
+
+### Sample output
+```text
+2
+1 2
+2 2
+```
+
+### Explanation
+The two witnesses are:
+- \((1,2)\), with \(1^2+2^2=5\),
+- \((2,2)\), with \(2^2+2^2=8\).
+
+Thus they cover:
+- residue \(0 \bmod 5\) via \(5\),
+- residue \(5 \bmod 13\) via \(5\),
+- residue \(8 \bmod 13\) via \(8\),
+- residue \(5 \bmod 15\) via \(5\),
+- residue \(8 \bmod 15\) via \(8\).
+
+So the covered total weight is
+\[
+10 + 7 + 6 + 9 + 4 = 36.
+\]
+
+The only uncovered query is \((5,1)\) with weight \(8\), so \(W=44\) and \(U=8\).
+
+The baseline witnesses are \((0,0)\) and \((1,0)\), whose sums are \(0\) and \(1\).  
+They cover only the first two queries, so \(V_{\text{base}}=18\), hence \(U_{\text{base}}=26\).
+
+Therefore the score for this file is
+\[
+\left\lfloor 10^6 \cdot \frac{26-8}{26} \right\rfloor
+=
+692307.
+\]

--- a/examples/frontier_smith/10/task.yaml
+++ b/examples/frontier_smith/10/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #10: Quadratic Witness Packing'
+  description: |-
+    Solve algorithmic problem #10 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 4s per test case
+    - Uses at most 512MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 4s per test case. Memory limit: 512MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 340
+  direction: maximize
+  args:
+    problem_id: frontiersmith_10
+    problem_type: default
+    time_limit: 4
+    memory_mb: 512
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/10/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/2/seed/solution.cpp
+++ b/examples/frontier_smith/2/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/2/seed/statement.txt
+++ b/examples/frontier_smith/2/seed/statement.txt
@@ -1,0 +1,203 @@
+# Farmwide Teleport Pad Deployment
+
+## Problem
+
+Farmer John is upgrading his manure logistics again.
+
+This time, instead of building a single teleporter, he may install a **network of teleport pads** at selected road intersections across the farm. The farm road system is modeled as a connected, undirected, weighted graph.
+
+There are `N` manure shipments. Shipment `i` must be moved from intersection `s_i` to intersection `t_i`. Each shipment is transported independently.
+
+If Farmer John installs a set of teleport pads, then for any shipment he may choose either:
+
+1. **Drive directly** from `s_i` to `t_i`, or
+2. **Use the teleport network once**:
+   - drive from `s_i` to any installed pad,
+   - teleport instantly and for free to any other installed pad,
+   - drive from that pad to `t_i`.
+
+Teleportation between installed pads has zero cost and unlimited capacity.
+
+However, each candidate pad location has a construction cost, and the total construction cost must not exceed the budget.
+
+Your task is to choose which candidate pad locations to build in order to minimize the total driving distance over all shipments.
+
+This is an **optimization challenge**: better solutions receive higher scores.
+
+---
+
+## Input
+
+The input describes one test file.
+
+- The first line contains five integers  
+  `V E M N C`
+  - `V`: number of intersections (`1..V`)
+  - `E`: number of roads
+  - `M`: number of candidate teleport-pad sites
+  - `N`: number of shipments
+  - `C`: total construction budget
+
+- The next `E` lines each contain three integers  
+  `u v w`  
+  meaning there is an undirected road between intersections `u` and `v` with length `w`.
+
+- The next `M` lines each contain two integers  
+  `p_j cost_j`  
+  meaning candidate site `j` is located at intersection `p_j` and costs `cost_j` to build.
+
+- The next `N` lines each contain two integers  
+  `s_i t_i`  
+  describing a shipment from `s_i` to `t_i`.
+
+All road lengths and construction costs are positive integers.
+
+The graph is connected.
+
+---
+
+## Output
+
+Output a feasible set of candidate sites to build.
+
+- The first line must contain a single integer `K` — the number of chosen sites.
+- The next `K` lines must each contain one integer: the index of a chosen candidate site (an integer from `1` to `M`).
+
+### Feasibility requirements
+
+Your output is **feasible** iff all of the following hold:
+
+- `0 <= K <= M`
+- all chosen indices are distinct
+- each chosen index is between `1` and `M`
+- the sum of construction costs of the chosen sites is at most `C`
+
+If your output is infeasible, your score for that test file is `0`.
+
+---
+
+## Objective
+
+Let `dist(a,b)` be the shortest-path distance between intersections `a` and `b` in the road graph.
+
+Let `S` be the set of chosen candidate sites, and let `P(S)` be their intersections.
+
+For shipment `i`, define:
+
+- Direct cost:
+  `direct_i = dist(s_i, t_i)`
+
+- Teleport-assisted cost:
+  - if `S` is empty, this cost is treated as `+infinity`
+  - otherwise  
+    `tele_i = min_{x in P(S)} dist(s_i, x) + min_{y in P(S)} dist(t_i, y)`
+
+The shipment cost is
+
+`d_i = min(direct_i, tele_i)`
+
+The objective value of your output is
+
+`O = sum_{i=1..N} d_i`
+
+Your goal is to **minimize** `O`.
+
+---
+
+## Scoring
+
+For each test file, define the **baseline** solution as building no pads at all.
+
+Its objective value is therefore
+
+`B = sum_{i=1..N} dist(s_i, t_i)`
+
+For a feasible submission with objective value `O`, the score for that test file is
+
+`score = round(1,000,000 * max(0, min(1, (B - O) / B )))`
+
+Since direct transport is always allowed, any feasible solution satisfies `O <= B`, so this is simply the relative improvement over the baseline, scaled to `1,000,000`.
+
+- Baseline solution: score `0`
+- Better solutions: higher scores
+- Perfectly eliminating all driving distance: score `1,000,000`
+
+If your output is infeasible, the score is `0`.
+
+The total score of a submission is the sum of its scores over all test files.
+
+---
+
+## Constraints
+
+- `2 <= V <= 8000`
+- `V-1 <= E <= 40000`
+- `1 <= M <= 3000`
+- `1 <= N <= 100000`
+- `1 <= C <= 10^12`
+- `1 <= w <= 10^9`
+- `1 <= cost_j <= 10^9`
+- `1 <= u, v, p_j, s_i, t_i <= V`
+- `s_i != t_i`
+- candidate site intersections `p_j` are distinct
+
+The exact optimum is intended to be computationally difficult in general; heuristic and approximation methods are expected.
+
+- Time limit: 4 seconds
+- Memory limit: 1024 MB
+
+---
+
+## Example
+
+### Sample input
+```text
+5 6 3 3 7
+1 2 4
+2 3 4
+3 4 4
+4 5 4
+1 5 20
+2 5 7
+2 3
+4 4
+5 5
+1 4
+1 5
+3 5
+```
+
+### Sample output
+```text
+2
+1
+2
+```
+
+### Explanation
+
+There are 3 candidate pad sites:
+
+- site 1 at intersection 2, cost 3
+- site 2 at intersection 4, cost 4
+- site 3 at intersection 5, cost 5
+
+The sample output builds sites 1 and 2, with total cost `3 + 4 = 7`, which fits the budget.
+
+Shortest direct shipment costs are:
+
+- `1 -> 4`: `12`
+- `1 -> 5`: `11`
+- `3 -> 5`: `8`
+
+So the baseline is `B = 31`.
+
+With pads at intersections 2 and 4:
+
+- `1 -> 4`: drive `1 -> 2` (4), teleport `2 -> 4` (0), drive `4 -> 4` (0), total `4`
+- `1 -> 5`: drive `1 -> 2` (4), teleport `2 -> 4` (0), drive `4 -> 5` (4), total `8`
+- `3 -> 5`: best remains `8`
+
+Thus `O = 4 + 8 + 8 = 20`.
+
+Relative improvement is `(31 - 20) / 31 = 11/31`, so the score for this file is approximately `354,839`.

--- a/examples/frontier_smith/2/task.yaml
+++ b/examples/frontier_smith/2/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #2: Farmwide Teleport Pad Deployment'
+  description: |-
+    Solve algorithmic problem #2 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 4s per test case
+    - Uses at most 1024MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 4s per test case. Memory limit: 1024MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 340
+  direction: maximize
+  args:
+    problem_id: frontiersmith_2
+    problem_type: default
+    time_limit: 4
+    memory_mb: 1024
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/2/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/3/seed/solution.cpp
+++ b/examples/frontier_smith/3/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/3/seed/statement.txt
+++ b/examples/frontier_smith/3/seed/statement.txt
@@ -1,0 +1,169 @@
+# Metallic Pink Resonator Layout
+
+## Problem
+The Martians have built a circular relay with ports labeled `0,1,…,M-1`.  
+Some ports will be equipped with **pink emitters**; the rest remain **plain reflectors**.
+
+If port `a` is an emitter and port `b` is a reflector, then together they can generate the frequency
+
+\[
+(a+b)\bmod M.
+\]
+
+For each frequency `r`, the Martians know:
+
+- a **value** `w_r` gained for each successful generating pair producing `r`,
+- a **saturation limit** `d_r`: once `d_r` pairs producing `r` exist, extra pairs for `r` give no additional benefit.
+
+You must choose which ports become emitters, subject to a budget.
+
+Let `A` be the set of chosen emitters, and `B = {0,1,…,M-1} \ A` be the reflectors.  
+For each residue `r`, define
+
+\[
+c_r = |\{(a,b)\in A\times B : (a+b)\bmod M = r\}|,
+\]
+
+where pairs are **ordered**: choosing emitter `a` and reflector `b` is one pair.
+
+The contribution of residue `r` is
+
+\[
+w_r \cdot \min(c_r, d_r).
+\]
+
+Your task is to output any feasible emitter set maximizing the total contribution.
+
+---
+
+## Input
+A single test file contains one instance.
+
+- The first line contains two integers `M` and `B` — the number of ports and the total budget.
+- The second line contains `M` integers `cost_0, cost_1, …, cost_{M-1}` — the cost of installing an emitter at each port.
+- The third line contains `M` integers `w_0, w_1, …, w_{M-1}` — the value of each residue.
+- The fourth line contains `M` integers `d_0, d_1, …, d_{M-1}` — the saturation limit of each residue.
+
+All residue arithmetic is modulo `M`.
+
+---
+
+## Output
+Output any feasible solution.
+
+- The first line must contain one integer `K` — the number of chosen emitter ports.
+- The second line must contain `K` distinct integers `p_1, p_2, …, p_K` in increasing order, each between `0` and `M-1`, denoting the emitter ports.
+
+A solution is **feasible** if:
+
+1. all listed ports are distinct,
+2. all listed ports are valid indices in `[0, M-1]`,
+3. \(\sum_{i=1}^{K} cost_{p_i} \le B\).
+
+If your output is infeasible or malformed, your objective value is `0`.
+
+If `K = 0`, you may omit the second line.
+
+---
+
+## Objective
+For your chosen emitter set `A` and reflector set `B = [0, M-1] \ A`, compute for each residue `r`:
+
+\[
+c_r = |\{(a,b)\in A\times B : (a+b)\bmod M = r\}|.
+\]
+
+Your objective value is
+
+\[
+U = \sum_{r=0}^{M-1} w_r \cdot \min(c_r, d_r).
+\]
+
+Higher is better.
+
+---
+
+## Scoring
+For each official test instance, the judge also computes a deterministic **baseline** solution:
+
+1. Sort all ports by `(cost_i, i)` ascending.
+2. Traverse this order once.
+3. Add port `i` to the emitter set iff doing so keeps the total cost at most `B`.
+
+Let the baseline objective value be `U_base`, and your objective value be `U`.
+
+The score for that test is:
+
+- `0`, if `U = 0` and `U_base = 0`;
+- otherwise
+
+\[
+100 \cdot \frac{U}{U + U_{base}}.
+\]
+
+So:
+- matching the baseline gives `50`,
+- worse than the baseline gives less than `50`,
+- better than the baseline gives more than `50`,
+- the score approaches `100` as `U` becomes much larger than `U_base`.
+
+Your final score is the arithmetic mean of your per-test scores over all official test instances.
+
+---
+
+## Constraints
+- `2 ≤ M ≤ 200000`
+- `1 ≤ cost_i ≤ 10^9`
+- `1 ≤ w_i ≤ 10^6`
+- `1 ≤ d_i ≤ M`
+- `1 ≤ B ≤ 10^18`
+- At least one port satisfies `cost_i ≤ B`
+
+The search space is exponential in `M`; exact optimization is not expected.
+
+- Time limit: 8 seconds
+- Memory limit: 1024 MB
+
+---
+
+## Example
+Input
+```text
+6 5
+3 2 2 4 1 3
+5 1 4 2 3 6
+1 2 1 1 2 1
+```
+
+Output
+```text
+3
+1 2 4
+```
+
+Brief explanation:
+
+- Chosen emitters: `{1,2,4}`
+- Total cost: `2 + 2 + 1 = 5`, so the solution is feasible.
+- Reflectors: `{0,3,5}`
+
+Ordered emitter-reflector pairs generate residues with counts:
+
+- residue `0`: 1 pair
+- residue `1`: 3 pairs
+- residue `2`: 1 pair
+- residue `3`: 1 pair
+- residue `4`: 2 pairs
+- residue `5`: 1 pair
+
+After applying saturation limits `d = [1,2,1,1,2,1]`, the objective is:
+
+\[
+5\cdot1 + 1\cdot2 + 4\cdot1 + 2\cdot1 + 3\cdot2 + 6\cdot1 = 25.
+\]
+
+For this instance, the baseline picks the same set, so `U = U_base = 25`, and the test score is
+
+\[
+100 \cdot \frac{25}{25+25} = 50.
+\]

--- a/examples/frontier_smith/3/task.yaml
+++ b/examples/frontier_smith/3/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #3: Metallic Pink Resonator Layout'
+  description: |-
+    Solve algorithmic problem #3 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 8s per test case
+    - Uses at most 1024MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 8s per test case. Memory limit: 1024MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 380
+  direction: maximize
+  args:
+    problem_id: frontiersmith_3
+    problem_type: default
+    time_limit: 8
+    memory_mb: 1024
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/3/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/4/seed/solution.cpp
+++ b/examples/frontier_smith/4/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/4/seed/statement.txt
+++ b/examples/frontier_smith/4/seed/statement.txt
@@ -1,0 +1,136 @@
+# Park Ranger Shift Balancing
+
+## Problem
+The city wants to inspect every trail in a large park during one night.
+
+The park has `n` glades, numbered `1` to `n`, and `m` undirected trails, numbered `1` to `m`.  
+Trail `i` connects glades `x_i` and `y_i` and has length `c_i`.
+
+- A trail may be a self-loop (`x_i = y_i`).
+- Several different trails may connect the same pair of glades.
+
+There are `k` ranger teams. Every team starts at glade `1`, walks along trails, and must return to glade `1` by the end of its shift.
+
+A team may traverse any trail any number of times. However, **every original trail must be traversed at least once by some team** so that it gets inspected.
+
+Your task is to output one closed walk for each team so that all trails are inspected, while balancing the teams as well as possible.
+
+## Input
+The first line contains three integers:
+
+`n m k`
+
+- `1 ≤ n ≤ 2 · 10^5`
+- `1 ≤ m ≤ 2 · 10^5`
+- `1 ≤ k ≤ 40`
+
+The next `m` lines describe the trails.  
+Line `i + 1` contains three integers:
+
+`x_i y_i c_i`
+
+- `1 ≤ x_i, y_i ≤ n`
+- `1 ≤ c_i ≤ 10^9`
+
+It is guaranteed that every glade incident to at least one trail is reachable from glade `1`.
+
+## Output
+Output exactly `k` route descriptions, one for each ranger team.
+
+For team `j`, output:
+
+`t_j a_{j,1} a_{j,2} ... a_{j,t_j}`
+
+where:
+
+- `t_j ≥ 0` is the number of trail traversals in team `j`'s walk,
+- each `a_{j,p}` is a nonzero signed integer with `|a_{j,p}|` between `1` and `m`.
+
+Interpretation of a signed trail id:
+
+- if `a = +i`, the team traverses trail `i` from `x_i` to `y_i`,
+- if `a = -i`, the team traverses trail `i` from `y_i` to `x_i`.
+
+A solution is **feasible** iff all of the following hold:
+
+1. Team `j` starts at glade `1`.
+2. For every consecutive traversal in team `j`'s list, the departure glade of the next signed trail equals the current glade.
+3. After its last traversal, team `j` is back at glade `1`.
+4. Every trail id `1..m` appears at least once in at least one team's list.
+
+Empty walks are allowed: `t_j = 0`.
+
+The judge treats all whitespace equally, so route descriptions may span multiple lines if desired.
+
+## Objective
+For each team `j`, let `L_j` be the total length of all traversals in its walk, counting repeated traversals each time.
+
+Your objective value is
+
+`A = max(L_1, L_2, ..., L_k)`
+
+which must be **minimized**.
+
+## Scoring
+For each test case, the judge first computes a deterministic baseline value `B`:
+
+1. Compute shortest-path distances `dist(v)` from glade `1` to every glade.
+2. For each trail `i = (x_i, y_i, c_i)`, define its standalone round-trip cost
+   `τ_i = dist(x_i) + c_i + dist(y_i)`.
+3. Sort all trails by decreasing `τ_i`  
+   (break ties by smaller trail id).
+4. Process trails in that order and assign each trail to the currently least-loaded team  
+   (break ties by smaller team index).
+5. Let `B` be the maximum load of any team after all assignments.
+
+This baseline corresponds to inspecting each trail separately by going from glade `1` to one endpoint, traversing the trail once, and returning from the other endpoint to glade `1`, with greedy load balancing.
+
+For a feasible submission with objective value `A`, the test score is
+
+`score = 100000 · min(2, B / A)`
+
+For an infeasible submission, the test score is `0`.
+
+The final score is the arithmetic mean of test scores over all test cases.
+
+Notes:
+
+- The baseline always scores `100000` on every test.
+- A solution twice as good as the baseline, or better, gets the capped score `200000` on that test.
+
+## Constraints
+- Time limit: 5 seconds
+- Memory limit: 512 MB
+
+## Example
+### Sample input
+```text
+4 4 2
+1 2 3
+2 3 2
+3 1 4
+1 4 5
+```
+
+### Sample output
+```text
+3 1 2 3
+2 4 -4
+```
+
+### Explanation
+- Team 1 walks along trails `1, 2, 3`, i.e. `1 -> 2 -> 3 -> 1`, for total length `3 + 2 + 4 = 9`.
+- Team 2 walks `1 -> 4 -> 1` using trail `4` twice, for total length `5 + 5 = 10`.
+
+All four trails are inspected at least once, and both teams return to glade `1`, so the solution is feasible.
+
+The objective value is `A = max(9, 10) = 10`.
+
+For the baseline:
+- `dist(1)=0`, `dist(2)=3`, `dist(3)=4`, `dist(4)=5`
+- standalone costs are `6, 9, 8, 10`
+- greedy balancing yields loads `16` and `17`, so `B = 17`
+
+Thus the sample score on this test would be
+
+`100000 · (17 / 10) = 170000`.

--- a/examples/frontier_smith/4/task.yaml
+++ b/examples/frontier_smith/4/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #4: Park Ranger Shift Balancing'
+  description: |-
+    Solve algorithmic problem #4 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 5s per test case
+    - Uses at most 512MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 5s per test case. Memory limit: 512MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 340
+  direction: maximize
+  args:
+    problem_id: frontiersmith_4
+    problem_type: default
+    time_limit: 5
+    memory_mb: 512
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/4/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/5/seed/solution.cpp
+++ b/examples/frontier_smith/5/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/5/seed/statement.txt
+++ b/examples/frontier_smith/5/seed/statement.txt
@@ -1,0 +1,183 @@
+# Prime Resonance Retuning
+
+## Problem
+
+Yash has built a **prime resonance network** on a rooted tree.
+
+The network has `n` nodes, rooted at node `1`.  
+Each node `i` stores a non-negative integer `a_i`. A modulus `m` is also given.
+
+For every node, only its value modulo `m` matters. Let
+
+- `P = { p | p is prime and 2 <= p < m }`
+
+be the set of prime residues of interest.
+
+You may install **retuners** on some nodes.  
+A retuner placed on node `v` with shift `d` adds `d` (modulo `m`) to **every node in the subtree of `v`**.
+
+If a node `u` has several retuners on its ancestors, their shifts add up modulo `m`.
+
+There are `t` observatories. Observatory `j` watches the subtree of node `s_j` and has importance weight `w_j`.
+
+After all chosen retuners are applied, observatory `j` gains credit for every prime residue `p in P` that appears at least once among the final values of nodes in the subtree of `s_j`.
+
+Your task is to choose where to place retuners and what shifts to use.
+
+---
+
+More formally:
+
+- Let `x_v` be the chosen shift at node `v`:
+  - `x_v = 0` means no retuner is installed at `v`
+  - `x_v in {1,2,...,m-1}` means a retuner with shift `x_v` is installed
+- At most `k` nodes may have `x_v != 0`
+- Final residue of node `u` is
+
+  `r_u = (a_u + sum of x_v over all ancestors v of u, including u) mod m`
+
+- For observatory `j`, let
+
+  `C_j = number of primes p in P such that there exists a node u in subtree(s_j) with r_u = p`
+
+- Its penalty is
+
+  `penalty_j = w_j * (|P| - C_j)`
+
+- Installing a retuner at node `v` costs `c_v`
+
+Your goal is to **minimize total penalty + total retuner cost**.
+
+## Input
+
+The input contains one test instance.
+
+- First line: four integers `n`, `m`, `t`, `k`
+  - `n` = number of nodes
+  - `m` = modulus
+  - `t` = number of observatories
+  - `k` = maximum number of retuners you may install
+- Second line: `n` integers `a_1, a_2, ..., a_n`
+- Third line: `n` integers `c_1, c_2, ..., c_n`
+- Next `n-1` lines: edges of the tree, each containing two integers `u`, `v`
+- Next `t` lines: observatories, each containing two integers `s_j`, `w_j`
+
+The tree is rooted at node `1`.
+
+## Output
+
+Output a feasible retuner placement.
+
+- First line: integer `q` — the number of installed retuners
+- Next `q` lines: two integers `v` and `d`
+  - `v` = node index
+  - `d` = shift, with `1 <= d < m`
+
+### Feasibility requirements
+
+Your output is feasible iff all of the following hold:
+
+- `0 <= q <= k`
+- all chosen nodes `v` are distinct
+- each shift satisfies `1 <= d < m`
+
+If the output is infeasible, the score for the test is `0`.
+
+## Objective
+
+Let `S` be the set of chosen retuners.
+
+The objective value is
+
+`F = sum over observatories j of [ w_j * (|P| - C_j) ] + sum over (v,d) in S of c_v`
+
+where `C_j` is the number of distinct prime residues from `P` appearing in the final residues of the subtree of `s_j`.
+
+You must **minimize `F`**.
+
+## Scoring
+
+For each test case, define the **baseline solution** as:
+
+- install no retuners
+
+Let its objective value be `F_base`.
+
+Your score for the test is:
+
+- if `F_base = 0`:
+  - score = `1,000,000` if `F = 0`
+  - score = `0` otherwise
+- else:
+
+  `score = floor(1,000,000 * max(0, (F_base - F) / F_base))`
+
+So:
+
+- matching the baseline gets score `0`
+- improving on the baseline gives a positive score
+- reaching objective `0` gets score `1,000,000`
+
+The final score is the average of test-case scores, rounded down to the nearest integer.
+
+## Constraints
+
+- `1 <= n <= 100000`
+- `3 <= m <= 1000`
+- `1 <= t <= 100000`
+- `0 <= a_i <= 10^9`
+- `1 <= c_i <= 10^9`
+- `1 <= w_j <= 10^9`
+- `1 <= k <= n`
+
+## Constraints
+- Time limit: 5 seconds
+- Memory limit: 512 MB
+
+## Example
+
+### Input
+```text
+5 10 3 3
+0 1 4 6 9
+5 2 2 1 1
+1 2
+1 3
+3 4
+3 5
+1 4
+3 3
+4 2
+```
+
+### Output
+```text
+1
+3 3
+```
+
+### Explanation
+
+Here `m = 10`, so the prime residues are `{2, 3, 5, 7}`.
+
+The single retuner `(3, 3)` adds `3` modulo `10` to nodes `3, 4, 5`.
+
+Final residues become:
+
+- node 1: `0`
+- node 2: `1`
+- node 3: `7`
+- node 4: `9`
+- node 5: `2`
+
+Observatory penalties:
+
+- subtree `1` contains prime residues `{2, 7}` → misses 2 primes → penalty `4 * 2 = 8`
+- subtree `3` contains prime residues `{2, 7}` → misses 2 primes → penalty `3 * 2 = 6`
+- subtree `4` contains no prime residue → misses 4 primes → penalty `2 * 4 = 8`
+
+Retuner cost: `c_3 = 2`
+
+So the objective is `F = 8 + 6 + 8 + 2 = 24`.
+
+With no retuners, the objective is `F_base = 36`, so this output improves over baseline.

--- a/examples/frontier_smith/5/task.yaml
+++ b/examples/frontier_smith/5/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #5: Prime Resonance Retuning'
+  description: |-
+    Solve algorithmic problem #5 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 5s per test case
+    - Uses at most 512MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 5s per test case. Memory limit: 512MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 340
+  direction: maximize
+  args:
+    problem_id: frontiersmith_5
+    problem_type: default
+    time_limit: 5
+    memory_mb: 512
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/5/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/6/seed/solution.cpp
+++ b/examples/frontier_smith/6/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/6/seed/statement.txt
+++ b/examples/frontier_smith/6/seed/statement.txt
@@ -1,0 +1,215 @@
+# Mobile Relay Layout
+
+## Problem
+
+A field-training area contains `N` fixed sensors. Sensor `j` is located at coordinates `(x_j, y_j)` and must upload `d_j` units of data to exactly one mobile relay hub.
+
+You may deploy up to `K` relay hubs. Each hub can be placed at any real-valued coordinate.
+
+If hub `i` is placed at `(X_i, Y_i)` and is assigned a non-empty set of sensors `S_i`, then:
+
+- its **squared service radius** is
+
+\[
+R_i^2 = \max_{j \in S_i} \left((X_i-x_j)^2 + (Y_i-y_j)^2\right)
+\]
+
+- its **load** is
+
+\[
+L_i = \sum_{j \in S_i} d_j
+\]
+
+- its **battery cost** is
+
+\[
+\text{cost}_i = P + A \cdot R_i^2 + B \cdot L_i^2
+\]
+
+where `P`, `A`, and `B` are given constants.
+
+Empty hubs are allowed in the output, but they contribute nothing and are ignored by the judge.
+
+Your task is to choose the number of hubs, their positions, and the assignment of every sensor so that the **total battery cost** is as small as possible.
+
+This is an optimization problem: every feasible output receives a score based on how good its total cost is.
+
+---
+
+## Input
+
+The input contains a single test case.
+
+- First line: two integers `N` and `K`
+- Second line: three real numbers `P`, `A`, and `B`
+- Next `N` lines: three real numbers `x_j`, `y_j`, and `d_j`
+
+### Meaning
+
+- `N`: number of sensors
+- `K`: maximum number of relay hubs you may deploy
+- `P`: fixed activation cost of each non-empty hub
+- `A`: coefficient for coverage radius cost
+- `B`: coefficient for load-balancing cost
+- `(x_j, y_j)`: position of sensor `j`
+- `d_j`: data amount of sensor `j`
+
+Sensors are numbered from `1` to `N` in input order.
+
+---
+
+## Output
+
+Your output must describe one feasible relay layout.
+
+- First line: one integer `M` — the number of hubs you output (`1 <= M <= K`)
+- Next `M` lines: two real numbers `X_i` and `Y_i` — the coordinates of hub `i`
+- Then output `N` integers `a_1, a_2, ..., a_N` (separated by arbitrary whitespace), where `a_j` is the hub index assigned to sensor `j`
+
+### Feasibility requirements
+
+Your output is **feasible** if and only if all of the following hold:
+
+1. `1 <= M <= K`
+2. Every printed hub coordinate is finite and satisfies `|X_i|, |Y_i| <= 10^9`
+3. For every sensor `j`, the assignment `a_j` is an integer in `[1, M]`
+
+If any requirement is violated, the submission is invalid and receives score `0` on that test.
+
+---
+
+## Objective
+
+For each hub `i`, let
+
+\[
+S_i = \{j \mid a_j = i\}
+\]
+
+If `S_i` is empty, hub `i` contributes `0`.
+
+Otherwise:
+
+\[
+R_i^2 = \max_{j \in S_i} \left((X_i-x_j)^2 + (Y_i-y_j)^2\right)
+\]
+
+\[
+L_i = \sum_{j \in S_i} d_j
+\]
+
+\[
+\text{cost}_i = P + A \cdot R_i^2 + B \cdot L_i^2
+\]
+
+The total objective value is
+
+\[
+C = \sum_{i=1}^{M} \text{cost}_i
+\]
+
+Your goal is to **minimize `C`**.
+
+The judge computes all values using `long double`.
+
+---
+
+## Scoring
+
+For each test, the judge also computes a deterministic **baseline** solution:
+
+1. Sort sensors by `(x_j, y_j, j)`.
+2. Split the sorted list into `K` consecutive blocks:
+   - block `t` contains indices from  
+     \[
+     \left\lfloor \frac{(t-1)N}{K} \right\rfloor + 1
+     \quad \text{to} \quad
+     \left\lfloor \frac{tN}{K} \right\rfloor
+     \]
+     in the sorted order, for `t = 1..K`
+3. Ignore empty blocks.
+4. For each non-empty block:
+   - create one hub at the arithmetic mean of the block's sensor coordinates
+   - assign every sensor in that block to that hub
+5. Let the baseline total cost be `C_base`
+
+If your solution has total cost `C`, then your per-test score is
+
+\[
+\text{score} = 10^6 \cdot \frac{C_{base}}{C_{base} + C}
+\]
+
+Properties:
+
+- If your solution matches the baseline exactly, you get `500000`
+- Better-than-baseline solutions get more than `500000`
+- Worse-than-baseline solutions get less than `500000`
+- Invalid outputs get `0`
+
+The final score is the arithmetic mean of per-test scores over all official tests.
+
+---
+
+## Constraints
+
+- `1 <= N <= 200000`
+- `1 <= K <= 100`
+- `0 < P, A, B <= 10^6`
+- `|x_j|, |y_j| <= 10^6`
+- `0 < d_j <= 10^6`
+
+## Constraints
+- Time limit: 4 seconds
+- Memory limit: 512 MB
+
+---
+
+## Example
+
+### Input
+```text
+6 2
+10 1 0.5
+0 0 2
+1 0 1
+0 1 1
+10 0 2
+10 1 1
+11 0 1
+```
+
+### Output
+```text
+2
+0.3333333333 0.3333333333
+10.3333333333 0.3333333333
+1 1 1 2 2 2
+```
+
+### Explanation
+
+The first hub serves sensors `1,2,3`, and the second serves `4,5,6`.
+
+For each hub:
+
+- load `L = 2+1+1 = 4`
+- squared radius  
+  \[
+  R^2 = \max\left(\frac{2}{9}, \frac{5}{9}, \frac{5}{9}\right) = \frac{5}{9}
+  \]
+- cost  
+  \[
+  10 + 1 \cdot \frac{5}{9} + 0.5 \cdot 4^2 = 18.555\ldots
+  \]
+
+So the total cost is approximately:
+
+\[
+C = 37.111\ldots
+\]
+
+For this instance, the deterministic baseline produces the same partition, so `C = C_base`, and the score is exactly:
+
+\[
+10^6 \cdot \frac{C_base}{C_base + C} = 500000
+\]

--- a/examples/frontier_smith/6/task.yaml
+++ b/examples/frontier_smith/6/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #6: Mobile Relay Layout'
+  description: |-
+    Solve algorithmic problem #6 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 4s per test case
+    - Uses at most 512MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 4s per test case. Memory limit: 512MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 340
+  direction: maximize
+  args:
+    problem_id: frontiersmith_6
+    problem_type: default
+    time_limit: 4
+    memory_mb: 512
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/6/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/7/seed/solution.cpp
+++ b/examples/frontier_smith/7/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/7/seed/statement.txt
+++ b/examples/frontier_smith/7/seed/statement.txt
@@ -1,0 +1,218 @@
+# Archipelago Relay Network Design
+
+## Problem
+The Republic of AtCoder consists of `L+1` islands aligned west-to-east, numbered `0` to `L`.
+
+For each `1 <= k <= L`, there is a bidirectional air route between islands `k-1` and `k`.
+Route `k` is operated by company `S_k`, which is either `A` or `J`.
+
+The government now wants to establish a **permanent cargo relay network** for daily shipments.
+
+There are `N` residents who may be hired as shuttle operators.
+
+- Resident `i` lives on island `X_i`.
+- They own a company coupon `C_i` (`A` or `J`).
+- Hiring them costs a fixed management fee `H_i`.
+- If hired, they can operate **one** bidirectional shuttle service between two islands `l_i < r_i` such that `r_i - l_i <= D_i`.
+
+A hired resident creates a direct bidirectional shuttle edge between `l_i` and `r_i`.
+
+### Coupon rule
+When a resident travels along a route owned by their coupon company, that route is free for them.
+Otherwise, it costs `1`.
+
+Therefore:
+
+- The **operating cost per unit cargo** of resident `i`'s shuttle `(l_i, r_i)` is the number of routes on the path from `l_i` to `r_i` whose owner is **not** `C_i`.
+- The **setup cost** of hiring resident `i` for shuttle `(l_i, r_i)` is
+
+`H_i + min(cost_i(X_i, l_i), cost_i(X_i, r_i))`
+
+where `cost_i(u, v)` is the number of routes on the path between islands `u` and `v` whose owner is **not** `C_i`.
+
+In addition to hired shuttles, the government may always use the original adjacent-island routes directly for cargo transport at cost `1` per unit cargo per route.
+
+---
+
+There are `M` daily cargo demands.
+
+Demand `j` requires shipping `W_j` units of cargo from island `A_j` to island `B_j` every day.
+
+For a fixed set of hired shuttles, each demand is transported independently along a **minimum-cost path** in the resulting graph:
+
+- vertices: islands `0..L`
+- always-available edges: `(k-1, k)` with cost `1`
+- hired shuttle edges: `(l_i, r_i)` with cost equal to that resident's operating cost
+
+The total daily cost is:
+
+- sum of setup costs of all hired residents
+- plus, for each demand, `W_j × (shortest path cost between A_j and B_j)`
+
+Your task is to output **any feasible relay design**. Better designs get better scores.
+
+## Input
+The input is given in the following format:
+
+```text
+L N M
+S
+X_1 C_1 H_1 D_1
+X_2 C_2 H_2 D_2
+...
+X_N C_N H_N D_N
+A_1 B_1 W_1
+A_2 B_2 W_2
+...
+A_M B_M W_M
+```
+
+- `S` is a string of length `L`
+- `S_k` is `A` or `J`, representing the owner of the route between islands `k-1` and `k`
+
+## Output
+Output exactly `N` lines.
+
+For each resident `i`, output one of the following:
+
+- `-1`  
+  meaning resident `i` is not hired
+
+- `l_i r_i`  
+  meaning resident `i` is hired to operate a shuttle between islands `l_i` and `r_i`
+
+### Feasibility requirements
+If resident `i` is hired, the following must hold:
+
+- `0 <= l_i < r_i <= L`
+- `r_i - l_i <= D_i`
+
+If any line is malformed or any hired resident violates these conditions, the output is infeasible.
+
+## Objective
+Minimize the total daily cost:
+
+```text
+TotalCost =
+(sum of setup costs of hired residents)
++ (sum over demands of W_j × shortest_path_cost(A_j, B_j))
+```
+
+### Definitions
+For resident `i`, let:
+
+- `bad_i(u, v)` = number of route indices `k` on the path between islands `u` and `v` such that `S_k != C_i`
+
+Then for a hired shuttle `(l_i, r_i)`:
+
+- setup cost = `H_i + min(bad_i(X_i, l_i), bad_i(X_i, r_i))`
+- shuttle edge cost = `bad_i(l_i, r_i)`
+
+The shortest path for each demand is computed in the graph consisting of:
+
+- adjacent-island edges `(k-1, k)` of cost `1`
+- all hired shuttle edges, bidirectional, with their shuttle edge costs
+
+## Scoring
+This is an optimization problem. Lower `TotalCost` is better.
+
+For each test file:
+
+- Let `B` be the baseline cost obtained by hiring nobody.  
+  Then all shipments use only adjacent-island routes, so
+
+```text
+B = sum over demands of W_j × |A_j - B_j|
+```
+
+- Let `U` be your output's `TotalCost`.
+
+If your output is infeasible, the score for that test file is `0`.
+
+Otherwise, the score is:
+
+```text
+Score = floor(10^9 × min(5, B / U))
+```
+
+- The baseline solution always scores exactly `10^9`.
+- Better-than-baseline solutions score more than `10^9`.
+- Scores are capped at `5 × 10^9` per test file.
+
+The final score is the sum of scores over all test files.
+
+## Constraints
+- `1 <= L <= 5000`
+- `1 <= N <= 5000`
+- `1 <= M <= 20000`
+- `S_k` is `A` or `J`
+- `0 <= X_i <= L`
+- `C_i` is `A` or `J`
+- `0 <= H_i <= 10^9`
+- `1 <= D_i <= L`
+- `0 <= A_j, B_j <= L`
+- `A_j != B_j`
+- `1 <= W_j <= 10^6`
+
+## Constraints
+- Time limit: 5 seconds
+- Memory limit: 1024 MB
+
+## Example
+### Sample Input
+```text
+6 3 3
+AAJJAJ
+0 A 1 3
+6 J 1 3
+3 A 4 6
+0 6 10
+1 5 4
+2 4 5
+```
+
+### Sample Output
+```text
+0 3
+3 6
+-1
+```
+
+### Explanation
+- Resident 1 operates shuttle `(0, 3)`.
+  - Path owner string: `AAJ`
+  - With coupon `A`, the shuttle edge cost is `1`
+  - Setup cost is `1 + min(0, 1) = 1`
+
+- Resident 2 operates shuttle `(3, 6)`.
+  - Path owner string: `JAJ`
+  - With coupon `J`, the shuttle edge cost is `1`
+  - Setup cost is `1 + min(1, 0) = 1`
+
+- Resident 3 is not hired.
+
+So the fixed setup cost is `2`.
+
+The resulting graph has:
+- normal edges of cost `1` between consecutive islands
+- shuttle edges `(0,3)` and `(3,6)`, each of cost `1`
+
+Demand costs:
+- `0 -> 6`, volume `10`: shortest path cost `2`, contributes `20`
+- `1 -> 5`, volume `4`: shortest path cost `4`, contributes `16`
+- `2 -> 4`, volume `5`: shortest path cost `2`, contributes `10`
+
+Total cost:
+```text
+2 + 20 + 16 + 10 = 48
+```
+
+Baseline cost:
+```text
+10×6 + 4×4 + 5×2 = 86
+```
+
+Score for this test file:
+```text
+floor(10^9 × 86 / 48) = 1791666666
+```

--- a/examples/frontier_smith/7/task.yaml
+++ b/examples/frontier_smith/7/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #7: Archipelago Relay Network Design'
+  description: |-
+    Solve algorithmic problem #7 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 5s per test case
+    - Uses at most 1024MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 5s per test case. Memory limit: 1024MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 340
+  direction: maximize
+  args:
+    problem_id: frontiersmith_7
+    problem_type: default
+    time_limit: 5
+    memory_mb: 1024
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/7/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/8/seed/solution.cpp
+++ b/examples/frontier_smith/8/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/8/seed/statement.txt
+++ b/examples/frontier_smith/8/seed/statement.txt
@@ -1,0 +1,188 @@
+# Resonant Bay Layout
+
+## Problem
+
+A research lab wants to place `n` oscillators on a long straight rail with numbered bays `0, 1, ..., m-1`.
+
+Oscillator `i` has an intrinsic phase ratio `p_i / q_i`. Some pairs of oscillators are connected by coupling channels. If oscillators `u` and `v` are placed `d = |x_u - x_v|` bays apart, then channel `(u, v)` produces energy
+
+\[
+E_{u,v}(d)
+=
+w_{u,v}
+\cdot
+\left|\sin\left(\pi \frac{p_u}{q_u} d\right)\right|
+\cdot
+\left|\sin\left(\pi \frac{p_v}{q_v} d\right)\right|.
+\]
+
+You must assign every oscillator to a **distinct integer bay**. Your goal is to maximize the total produced energy over all channels.
+
+This is an **optimization challenge**: any feasible output is accepted, and better layouts receive better scores.
+
+## Input
+
+The first line contains an integer `t` — the number of test cases.
+
+For each test case:
+
+- The first line contains three integers `n`, `m`, and `r`:
+  - `n` — number of oscillators
+  - `m` — number of bays
+  - `r` — number of coupling channels
+- The next `n` lines each contain two integers `p_i` and `q_i`.
+- The next `r` lines each contain three integers `u`, `v`, and `w` describing a channel between oscillators `u` and `v` with weight `w`.
+
+Oscillators are numbered from `1` to `n`.
+
+There are no self-loops and no repeated channels.
+
+## Output
+
+For each test case, output one line containing `n` integers:
+
+\[
+x_1, x_2, \dots, x_n
+\]
+
+where `x_i` is the bay chosen for oscillator `i`.
+
+A solution is **feasible** for a test case if and only if:
+
+- `0 <= x_i < m` for all `i`
+- all `x_i` are pairwise distinct
+
+If a test case output is infeasible, its objective value is defined as `0`.
+
+## Objective
+
+For a feasible layout, let
+
+\[
+d_{u,v} = |x_u - x_v|.
+\]
+
+The total energy is
+
+\[
+F
+=
+\sum_{(u,v)\in \text{channels}}
+w_{u,v}
+\cdot
+\left|\sin\left(\pi \frac{p_u}{q_u} d_{u,v}\right)\right|
+\cdot
+\left|\sin\left(\pi \frac{p_v}{q_v} d_{u,v}\right)\right|.
+\]
+
+You must **maximize** `F`.
+
+### Judge computation details
+
+For each factor, the judge may reduce the angle using periodicity before evaluating sine:
+
+\[
+\sin\left(\pi \frac{p_i}{q_i} d\right)
+=
+\sin\left(\pi \frac{(p_i d \bmod 2q_i)}{q_i}\right).
+\]
+
+This is mathematically equivalent and avoids large angles.
+
+## Scoring
+
+For each test case, a deterministic **baseline layout** is defined as follows:
+
+1. Compute the weighted degree of each oscillator:
+   \[
+   \deg(i) = \sum_{(i,j)\in \text{channels}} w_{i,j}.
+   \]
+2. Sort oscillators by decreasing `deg(i)`, breaking ties by smaller index.
+3. Define baseline bays:
+   - if `n = 1`, the only bay is `0`
+   - otherwise, for `k = 0, 1, ..., n-1`:
+     \[
+     b_k = \left\lfloor \frac{k(m-1)}{n-1} \right\rfloor
+     \]
+4. Assign the `k`-th oscillator in the sorted order to bay `b_k`.
+
+Let `B` be the objective value of this baseline layout, and let `F` be the objective value of your output.
+
+The score for that test case is
+
+\[
+S
+=
+10^6
+\cdot
+\operatorname{clamp}\left(
+\frac{F+1}{B+1},
+0,
+2
+\right),
+\]
+
+where
+
+\[
+\operatorname{clamp}(x,0,2)=
+\begin{cases}
+0 & x<0\\
+x & 0\le x\le 2\\
+2 & x>2
+\end{cases}
+\]
+
+The score of an input file is the arithmetic mean of its test case scores.
+
+Higher is better.
+
+## Constraints
+
+- `1 <= t <= 20`
+- `2 <= n <= 400`
+- `n <= m <= 10^9`
+- `1 <= r <= min(30000, n(n-1)/2)`
+- `1 <= p_i, q_i <= 10^9`
+- `1 <= w <= 10^6`
+
+Across one input file:
+
+- `sum(n) <= 4000`
+- `sum(r) <= 120000`
+
+- Time limit: 8 seconds
+- Memory limit: 512 MB
+
+## Example
+
+### Input
+```text
+1
+4 7 4
+1 2
+1 3
+2 5
+1 4
+1 2 10
+1 3 7
+2 4 8
+3 4 6
+```
+
+### Output
+```text
+0 3 5 1
+```
+
+### Explanation
+This places the 4 oscillators in distinct bays:
+
+- oscillator 1 at bay 0
+- oscillator 2 at bay 3
+- oscillator 3 at bay 5
+- oscillator 4 at bay 1
+
+For each channel, the judge computes the bay distance, evaluates the two sine factors, multiplies by the channel weight, and sums the results.
+
+The baseline layout is built from weighted-degree order and evenly spaced bays. Your score depends continuously on how your total energy compares to that baseline.

--- a/examples/frontier_smith/8/task.yaml
+++ b/examples/frontier_smith/8/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #8: Resonant Bay Layout'
+  description: |-
+    Solve algorithmic problem #8 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 8s per test case
+    - Uses at most 512MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 8s per test case. Memory limit: 512MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 380
+  direction: maximize
+  args:
+    problem_id: frontiersmith_8
+    problem_type: default
+    time_limit: 8
+    memory_mb: 512
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/8/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/9/seed/solution.cpp
+++ b/examples/frontier_smith/9/seed/solution.cpp
@@ -1,0 +1,12 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    // TODO: Read the problem statement in statement.txt
+    // Read input from stdin, write output to stdout
+
+    return 0;
+}

--- a/examples/frontier_smith/9/seed/statement.txt
+++ b/examples/frontier_smith/9/seed/statement.txt
@@ -1,0 +1,156 @@
+# Duff's Defensive Lineup
+
+## Problem
+
+Duff has `n` friends. The `i`-th friend has name `s_i` (names are not necessarily unique).
+
+Before asking Malek to collect candies, Duff may reorder her friends into a single queue. Let the final order be a permutation `p` of `1..n`, where friend `p_1` stands first, friend `p_2` stands second, and so on.
+
+Duff then issues `q` complaints. Each complaint is described by three integers `l`, `r`, and `k`.
+
+For one complaint `(l, r, k)`:
+
+- Duff looks at every **adjacent pair of seats** `(i, i+1)` such that `l <= i < r`.
+- For each such pair, she forms the merged badge string  
+  `s_{p_i} + s_{p_{i+1}}`  
+  (plain concatenation, with **no separator**).
+- Malek must pay  
+  `occur(s_k, s_{p_i} + s_{p_{i+1}})`  
+  candies for that pair, where `occur(t, x)` is the number of occurrences of string `t` as a contiguous substring of `x`. Overlapping occurrences count.
+
+Your task is to output **any permutation** of the friends. Better permutations lead to fewer total candies.
+
+This is an optimization problem: the judge will compute the total candies for your permutation.
+
+---
+
+## Input
+
+The input contains a single test case.
+
+- The first line contains two integers `n` and `q`.
+- The next `n` lines contain the names `s_1, s_2, ..., s_n`.
+- The next `q` lines each contain three integers `l`, `r`, and `k`, describing one complaint.
+
+---
+
+## Output
+
+Print one line containing a permutation of `1..n`:
+
+`p_1 p_2 ... p_n`
+
+### Feasibility requirements
+
+Your output is **feasible** if and only if:
+
+- it contains exactly `n` integers,
+- each integer is between `1` and `n`,
+- every value from `1` to `n` appears exactly once.
+
+If the output is infeasible, the score for that test file is `0`.
+
+---
+
+## Objective
+
+For a feasible permutation `p`, define its total candy cost as
+
+\[
+C(p)=\sum_{j=1}^{q}\ \sum_{i=l_j}^{r_j-1} occur\big(s_{k_j},\ s_{p_i}s_{p_{i+1}}\big),
+\]
+
+where `(l_j, r_j, k_j)` is the `j`-th complaint.
+
+Your goal is to **minimize** `C(p)`.
+
+---
+
+## Scoring
+
+Let:
+
+- `Y` = your total candy cost,
+- `B` = the total candy cost of the **baseline permutation**  
+  `p = [1, 2, ..., n]`.
+
+For each test file, your score is
+
+\[
+\text{score} = 1000 \times \min\left(2,\ \frac{B+1}{Y+1}\right).
+\]
+
+### Notes
+
+- The `+1` avoids division-by-zero corner cases.
+- The baseline permutation always scores exactly `1000`.
+- Better-than-baseline solutions score more than `1000`, up to a maximum of `2000`.
+- Worse solutions score less than `1000`.
+- The final contest score is the arithmetic mean of the scores over all test files.
+
+---
+
+## Constraints
+
+- `1 <= n <= 2000`
+- `1 <= q <= 200000`
+- `1 <= |s_i| <= 40`
+- All names consist only of lowercase English letters.
+- `1 <= l < r <= n`
+- `1 <= k <= n`
+- The sum of all `|s_i|` does not exceed `100000`.
+
+- Time limit: 5 seconds
+- Memory limit: 512 MB
+
+---
+
+## Example
+
+### Input
+```text
+4 3
+a
+ba
+ab
+b
+1 4 1
+2 4 2
+1 3 3
+```
+
+### Output
+```text
+2 4 1 3
+```
+
+### Explanation
+
+The output permutation is `[2, 4, 1, 3]`, so the adjacent merged strings are:
+
+- seats `(1,2)`: `s_2 + s_4 = "ba" + "b" = "bab"`
+- seats `(2,3)`: `s_4 + s_1 = "b" + "a" = "ba"`
+- seats `(3,4)`: `s_1 + s_3 = "a" + "ab" = "aab"`
+
+Now evaluate the complaints:
+
+1. `(1, 4, 1)` uses target `s_1 = "a"` on all three adjacent pairs  
+   `occur("a","bab") + occur("a","ba") + occur("a","aab") = 1 + 1 + 2 = 4`
+
+2. `(2, 4, 2)` uses target `s_2 = "ba"` on pairs `(2,3)` and `(3,4)`  
+   `occur("ba","ba") + occur("ba","aab") = 1 + 0 = 1`
+
+3. `(1, 3, 3)` uses target `s_3 = "ab"` on pairs `(1,2)` and `(2,3)`  
+   `occur("ab","bab") + occur("ab","ba") = 1 + 0 = 1`
+
+So the submitted cost is `Y = 4 + 1 + 1 = 6`.
+
+For the baseline permutation `[1,2,3,4]`, the cost is `B = 8`, so this submission would score
+
+\[
+1000 \times \min\left(2,\frac{8+1}{6+1}\right)
+= 1000 \times \frac{9}{7}
+\approx 1285.714.
+\]
+
+Any feasible permutation is accepted; lower total cost gives a better score.

--- a/examples/frontier_smith/9/task.yaml
+++ b/examples/frontier_smith/9/task.yaml
@@ -1,0 +1,51 @@
+task:
+  name: 'Frontier-Smith #9: Duff''s Defensive Lineup'
+  description: |-
+    Solve algorithmic problem #9 from the Frontier-Smith benchmark.
+    Read the problem statement in `statement.txt`, then write a C++17 solution
+    and save it as `solution.cpp`.
+
+    ## Solution format
+
+    Your solution must be a self-contained C++17 file that:
+    - Reads input from stdin
+    - Writes output to stdout
+    - Compiles with `g++ -std=c++17 -O2`
+    - Runs within the time limit of 5s per test case
+    - Uses at most 512MB of memory
+
+    ## Strategy tips
+
+    - Start with a correct brute-force, then optimize.
+    - Many problems reward heuristics: simulated annealing, beam search, greedy + local search.
+    - Check the scoring formula in the statement — some problems score relative to a baseline.
+    - Test your solution locally before submitting.
+  tips: |-
+    - Your score is 0-100 based on solution quality across 10 test cases.
+    - Invalid or crashing solutions score 0.
+    - Time limit: 5s per test case. Memory limit: 512MB.
+    - The problem statement is in statement.txt.
+grader:
+  entrypoint: frontier_smith_grader.grader:Grader
+  setup:
+  - uv pip install -e ../grader
+  timeout: 340
+  direction: maximize
+  args:
+    problem_id: frontiersmith_9
+    problem_type: default
+    time_limit: 5
+    memory_mb: 512
+    n_cases: 10
+agents:
+  count: 1
+  runtime: claude_code
+  model: claude-sonnet-4-6
+  max_turns: 200
+workspace:
+  results_dir: ./results
+  repo_path: ./examples/frontier_smith/9/seed
+run:
+  verbose: false
+  ui: false
+  session: tmux

--- a/examples/frontier_smith/README.md
+++ b/examples/frontier_smith/README.md
@@ -1,0 +1,123 @@
+# Frontier-Smith
+
+Ten synthetic, open-ended algorithmic problems sourced from
+[FrontierCS/FrontierSmith][upstream]. Each problem is wrapped as a CORAL task
+so agents can iterate on a C++17 `solution.cpp` against a sandboxed judge.
+
+[upstream]: https://github.com/FrontierCS/FrontierSmith
+
+## What's in here
+
+| # | Title | Time | Memory |
+|---|---|---|---|
+| 1 | Scorched Bridges Campaign | 8s | 512MB |
+| 2 | Farmwide Teleport Pad Deployment | 4s | 1024MB |
+| 3 | Metallic Pink Resonator Layout | 8s | 1024MB |
+| 4 | Park Ranger Shift Balancing | 5s | 512MB |
+| 5 | Prime Resonance Retuning | 5s | 512MB |
+| 6 | Mobile Relay Layout | 4s | 512MB |
+| 7 | Archipelago Relay Network Design | 5s | 1024MB |
+| 8 | Resonant Bay Layout | 8s | 512MB |
+| 9 | Duff's Defensive Lineup | 5s | 512MB |
+| 10 | Quadratic Witness Packing | 4s | 512MB |
+
+Each problem is open-ended — solutions are scored 0–100 by a custom checker
+against 10 test cases, with higher being better. Brute force is rarely
+sufficient; heuristic search (simulated annealing, golden-section, beam
+search, problem-specific structure) is the expected path.
+
+## Layout
+
+```
+examples/frontier_smith/
+├── README.md
+├── grader/                              # one shared grader package
+│   ├── pyproject.toml
+│   └── src/frontier_smith_grader/
+│       ├── __init__.py
+│       └── grader.py                    # delegates to frontier_cs.SingleEvaluator
+└── <N>/                                 # N = 1..10
+    ├── task.yaml                        # grader.entrypoint + grader.args.problem_id
+    └── seed/
+        ├── statement.txt                # problem statement
+        └── solution.cpp                 # empty starter
+```
+
+All ten `task.yaml` files share the same `grader.entrypoint`
+(`frontier_smith_grader.grader:Grader`) and differ only in
+`grader.args.problem_id` (`frontiersmith_1` .. `frontiersmith_10`) and the
+per-problem limits surfaced from FrontierSmith's `config.yaml`.
+
+## How evaluation works
+
+The grader compiles the agent's `solution.cpp` and submits it to a
+[go-judge][go-judge] server via the `frontier_cs` Python package's
+`SingleEvaluator`. The judge runs the solution on the FrontierSmith test
+cases and applies each problem's custom C++ checker.
+
+The `frontier_cs` package is declared as a git dependency in
+`grader/pyproject.toml`, so it gets pulled into the grader venv
+automatically when `uv pip install -e ../grader` runs during
+`coral start`. No separate clone is required for the Python side.
+
+The **judge server**, however, still has to be running locally and aware
+of these problems. Set `PROBLEMS_DIR` to FrontierSmith's
+`Frontier-CS/algorithmic/problems/` directory before bringing the judge
+up with `docker compose up -d`.
+
+[go-judge]: https://github.com/criyle/go-judge
+
+## Setup
+
+Clone FrontierSmith and Frontier-CS somewhere alongside this repo (you
+need both: FrontierSmith for the problem statements/test data, and
+Frontier-CS for the docker-compose file that runs the judge):
+
+```bash
+git clone https://github.com/FrontierCS/FrontierSmith ../FrontierSmith
+git clone https://github.com/FrontierCS/Frontier-CS    ../Frontier-CS
+```
+
+Start the judge with FrontierSmith's problems mounted:
+
+```bash
+cd ../Frontier-CS/algorithmic
+PROBLEMS_DIR=$(realpath ../../FrontierSmith/Frontier-CS/algorithmic/problems) \
+  docker compose up -d
+```
+
+The grader also needs to point `frontier_cs` at the same Frontier-CS
+checkout (it auto-detects when run from a source checkout, but inside
+CORAL's grader venv that detection fails). Export `FRONTIER_CS_BASE_DIR`
+once in the shell that launches `coral start`:
+
+```bash
+export FRONTIER_CS_BASE_DIR=$(realpath ../Frontier-CS)
+```
+
+If `FRONTIER_CS_BASE_DIR` is unset the grader falls back to looking for a
+`Frontier-CS/` directory next to the CORAL repo, so the default sibling
+layout above works out of the box.
+
+Then validate and run as usual:
+
+```bash
+coral validate examples/frontier_smith/1
+coral start    -c examples/frontier_smith/1/task.yaml
+```
+
+## Attribution
+
+Problem statements, test data, and checkers (`chk.cc`) are authored by the
+FrontierSmith team and live in
+[`Frontier-CS/algorithmic/problems/frontiersmith_{1..10}/`][upstream-problems]
+of the upstream repository. The FrontierSmith README notes these correspond
+to problems 306–315 in the main Frontier-CS benchmark.
+
+The upstream repository does not declare a license file as of this writing.
+Treat the bundled `statement.txt` files (the only upstream artifacts copied
+into this directory) as belonging to the FrontierSmith authors; this
+wrapper code (`task.yaml`, `grader/`) is part of CORAL and follows CORAL's
+Apache-2.0 license.
+
+[upstream-problems]: https://github.com/FrontierCS/FrontierSmith/tree/main/Frontier-CS/algorithmic/problems

--- a/examples/frontier_smith/grader/pyproject.toml
+++ b/examples/frontier_smith/grader/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "frontier-smith-grader"
+version = "0.1.0"
+description = "CORAL grader for the Frontier-Smith algorithmic tasks (frontiersmith_1 .. frontiersmith_10)."
+requires-python = ">=3.11"
+dependencies = [
+    "coral",
+    "frontier-cs @ git+https://github.com/FrontierCS/Frontier-CS.git",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/frontier_smith_grader"]

--- a/examples/frontier_smith/grader/src/frontier_smith_grader/__init__.py
+++ b/examples/frontier_smith/grader/src/frontier_smith_grader/__init__.py
@@ -1,0 +1,5 @@
+"""Frontier-Smith grader (entrypoint: frontier_smith_grader.grader:Grader)."""
+
+from .grader import Grader
+
+__all__ = ["Grader"]

--- a/examples/frontier_smith/grader/src/frontier_smith_grader/grader.py
+++ b/examples/frontier_smith/grader/src/frontier_smith_grader/grader.py
@@ -1,0 +1,102 @@
+"""Frontier-Smith algorithmic grader.
+
+Delegates evaluation to the ``frontier_cs`` package's ``SingleEvaluator``,
+which compiles the agent's C++ solution, runs it against the problem's
+test cases inside the go-judge sandbox, and reports a 0-100 score.
+
+The 10 Frontier-Smith problems (``frontiersmith_1`` .. ``frontiersmith_10``)
+live in the FrontierSmith repository under
+``Frontier-CS/algorithmic/problems/``. The judge server resolves a
+``problem_id`` against its ``PROBLEMS_DIR``; point that env var at the
+FrontierSmith problems directory before starting the judge (see the README
+in ``examples/frontier_smith/``) and pass the matching ``problem_id`` via
+``grader.args`` in each task's ``task.yaml``.
+
+``frontier_cs.SingleEvaluator`` insists on a ``base_dir`` that contains an
+``algorithmic/`` directory; it normally auto-detects this from its own
+install path, but that fails when the package is installed into a venv
+(``site-packages/frontier_cs`` has no ``algorithmic/`` sibling). Set
+``FRONTIER_CS_BASE_DIR`` to your local Frontier-CS clone (the same one
+running ``docker compose``) so the evaluator skips auto-detection. The
+directory's only role here is satisfying the validator and locating the
+docker-compose file if the judge needs (re)starting; submissions go over
+HTTP to ``judge_url``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from coral.grader import TaskGrader
+from coral.types import ScoreBundle
+
+
+def _resolve_base_dir() -> Path:
+    """Return a Path that has an ``algorithmic/`` child, satisfying frontier_cs.
+
+    Order: ``FRONTIER_CS_BASE_DIR`` env var, then a small set of common
+    sibling-clone locations relative to this repo. We don't fabricate a
+    stub: if the runner ever needs to fall back to ``docker compose``,
+    pointing it at a fake directory would mask a real misconfiguration.
+    """
+    candidates: list[Path] = []
+    env = os.environ.get("FRONTIER_CS_BASE_DIR")
+    if env:
+        candidates.append(Path(env).expanduser())
+
+    here = Path(__file__).resolve()
+    # examples/frontier_smith/grader/src/frontier_smith_grader/grader.py
+    # → walk up to the directory holding the CORAL repo and look for siblings.
+    for parent in here.parents:
+        candidates.append(parent / "Frontier-CS")
+        if parent.name == "CORAL":
+            candidates.append(parent.parent / "Frontier-CS")
+            break
+
+    for candidate in candidates:
+        if (candidate / "algorithmic").is_dir():
+            return candidate
+
+    raise RuntimeError(
+        "Could not locate a Frontier-CS checkout. Set FRONTIER_CS_BASE_DIR to "
+        "the directory containing 'algorithmic/' (the same checkout running "
+        "the judge via docker compose). Searched: "
+        + ", ".join(str(c) for c in candidates)
+    )
+
+
+class Grader(TaskGrader):
+    """Grader for a single Frontier-Smith algorithmic problem."""
+
+    def evaluate(self) -> ScoreBundle:
+        problem_id = self.args.get("problem_id")
+        if not problem_id:
+            return self.fail("grader arg 'problem_id' is required")
+
+        solution_path = Path(self.codebase_path) / "solution.cpp"
+        if not solution_path.exists():
+            return self.score(0.0, feedback="No solution.cpp found in workspace.")
+
+        code = solution_path.read_text()
+        if not code.strip():
+            return self.score(0.0, feedback="solution.cpp is empty.")
+
+        from frontier_cs import SingleEvaluator
+
+        try:
+            base_dir = _resolve_base_dir()
+        except RuntimeError as exc:
+            return self.fail(str(exc))
+
+        evaluator = SingleEvaluator(base_dir=base_dir, register_cleanup=False)
+        result = evaluator.evaluate(
+            "algorithmic", problem_id=problem_id, code=code,
+        )
+
+        if not result.success:
+            msg = result.message or "Evaluation failed"
+            return self.score(0.0, feedback=msg)
+
+        score = result.score if result.score is not None else 0.0
+        return self.score(score, feedback=f"Score: {score:.2f}/100")


### PR DESCRIPTION
## Summary
- Adds the 10 Frontier-Smith algorithmic problems (`frontiersmith_1`..`10`) from [FrontierCS/FrontierSmith](https://github.com/FrontierCS/FrontierSmith) as CORAL tasks under `examples/frontier_smith/<N>/`. Each task has its own `task.yaml` + `seed/` (problem `statement.txt` + empty starter `solution.cpp`).
- One shared grader package at `examples/frontier_smith/grader/` delegates to `frontier_cs.SingleEvaluator`, which submits the agent's compiled C++ to a locally-running go-judge server and reports a 0–100 score.
- The grader resolves Frontier-CS's `base_dir` from `FRONTIER_CS_BASE_DIR` (or a sibling clone next to the CORAL repo). Without this, `frontier_cs`'s auto-detection walks 3 levels up from its install path, lands inside the grader venv's `site-packages`, finds no `algorithmic/` directory, and crashes with `RuntimeError: algorithmic/ not found in …`. The `examples/frontier_smith/README.md` documents the setup (`PROBLEMS_DIR` for the judge, `FRONTIER_CS_BASE_DIR` for the grader).

## Test plan
- [x] `uv run coral validate examples/frontier_smith/1` → `Validation: OK`, grader runs end-to-end against the empty seed and returns Score: 0.
- [ ] With the judge running (`docker compose up -d` in `Frontier-CS/algorithmic/` with `PROBLEMS_DIR` pointing at the FrontierSmith problems) and `FRONTIER_CS_BASE_DIR` exported, run `coral start -c examples/frontier_smith/1/task.yaml` and verify a real submission gets a numeric score back.
- [ ] Spot-check 1–2 other problem dirs (e.g. `5`, `10`) to confirm the shared grader handles different `problem_id`s and per-problem time/memory limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)