### PR TITLE
feat(agent): allow custom runtime via `module.path:ClassName` entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 ### 🔥 News
 
 - **[2026-04-24]** Rubric judges — two reusable LLM-judge grader packages for open-ended tasks (reports, memos, legal analysis). See the [Rubric Judges guide](https://docs.coralxyz.com/guides/rubric-judge).
-- [Older news →](https://docs.coralxyz.com/blog)
+- **[2026-04-03]** Our paper, "CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery," is now out! Check it out on [Arxiv](https://arxiv.org/abs/2604.01658v1).
+- **[2026-03-18]** CORAL is released! Check out our [blog post](https://human-agent-society.github.io/CORAL/).
 
 ![CORAL demo — autonomous AI coding agents running in parallel git worktrees, sharing knowledge through a common state directory](assets/demo.gif)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -31,7 +31,8 @@
 ### 🔥 News
 
 - **[2026-04-24]** 新增 Rubric 评审 —— 两个开箱即用的 LLM 评审 grader 包，专为开放式任务（报告、备忘、法律分析）设计。详见 [Rubric Judges 文档](https://docs.coralxyz.com/guides/rubric-judge)。
-- [更多历史动态 →](https://docs.coralxyz.com/blog)
+- **[2026-04-03]** 我们的论文 "CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery" 现已发布！请查看 [Arxiv](https://arxiv.org/abs/2604.01658v1)。
+- **[2026-03-18]** CORAL 正式发布！点击查看 [Blog](https://human-agent-society.github.io/CORAL/)。
 
 ![CORAL 多 Agent 自主编程演示 —— 多个编程 Agent 在独立 git worktree 中并行运行,通过共享状态目录交换知识](assets/demo.gif)
 

--- a/coral/agent/registry.py
+++ b/coral/agent/registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 from coral.agent.builtin.claude_code import ClaudeCodeRuntime
 from coral.agent.builtin.codex import CodexRuntime
 from coral.agent.builtin.cursor_agent import CursorAgentRuntime
@@ -39,24 +41,72 @@ _DEFAULT_MODELS: dict[str, str] = {
 }
 
 
+def _is_entrypoint(name: str) -> bool:
+    return ":" in name
+
+
+def _load_entrypoint(spec: str) -> type:
+    """Resolve 'module.path:ClassName' and verify it satisfies AgentRuntime."""
+    if spec.count(":") != 1:
+        raise ValueError(f"Custom runtime entrypoint must be 'module.path:ClassName', got {spec!r}")
+    mod_path, cls_name = spec.split(":", 1)
+    if not mod_path or not cls_name:
+        raise ValueError(f"Custom runtime entrypoint must be 'module.path:ClassName', got {spec!r}")
+    try:
+        module = importlib.import_module(mod_path)
+    except ImportError as e:
+        raise ImportError(
+            f"Failed to import custom runtime module {mod_path!r}: {e}. "
+            f"Install the package in the same environment as `coral` (e.g. `uv pip install -e .`)."
+        ) from e
+    try:
+        cls = getattr(module, cls_name)
+    except AttributeError as e:
+        raise AttributeError(f"Module {mod_path!r} has no attribute {cls_name!r}") from e
+    try:
+        instance = cls()
+    except Exception as e:
+        raise TypeError(
+            f"Custom runtime {spec} could not be instantiated with no arguments: {e}"
+        ) from e
+    if not isinstance(instance, AgentRuntime):
+        raise TypeError(
+            f"Custom runtime {spec} does not satisfy the AgentRuntime protocol "
+            f"(see coral/agent/runtime.py for the required methods)."
+        )
+    return cls
+
+
 def get_runtime(name: str) -> AgentRuntime:
     """Get a runtime instance by name.
 
-    Supports canonical names (claude_code, codex, opencode) and aliases.
+    Supports canonical names (claude_code, codex, opencode), aliases, and
+    custom entrypoints of the form 'module.path:ClassName' — the entrypoint
+    is imported on first use and cached in `_RUNTIMES`.
     """
     canonical = _ALIASES.get(name, name)
     cls = _RUNTIMES.get(canonical)
+    if cls is None and _is_entrypoint(canonical):
+        cls = _load_entrypoint(canonical)
+        _RUNTIMES[canonical] = cls
     if cls is None:
         available = sorted(set(list(_RUNTIMES.keys()) + list(_ALIASES.keys())))
         raise ValueError(
-            f"Unknown runtime {name!r}. Available: {', '.join(available)}"
+            f"Unknown runtime {name!r}. Available: {', '.join(available)}. "
+            f"For a custom runtime, set agents.runtime = 'module.path:ClassName'."
         )
     return cls()
 
 
 def default_model_for_runtime(name: str) -> str | None:
-    """Return the default model for a runtime, or None if unknown."""
+    """Return the default model for a runtime, or None if unknown.
+
+    Returns None for custom entrypoint runtimes — users must set
+    `agents.model` explicitly when wiring their own runtime.
+    """
     canonical = _ALIASES.get(name, name)
+    if _is_entrypoint(canonical):
+        return None
     return _DEFAULT_MODELS.get(canonical)
 
 

--- a/coral/cli/author.py
+++ b/coral/cli/author.py
@@ -63,7 +63,7 @@ def cmd_init(args: argparse.Namespace) -> None:
         f"  description: |\n"
         f"    Describe your task here. Agents read this verbatim from CORAL.md.\n"
         f"    Reference the program file by name (solution.py) and describe what\n"
-        f"    it must do — e.g. \"solution.py must print a single float to stdout\".\n"
+        f'    it must do — e.g. "solution.py must print a single float to stdout".\n'
         f"\n"
         f"grader:\n"
         f'  entrypoint: "{module_name}.grader:Grader"\n'
@@ -76,7 +76,7 @@ def cmd_init(args: argparse.Namespace) -> None:
         f"\n"
         f"agents:\n"
         f"  count: 1\n"
-        f"  runtime: claude_code         # claude_code | codex | cursor | kiro | opencode\n"
+        f"  runtime: claude_code         # claude_code | codex | cursor | kiro | opencode | 'pkg.module:Cls' for a custom runtime\n"
         f"\n"
         f"workspace:\n"
         f'  repo_path: "./seed"          # relative to where you run `coral start`\n'

--- a/coral/config.py
+++ b/coral/config.py
@@ -322,8 +322,14 @@ def _preprocess(data: dict[str, Any]) -> dict[str, Any]:
         specified = {h["name"] for h in heartbeat_raw}
         for dflt in AgentConfig().heartbeat:
             if dflt.name not in specified:
-                heartbeat_raw.append({"name": dflt.name, "every": dflt.every,
-                                      "global": dflt.is_global, "trigger": dflt.trigger})
+                heartbeat_raw.append(
+                    {
+                        "name": dflt.name,
+                        "every": dflt.every,
+                        "global": dflt.is_global,
+                        "trigger": dflt.trigger,
+                    }
+                )
         agents_data["heartbeat"] = [
             {
                 "name": h["name"],
@@ -348,13 +354,22 @@ def _preprocess(data: dict[str, Any]) -> dict[str, Any]:
             },
         ]
 
-    # If runtime is set but model is not, use the runtime-specific default
+    # If runtime is set but model is not, use the runtime-specific default.
+    # Custom-entrypoint runtimes ('module.path:ClassName') have no default —
+    # require the user to set agents.model explicitly so a footgun like the
+    # builtin "sonnet" default doesn't silently land on a foreign runtime.
     if "runtime" in agents_data and "model" not in agents_data:
         from coral.agent.registry import default_model_for_runtime
 
-        default_model = default_model_for_runtime(agents_data["runtime"])
+        rt = agents_data["runtime"]
+        default_model = default_model_for_runtime(rt)
         if default_model:
             agents_data["model"] = default_model
+        elif isinstance(rt, str) and ":" in rt:
+            raise ValueError(
+                f"agents.runtime={rt!r} is a custom runtime entrypoint; "
+                f"set agents.model explicitly in task.yaml."
+            )
 
     # Normalize assignments: fill in missing model defaults from the assignment's
     # runtime so each entry stores a concrete model. Empty fields are kept as ""

--- a/tests/test_custom_runtime.py
+++ b/tests/test_custom_runtime.py
@@ -1,0 +1,185 @@
+"""Custom runtime entrypoint loading via `agents.runtime: 'pkg.module:Cls'`."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from coral.agent import registry
+from coral.agent.registry import (
+    default_model_for_runtime,
+    get_runtime,
+)
+from coral.agent.runtime import AgentHandle
+from coral.config import CoralConfig
+
+# ---------------------------------------------------------------------------
+# Fixture: inject a fake runtime module into sys.modules so the registry can
+# import it via `module.path:ClassName` without touching the filesystem.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    """Minimal class satisfying the AgentRuntime structural protocol."""
+
+    def start(
+        self,
+        worktree_path: Path,
+        coral_md_path: Path,
+        model: str = "any",
+        runtime_options: dict[str, Any] | None = None,
+        max_turns: int = 200,
+        log_dir: Path | None = None,
+        verbose: bool = False,
+        resume_session_id: str | None = None,
+        prompt: str | None = None,
+        prompt_source: str | None = None,
+        task_name: str | None = None,
+        task_description: str | None = None,
+        gateway_url: str | None = None,
+        gateway_api_key: str | None = None,
+    ) -> AgentHandle:  # pragma: no cover — never called in these tests
+        raise NotImplementedError
+
+    def extract_session_id(self, log_path: Path) -> str | None:  # pragma: no cover
+        return None
+
+    @property
+    def instruction_filename(self) -> str:
+        return "FAKE.md"
+
+    @property
+    def shared_dir_name(self) -> str:
+        return ".fake"
+
+
+class _NotARuntime:
+    """Class that does NOT satisfy the AgentRuntime protocol."""
+
+    def hello(self) -> str:  # pragma: no cover
+        return "world"
+
+
+@pytest.fixture
+def fake_runtime_module() -> types.ModuleType:
+    """Inject a fake module exposing _FakeRuntime + _NotARuntime."""
+    mod_name = "coral_test_fake_runtime_module"
+    module = types.ModuleType(mod_name)
+    module.FakeRuntime = _FakeRuntime  # type: ignore[attr-defined]
+    module.NotARuntime = _NotARuntime  # type: ignore[attr-defined]
+    sys.modules[mod_name] = module
+    yield module
+    sys.modules.pop(mod_name, None)
+    # Drop registry cache entries so other tests start clean.
+    for key in list(registry._RUNTIMES):
+        if ":" in key and key.startswith(mod_name + ":"):
+            registry._RUNTIMES.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Successful resolution + caching
+# ---------------------------------------------------------------------------
+
+
+def test_get_runtime_loads_entrypoint(fake_runtime_module: types.ModuleType) -> None:
+    spec = "coral_test_fake_runtime_module:FakeRuntime"
+    instance = get_runtime(spec)
+    assert isinstance(instance, _FakeRuntime)
+
+
+def test_get_runtime_caches_entrypoint(fake_runtime_module: types.ModuleType) -> None:
+    spec = "coral_test_fake_runtime_module:FakeRuntime"
+    get_runtime(spec)
+    assert spec in registry._RUNTIMES
+    # Subsequent resolves should reuse the cached class without re-importing.
+    sys.modules.pop("coral_test_fake_runtime_module")
+    instance = get_runtime(spec)
+    assert isinstance(instance, _FakeRuntime)
+
+
+def test_default_model_for_runtime_returns_none_for_entrypoint() -> None:
+    # Nothing registered, no module touched — pure name inspection.
+    assert default_model_for_runtime("any.pkg:Anything") is None
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_get_runtime_errors_on_unknown_module() -> None:
+    with pytest.raises(ImportError, match="Failed to import"):
+        get_runtime("nonexistent_module_xyz:Whatever")
+
+
+def test_get_runtime_errors_on_missing_attribute(
+    fake_runtime_module: types.ModuleType,
+) -> None:
+    with pytest.raises(AttributeError, match="MissingClass"):
+        get_runtime("coral_test_fake_runtime_module:MissingClass")
+
+
+def test_get_runtime_errors_on_non_runtime_class(
+    fake_runtime_module: types.ModuleType,
+) -> None:
+    with pytest.raises(TypeError, match="AgentRuntime protocol"):
+        get_runtime("coral_test_fake_runtime_module:NotARuntime")
+
+
+def test_get_runtime_errors_on_malformed_entrypoint() -> None:
+    # Empty class name
+    with pytest.raises(ValueError, match="module.path:ClassName"):
+        get_runtime("some_module:")
+    # Empty module name
+    with pytest.raises(ValueError, match="module.path:ClassName"):
+        get_runtime(":SomeClass")
+
+
+def test_get_runtime_unknown_plain_name_still_errors() -> None:
+    """Names without ':' fall through the original 'Unknown runtime' path."""
+    with pytest.raises(ValueError, match="Unknown runtime"):
+        get_runtime("not_a_real_runtime")
+
+
+# ---------------------------------------------------------------------------
+# Config-level guard: explicit agents.model required for entrypoint runtimes
+# ---------------------------------------------------------------------------
+
+
+def test_config_raises_when_entrypoint_runtime_without_model() -> None:
+    with pytest.raises(ValueError, match="custom runtime entrypoint"):
+        CoralConfig.from_dict(
+            {
+                "task": {"name": "t", "description": "d"},
+                "agents": {"runtime": "coral_test_fake_runtime_module:FakeRuntime"},
+            }
+        )
+
+
+def test_config_accepts_entrypoint_runtime_with_explicit_model() -> None:
+    cfg = CoralConfig.from_dict(
+        {
+            "task": {"name": "t", "description": "d"},
+            "agents": {
+                "runtime": "coral_test_fake_runtime_module:FakeRuntime",
+                "model": "my-custom-model",
+            },
+        }
+    )
+    assert cfg.agents.runtime == "coral_test_fake_runtime_module:FakeRuntime"
+    assert cfg.agents.model == "my-custom-model"
+
+
+def test_config_keeps_builtin_default_for_known_runtime() -> None:
+    """Sanity check: existing default-model resolution path is unchanged."""
+    cfg = CoralConfig.from_dict(
+        {
+            "task": {"name": "t", "description": "d"},
+            "agents": {"runtime": "claude_code"},
+        }
+    )
+    assert cfg.agents.model == "sonnet"


### PR DESCRIPTION
## Summary

- Adds custom-runtime support to `agents.runtime` in `task.yaml` — any value containing `:` is treated as a `module.path:ClassName` entrypoint, imported on first use, validated against the `AgentRuntime` protocol, and cached.
- Symmetric with the grader's `entrypoint` pattern, but a single overloaded field (no new config key).
- Requires explicit `agents.model` when the runtime is an entrypoint, so the builtin `"sonnet"` default never silently lands on a foreign runtime.

## Usage

```yaml
agents:
  runtime: my_pkg.my_runtime:MyRuntime
  model: my-custom-model    # required for entrypoint runtimes
```

`uv pip install -e .` your runtime package into the same env that runs `coral`. The same overload also works in `agents.assignments[].runtime`.

## Files

- `coral/agent/registry.py` — `_load_entrypoint()` + entrypoint branch in `get_runtime()`; `default_model_for_runtime()` returns `None` for entrypoints.
- `coral/config.py` — `_preprocess` raises if `agents.runtime` is an entrypoint and `agents.model` is unset in raw YAML.
- `coral/cli/author.py` — scaffold comment now mentions the overload.
- `tests/test_custom_runtime.py` — 11 new tests (load + cache, default-model None, error paths for missing module / missing attr / non-`AgentRuntime` class / malformed spec, unchanged "Unknown runtime" path, config-level model-required guard).

## Test plan

- [x] `uv run pytest tests/test_custom_runtime.py -v` — 11/11 pass
- [x] `uv run pytest tests/ --ignore=tests/test_grader_daemon.py -q` — 245/245 pass
- [x] `uv run ruff check coral/agent/registry.py coral/config.py coral/cli/author.py tests/test_custom_runtime.py` — clean
- [ ] End-to-end smoke: write a tiny custom runtime in a sibling repo, install it into the coral env, and run `coral start -c task.yaml` against an example task with `runtime: pkg:Cls` + explicit `model:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)