### PR TITLE
fix(web): migrate to Starlette 1.0 lifespan handlers

### DIFF
--- a/coral/web/app.py
+++ b/coral/web/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from starlette.applications import Starlette
@@ -46,20 +47,24 @@ def create_app(coral_dir: Path, results_dir: Path | None = None) -> Starlette:
     results_dir = Path(results_dir).resolve()
     static_dir = Path(__file__).parent / "static"
 
-    async def on_startup() -> None:
+    @asynccontextmanager
+    async def lifespan(app):
+        # startup
         app.state.coral_dir = coral_dir
         app.state.results_dir = results_dir
         app.state._switch_lock = asyncio.Lock()
         app.state.watcher = FileWatcher(coral_dir)
         app.state._watcher_task = asyncio.create_task(app.state.watcher.run())
-
-    async def on_shutdown() -> None:
-        app.state.watcher.stop()
-        app.state._watcher_task.cancel()
         try:
-            await app.state._watcher_task
-        except asyncio.CancelledError:
-            pass
+            yield
+        finally:
+            # shutdown
+            app.state.watcher.stop()
+            app.state._watcher_task.cancel()
+            try:
+                await app.state._watcher_task
+            except asyncio.CancelledError:
+                pass
 
     # SPA fallback: serve index.html for any non-API, non-static route
     async def spa_fallback(request: Request) -> Response:
@@ -109,8 +114,7 @@ def create_app(coral_dir: Path, results_dir: Path | None = None) -> Starlette:
     app = Starlette(
         routes=routes,
         middleware=middleware,
-        on_startup=[on_startup],
-        on_shutdown=[on_shutdown],
+        lifespan=lifespan,
     )
 
     return app


### PR DESCRIPTION
## Problem

Starlette 1.0.0 removed the `on_startup` and `on_shutdown` parameters from the `Starlette()` constructor in favor of the unified `lifespan` context manager. `coral.web.app.create_app()` still passes the removed parameters, causing the web dashboard to fail at boot with:

```
TypeError: Starlette.__init__() got an unexpected keyword argument 'on_startup'
```

The crash propagates: `coral.agent.manager` exits, grader daemon and agent runtime (codex / claude_code / ...) processes are orphaned, every `coral start` with `run.ui=true` fails silently with `Manager: not running` after a few seconds. Tasks that ship with `run.ui: true` (e.g. the bundled `examples/mnist/task.yaml` invocation `coral start ... run.ui=true`) are blocked on any environment that resolves `starlette>=1.0`.

## Fix

Migrate `on_startup` + `on_shutdown` into a single `lifespan` `@asynccontextmanager` per the Starlette 1.0 API.

```python
@asynccontextmanager
async def lifespan(app):
    # startup
    app.state.coral_dir = coral_dir
    ...
    try:
        yield
    finally:
        # shutdown
        app.state.watcher.stop()
        ...

app = Starlette(routes=routes, middleware=middleware, lifespan=lifespan)
```

Behavior is preserved identically — same state initialization on startup, same `FileWatcher` teardown on shutdown (`try/finally` matches the original `try/except CancelledError` semantics).

## Testing

- Smoke test: `from coral.web.app import create_app; create_app(...)` returns a valid `Starlette` instance with `app.router.lifespan_context` populated.
- End-to-end: `coral start -c task.yaml run.ui=true` boots a healthy manager + dashboard at `:8420` + agents, agents produce eval attempts as expected, dashboard renders attempts in real time.

## References

- Starlette migration guide: https://www.starlette.io/lifespan/