### PR TITLE
blog: list all paper authors and affiliations

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -265,34 +265,50 @@ a:hover{color:var(--link-h)}
     <div class="hero-authors">
       <!-- Row 1: Core contributors -->
       <div class="author-row">
-        <span class="author-name author-core">Ao Qu</span><sup>1*</sup><span class="author-sep">&nbsp;&nbsp;</span>
-        <span class="author-name author-core">Yihao Yan</span><sup>*</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name author-core">Ao Qu</span><sup>1,8*</sup><span class="author-sep">&nbsp;&nbsp;</span>
         <span class="author-name author-core">Han Zheng</span><sup>1*</sup><span class="author-sep">&nbsp;&nbsp;</span>
-        <span class="author-name author-core">Zijian Zhou</span><sup>2*</sup>
+        <span class="author-name author-core">Zijian Zhou</span><sup>2,3*</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name author-core">Yihao Yan</span><sup>*</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Yihong Tang</span><sup>4</sup>
       </div>
       <!-- Row 2 -->
       <div class="author-row">
         <span class="author-name">Shao Yong Ong</span><sup>2</sup><span class="author-sep">&nbsp;&nbsp;</span>
-        <span class="author-name">Fenglu Hong</span><sup>3</sup><span class="author-sep">&nbsp;&nbsp;</span>
-        <span class="author-name">Jiacheng Zhu</span><sup>4†</sup>
+        <span class="author-name">Fenglu Hong</span><sup>5,6</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Kaichen Zhou</span><sup>1</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Chonghe Jiang</span><sup>1,8</sup>
       </div>
-      <!-- Row 3: Equal advising -->
+      <!-- Row 3 -->
       <div class="author-row">
-        <span class="author-name">Bryan Kian Hsiang Low</span><sup>2‡</sup><span class="author-sep">&nbsp;&nbsp;</span>
-        <span class="author-name">Jinhua Zhao</span><sup>1‡</sup><span class="author-sep">&nbsp;&nbsp;</span>
-        <span class="author-name">Paul Pu Liang</span><sup>1‡</sup>
+        <span class="author-name">Minwei Kong</span><sup>8</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Jiacheng Zhu</span><sup>7‡</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Xuan Jiang</span><sup>9‡</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Sirui Li</span><sup>10‡</sup>
+      </div>
+      <!-- Row 4: Joint advising -->
+      <div class="author-row">
+        <span class="author-name">Cathy Wu</span><sup>1†</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Bryan Kian Hsiang Low</span><sup>2,8†</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Jinhua Zhao</span><sup>1,8†</sup><span class="author-sep">&nbsp;&nbsp;</span>
+        <span class="author-name">Paul Pu Liang</span><sup>1,8†</sup>
       </div>
       <!-- Affiliations -->
       <div class="author-affil">
-        <sup>1</sup>Massachusetts Institute of Technology &nbsp;&nbsp;
-        <sup>2</sup>National University of Singapore &nbsp;&nbsp;
-        <sup>3</sup>Stanford University &nbsp;&nbsp;
-        <sup>4</sup>Meta Superintelligence Lab
+        <sup>1</sup>MIT &nbsp;&nbsp;
+        <sup>2</sup>NUS &nbsp;&nbsp;
+        <sup>3</sup>MiniMax &nbsp;&nbsp;
+        <sup>4</sup>McGill &nbsp;&nbsp;
+        <sup>5</sup>Stanford &nbsp;&nbsp;
+        <sup>6</sup>SambaNova &nbsp;&nbsp;
+        <sup>7</sup>Meta
+        <br>
+        <sup>8</sup>Singapore-MIT Alliance for Research and Technology &nbsp;&nbsp;
+        <sup>9</sup>Amazon &nbsp;&nbsp;
+        <sup>10</sup>Microsoft
       </div>
       <!-- Legend -->
       <div class="author-footnote">
-        * Equal Contribution (alphabetical order) &nbsp;&nbsp; ‡ Equal Advising
-        <br>† Work done outside of Meta and does not represent the views of Meta.
+        * Equal Contribution (alphabetical order) &nbsp;&nbsp; † Joint Advising &nbsp;&nbsp; ‡ Work done outside the authors&rsquo; employment
       </div>
     </div>
 


### PR DESCRIPTION
Sync the blog author block with the arXiv paper (2604.01658): add the seven missing names (Yihong Tang, Kaichen Zhou, Chonghe Jiang, Minwei Kong, Xuan Jiang, Sirui Li, Cathy Wu), reorder to match the paper, and update affiliations and footnote symbols accordingly.