### PR TITLE
feat(falsifications): quorum + TTL ledger for team dead-end claims

### DIFF
--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -497,6 +497,7 @@ class AgentManager:
             agent_id,
             single_agent=single_agent,
             shared_dir=shared_dir_name,
+            coral_dir=self.paths.coral_dir,
         )
         (worktree_path / instruction_file).write_text(coral_md)
 

--- a/coral/cli/__init__.py
+++ b/coral/cli/__init__.py
@@ -316,6 +316,58 @@ Run 'coral <command> --help' for details on any command."""
     p_skills.add_argument("--read", "-r", help="Show details of a skill (name or prefix)")
     _add_run_args(p_skills)
 
+    p_falsify = sub.add_parser(
+        "falsify",
+        help="Record that you've found a topic/approach to be dead",
+        description=(
+            "Add this agent's vote that <slug> doesn't work. The team's "
+            "consensus on dead-ends is the set of topics with >=quorum "
+            "distinct votes within the TTL window."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  coral falsify xfmr-distill -m 'ADD at w=0.04 -> -0.00018'\n"
+            "  coral falsify ssm-distill -m 'val 0.66, ensemble drag'"
+        ),
+        formatter_class=_CommandHelpFormatter,
+    )
+    p_falsify.add_argument("slug", help="Topic slug (kebab-case, e.g. 'xfmr-distill')")
+    p_falsify.add_argument("-m", "--message", required=True, help="Evidence / reasoning")
+    p_falsify.add_argument(
+        "--ttl", type=int, help="Override TTL (in evals) for this claim"
+    )
+    p_falsify.add_argument(
+        "--force", action="store_true", help="Overwrite existing claim by this agent"
+    )
+    p_falsify.add_argument(
+        "--as",
+        dest="as_agent",
+        help="Override agent id (only used when no .coral_agent_id breadcrumb is present)",
+    )
+    _add_run_args(p_falsify)
+
+    p_falsified = sub.add_parser(
+        "falsified",
+        help="List topics with team consensus on being dead",
+        description=(
+            "Show topics that >=quorum distinct agents have independently "
+            "claimed falsified (and at least one claim is still within TTL)."
+        ),
+        formatter_class=_CommandHelpFormatter,
+    )
+    _add_run_args(p_falsified)
+
+    p_disputed = sub.add_parser(
+        "disputed",
+        help="List single-voice or expired claims (candidates for re-test)",
+        description=(
+            "Topics claimed dead by only one agent OR whose claim has expired "
+            "past TTL. A skeptic agent should consider re-testing these."
+        ),
+        formatter_class=_CommandHelpFormatter,
+    )
+    _add_run_args(p_disputed)
+
     p_runs = sub.add_parser(
         "runs",
         help="List all runs across tasks",
@@ -504,6 +556,7 @@ Run 'coral <command> --help' for details on any command."""
     # Lazy imports for fast startup
     from coral.cli.author import cmd_init, cmd_validate
     from coral.cli.eval import cmd_checkout, cmd_diff, cmd_eval, cmd_revert, cmd_wait
+    from coral.cli.falsify import cmd_disputed, cmd_falsified, cmd_falsify
     from coral.cli.heartbeat import cmd_heartbeat
     from coral.cli.query import cmd_log, cmd_notes, cmd_runs, cmd_show, cmd_skills
     from coral.cli.start import cmd_resume, cmd_start, cmd_status, cmd_stop
@@ -524,6 +577,9 @@ Run 'coral <command> --help' for details on any command."""
         "show": cmd_show,
         "notes": cmd_notes,
         "skills": cmd_skills,
+        "falsify": cmd_falsify,
+        "falsified": cmd_falsified,
+        "disputed": cmd_disputed,
         "runs": cmd_runs,
         "init": cmd_init,
         "validate": cmd_validate,

--- a/coral/cli/falsify.py
+++ b/coral/cli/falsify.py
@@ -1,0 +1,246 @@
+"""Commands: falsify, falsified, disputed.
+
+These manage the team's "what doesn't work" list with a quorum + TTL gate
+(see ``coral.hub.falsifications``).  An agent declares a topic dead by
+running::
+
+    coral falsify <slug> -m "evidence ..."
+
+which writes a note under ``.coral/public/notes/`` with the right
+frontmatter.  ``coral falsified`` lists topics that have ≥quorum distinct
+agents claiming them.  ``coral disputed`` lists single-voice or expired
+claims — the topics a future agent should consider re-testing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+from coral.cli._helpers import find_coral_dir, read_agent_id
+from coral.hub.attempts import read_eval_count
+from coral.hub.falsifications import (
+    TopicStatus,
+    find_consensus,
+    find_disputed,
+    list_topics,
+    validate_slug,
+)
+
+
+def _read_sharing_config(coral_dir: Path) -> tuple[int, int]:
+    """Return (quorum, default_ttl) from ``coral_dir/config.yaml`` with sensible
+    fallbacks (2 / 30) when missing.  Same yaml-parse pattern as
+    ``read_direction()``."""
+    quorum = 2
+    ttl = 30
+    config_path = coral_dir / "config.yaml"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                cfg = yaml.safe_load(f) or {}
+        except (OSError, yaml.YAMLError):
+            cfg = {}
+        sharing = (cfg.get("sharing") or {}) if isinstance(cfg, dict) else {}
+        # Sub-config dict: sharing.falsification.{quorum,ttl_evals}
+        falsification = (sharing.get("falsification") or {}) if isinstance(sharing, dict) else {}
+        quorum = int(falsification.get("quorum", quorum) or quorum)
+        ttl = int(falsification.get("ttl_evals", ttl) or ttl)
+    return max(1, quorum), max(1, ttl)
+
+
+def _slugify_filename(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-") or "claim"
+
+
+def cmd_falsify(args: argparse.Namespace) -> None:
+    """Record this agent's "topic X is dead" claim.
+
+    Writes a note under ``.coral/public/notes/falsified-<slug>-by-<agent>.md``
+    with the right frontmatter so ``coral falsified`` / ``coral disputed`` /
+    the CORAL.md template can pick it up.
+
+    Examples:
+      coral falsify xfmr-distill -m "ADD at w=0.04 → -0.00018, eval 28"
+      coral falsify ssm-distill -m "val 0.66, ensemble drag"
+    """
+    slug = args.slug
+    try:
+        validate_slug(slug)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        print(
+            "       Use lowercase letters/digits separated by single dashes, "
+            "e.g. 'xfmr-distill-student'.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    coral_dir = find_coral_dir(getattr(args, "task", None), getattr(args, "run", None))
+    agent_id = read_agent_id()
+    if agent_id == "unknown":
+        # The CLI can be invoked from a maintainer shell at the run root, in
+        # which case we have no breadcrumb. Refuse rather than write an
+        # uncountable claim (no creator → quorum can't see it).
+        print(
+            "error: cannot determine agent_id (no .coral_agent_id breadcrumb in cwd).\n"
+            "       Run this from inside an agent worktree, or pass --as <agent-id>.",
+            file=sys.stderr,
+        )
+        if not getattr(args, "as_agent", None):
+            sys.exit(2)
+        agent_id = args.as_agent
+
+    quorum, default_ttl = _read_sharing_config(coral_dir)
+    eval_count = read_eval_count(coral_dir)
+    ttl = int(getattr(args, "ttl", None) or default_ttl)
+
+    notes_dir = coral_dir / "public" / "notes"
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"falsified-{_slugify_filename(slug)}-by-{_slugify_filename(agent_id)}.md"
+    note_path = notes_dir / filename
+
+    if note_path.exists() and not getattr(args, "force", False):
+        print(
+            f"error: a claim by {agent_id} on '{slug}' already exists at "
+            f"{note_path.relative_to(coral_dir.parent)}.\n"
+            "       Pass --force to overwrite (e.g. to refresh evidence and "
+            "reset the TTL clock).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    body = (args.message or "").strip()
+    if not body:
+        body = "(no evidence provided)"
+
+    created = datetime.now(UTC).isoformat(timespec="seconds")
+    content = (
+        "---\n"
+        f"creator: {agent_id}\n"
+        f"created: {created}\n"
+        f"falsifies: {slug}\n"
+        f"claimed_at_eval: {eval_count}\n"
+        f"ttl_evals: {ttl}\n"
+        "---\n"
+        "\n"
+        f"# Falsifying {slug}\n"
+        "\n"
+        f"{body}\n"
+    )
+    note_path.write_text(content)
+
+    # Tell the agent how the team will see this claim.
+    matches = [
+        s
+        for s in list_topics(
+            coral_dir,
+            current_eval=eval_count,
+            quorum=quorum,
+            default_ttl=default_ttl,
+        )
+        if s.topic == slug
+    ]
+    status = matches[0] if matches else None
+
+    print(f"Wrote claim to {note_path.relative_to(coral_dir.parent)}")
+    if status:
+        if status.level == "consensus":
+            voices = ", ".join(status.voices)
+            print(
+                f"Status: CONSENSUS — quorum reached "
+                f"({len(status.voices)}/{quorum}, voices: {voices})."
+            )
+        elif status.level == "disputed":
+            print(
+                f"Status: DISPUTED — {len(status.voices)}/{quorum} voices so "
+                f"far. Need {quorum - len(status.voices)} more independent "
+                "agent(s) to confirm."
+            )
+        elif status.level == "stale":
+            # Shouldn't happen right after a write, but defensive.
+            print("Status: STALE")
+
+
+def cmd_falsified(args: argparse.Namespace) -> None:
+    """List topics with team consensus (≥quorum agents claim them dead).
+
+    Example:
+      coral falsified
+    """
+    coral_dir = find_coral_dir(getattr(args, "task", None), getattr(args, "run", None))
+    quorum, default_ttl = _read_sharing_config(coral_dir)
+    eval_count = read_eval_count(coral_dir)
+
+    topics = find_consensus(
+        coral_dir,
+        current_eval=eval_count,
+        quorum=quorum,
+        default_ttl=default_ttl,
+    )
+    if not topics:
+        print(
+            f"No topics have reached consensus yet "
+            f"(quorum={quorum}, current eval={eval_count})."
+        )
+        return
+    print(f"Team consensus dead-ends ({len(topics)} topic(s), quorum={quorum}):")
+    _print_topic_table(topics, eval_count)
+
+
+def cmd_disputed(args: argparse.Namespace) -> None:
+    """List topics with disputed or stale claims — worth re-testing.
+
+    Example:
+      coral disputed
+    """
+    coral_dir = find_coral_dir(getattr(args, "task", None), getattr(args, "run", None))
+    quorum, default_ttl = _read_sharing_config(coral_dir)
+    eval_count = read_eval_count(coral_dir)
+
+    topics = find_disputed(
+        coral_dir,
+        current_eval=eval_count,
+        quorum=quorum,
+        default_ttl=default_ttl,
+    )
+    if not topics:
+        print(
+            f"No disputed or stale claims (quorum={quorum}, "
+            f"current eval={eval_count})."
+        )
+        return
+    print(
+        f"Disputed / stale claims ({len(topics)} topic(s), quorum={quorum}) — "
+        "candidates for re-test:"
+    )
+    _print_topic_table(topics, eval_count)
+
+
+def _print_topic_table(topics: list[TopicStatus], current_eval: int) -> None:
+    """Plain-text table of topic statuses."""
+    rows = [("Topic", "Status", "Voices", "All voices", "Expires", "Note(s)")]
+    for s in topics:
+        if s.level == "consensus" or s.level == "disputed":
+            expires = (
+                f"{s.expires_at_eval} "
+                f"(in {max(0, s.expires_at_eval - current_eval)})"
+            )
+        else:  # stale
+            expires = "expired"
+        active = ", ".join(s.voices) or "—"
+        all_v = ", ".join(s.all_voices) or "—"
+        first_note = s.claims[0].note_path if s.claims else ""
+        rows.append((s.topic, s.level, active, all_v, expires, first_note))
+
+    widths = [max(len(r[i]) for r in rows) for i in range(len(rows[0]))]
+    for i, row in enumerate(rows):
+        line = "  ".join(cell.ljust(widths[j]) for j, cell in enumerate(row))
+        print(line)
+        if i == 0:
+            print("  ".join("-" * w for w in widths))

--- a/coral/config.py
+++ b/coral/config.py
@@ -211,12 +211,38 @@ class AgentConfig:
 
 
 @dataclass
+class FalsificationConfig:
+    """Tunables for the team falsification ledger (quorum + TTL).
+
+    A topic is "team consensus" only after ``quorum`` distinct agents have
+    independently claimed it falsified (via a note's ``falsifies:`` frontmatter
+    field) within the last ``ttl_evals`` global evals. A lone claim is
+    "disputed" until a second agent confirms it; any claim expires past TTL
+    to "stale".
+    """
+
+    # Minimum number of distinct agents whose active claims are required for
+    # team consensus. 1 = legacy behavior (any single claim wins). 2 = a lone
+    # claim is "disputed" until a second agent confirms.
+    quorum: int = 2
+    # How many global evals a claim stays active before expiring to "stale"
+    # (and stopping counting toward quorum). Force-decays claims so the team
+    # periodically re-tests dead ends instead of carrying one agent's snap
+    # judgement forever.
+    ttl_evals: int = 30
+
+
+@dataclass
 class SharingConfig:
     """What shared state is enabled."""
 
     attempts: bool = True
     notes: bool = True
     skills: bool = True
+    # Knobs for the falsification ledger surfaced via `coral falsify` /
+    # `coral falsified` / `coral disputed`. Independent of the bools above —
+    # the ledger is always on; this just tunes its consensus thresholds.
+    falsification: FalsificationConfig = field(default_factory=FalsificationConfig)
 
 
 @dataclass

--- a/coral/hub/falsifications.py
+++ b/coral/hub/falsifications.py
@@ -1,0 +1,276 @@
+"""Aggregate falsification claims from note frontmatter into team consensus.
+
+A note declares a topic falsified by adding two YAML frontmatter fields::
+
+    ---
+    creator: agent-1
+    created: 2026-05-16T10:00:00+08:00
+    falsifies: xfmr-distill-student   # kebab-case slug
+    claimed_at_eval: 28               # global eval count when the claim was made
+    # ttl_evals: 30                   # optional override
+    ---
+
+Multiple agents can independently claim the same topic (one note per claim).
+This module groups them by topic, applies the configured TTL window, and
+returns one of:
+
+- ``consensus``  — at least ``quorum`` distinct agents have claimed the topic
+                   AND at least one of those claims is still within TTL
+- ``disputed``   — fewer than ``quorum`` distinct active claims, but at least
+                   one is still within TTL
+- ``stale``      — claims exist but ALL are past TTL
+- ``unknown``    — no claim has ever been written (callers should not see)
+
+The source of truth is the notes themselves — this module is read-only over
+``list_notes()``.  No new on-disk format.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from coral.hub.notes import list_notes
+
+StatusLevel = Literal["consensus", "disputed", "stale", "unknown"]
+
+_SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+def validate_slug(slug: str) -> None:
+    """Raise ValueError unless ``slug`` is kebab-case (``[a-z0-9-]``).
+
+    Examples that PASS: ``xfmr-distill``, ``ssm-distill-student``, ``cnn-2layer``
+    Examples that FAIL: ``XfmrDistill``, ``xfmr_distill``, ``-leading-dash``,
+    ``trailing-dash-``, ``double--dash``, empty string.
+    """
+    if not slug:
+        raise ValueError("falsification slug cannot be empty")
+    if not _SLUG_RE.fullmatch(slug):
+        raise ValueError(
+            f"falsification slug {slug!r} must be kebab-case "
+            f"(lowercase letters/digits separated by single dashes), "
+            f"e.g. 'xfmr-distill-student'"
+        )
+
+
+@dataclass
+class Claim:
+    """One agent's falsification claim, sourced from a single note."""
+
+    topic: str
+    creator: str
+    claimed_at_eval: int
+    ttl_evals: int
+    note_path: str  # path relative to .coral/public/notes/, for citing
+    title: str
+
+    def expires_at_eval(self) -> int:
+        return self.claimed_at_eval + self.ttl_evals
+
+    def is_active(self, current_eval: int) -> bool:
+        return current_eval < self.expires_at_eval()
+
+
+@dataclass
+class TopicStatus:
+    """Aggregated status for a single falsification topic."""
+
+    topic: str
+    level: StatusLevel
+    voices: list[str] = field(default_factory=list)  # distinct agent ids, active
+    all_voices: list[str] = field(default_factory=list)  # distinct agent ids, including expired
+    claims: list[Claim] = field(default_factory=list)  # sorted by claimed_at_eval ASC
+    expires_at_eval: int = 0  # max expiry across active claims; 0 if none active
+
+    def evidence_paths(self) -> list[str]:
+        return [c.note_path for c in self.claims]
+
+
+def _parse_int(value: Any, default: int = 0) -> int:
+    """Robustly coerce a frontmatter scalar to int (notes use a hand-rolled parser
+    that always returns strings)."""
+    if value is None or value == "":
+        return default
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _collect_claims(coral_dir: str | Path, default_ttl: int) -> list[Claim]:
+    """Walk all notes via list_notes() and extract falsification claims.
+
+    Notes without a ``falsifies`` field are skipped.  Notes whose slug fails
+    validation are skipped (silent — the writer should already have been told
+    via the CLI's `coral falsify` command).  Missing ``claimed_at_eval`` is
+    treated as 0 so the claim ages out immediately (which surfaces a write-time
+    bug rather than silently weighting the claim as fresh).
+    """
+    claims: list[Claim] = []
+    for note in list_notes(coral_dir):
+        topic = (note.get("falsifies") or "").strip()
+        if not topic:
+            continue
+        try:
+            validate_slug(topic)
+        except ValueError:
+            # Bad slug — skip silently. The CLI rejects writes; a bad slug here
+            # means the agent edited frontmatter by hand. Surfacing it via
+            # `coral disputed` would be noise.
+            continue
+
+        creator = (note.get("creator") or "").strip()
+        if not creator:
+            # Without a creator we can't count voices. Skip.
+            continue
+
+        claimed_at = _parse_int(note.get("claimed_at_eval"), default=0)
+        ttl = _parse_int(note.get("ttl_evals"), default=default_ttl)
+        if ttl <= 0:
+            ttl = default_ttl
+
+        # _path is set by list_notes() for individual files; legacy aggregated
+        # notes don't have it (and they predate falsifications anyway).
+        path_obj = note.get("_path")
+        notes_root = Path(coral_dir) / "public" / "notes"
+        try:
+            rel_path = (
+                str(Path(path_obj).resolve().relative_to(notes_root.resolve()))
+                if path_obj
+                else note.get("filename", "")
+            )
+        except ValueError:
+            rel_path = note.get("filename", "")
+
+        claims.append(
+            Claim(
+                topic=topic,
+                creator=creator,
+                claimed_at_eval=claimed_at,
+                ttl_evals=ttl,
+                note_path=rel_path,
+                title=note.get("title", ""),
+            )
+        )
+    return claims
+
+
+def _classify(claims: list[Claim], current_eval: int, quorum: int) -> TopicStatus:
+    """Compute a TopicStatus from a list of claims for the SAME topic."""
+    assert claims, "_classify requires at least one claim"
+    topic = claims[0].topic
+    claims_sorted = sorted(claims, key=lambda c: c.claimed_at_eval)
+    active = [c for c in claims_sorted if c.is_active(current_eval)]
+    voices_active = sorted({c.creator for c in active})
+    voices_all = sorted({c.creator for c in claims_sorted})
+    expires_at = max((c.expires_at_eval() for c in active), default=0)
+
+    if len(voices_active) >= quorum:
+        level: StatusLevel = "consensus"
+    elif active:
+        level = "disputed"
+    else:
+        level = "stale"
+
+    return TopicStatus(
+        topic=topic,
+        level=level,
+        voices=voices_active,
+        all_voices=voices_all,
+        claims=claims_sorted,
+        expires_at_eval=expires_at,
+    )
+
+
+def list_topics(
+    coral_dir: str | Path,
+    *,
+    current_eval: int,
+    quorum: int = 2,
+    default_ttl: int = 30,
+) -> list[TopicStatus]:
+    """Return one TopicStatus per topic that has at least one claim.
+
+    Topics with status ``unknown`` are not returned (they have no claims).
+    Result is sorted by topic slug for stable output.
+    """
+    if quorum < 1:
+        quorum = 1
+
+    by_topic: dict[str, list[Claim]] = {}
+    for c in _collect_claims(coral_dir, default_ttl=default_ttl):
+        by_topic.setdefault(c.topic, []).append(c)
+
+    statuses = [
+        _classify(claims, current_eval=current_eval, quorum=quorum)
+        for claims in by_topic.values()
+    ]
+    statuses.sort(key=lambda s: s.topic)
+    return statuses
+
+
+def topic_status(
+    topic: str,
+    coral_dir: str | Path,
+    *,
+    current_eval: int,
+    quorum: int = 2,
+    default_ttl: int = 30,
+) -> TopicStatus:
+    """Status for a specific topic.  Returns level=``unknown`` if no claims."""
+    validate_slug(topic)
+    matches = [
+        c
+        for c in _collect_claims(coral_dir, default_ttl=default_ttl)
+        if c.topic == topic
+    ]
+    if not matches:
+        return TopicStatus(topic=topic, level="unknown")
+    return _classify(matches, current_eval=current_eval, quorum=quorum)
+
+
+def find_consensus(
+    coral_dir: str | Path,
+    *,
+    current_eval: int,
+    quorum: int = 2,
+    default_ttl: int = 30,
+) -> list[TopicStatus]:
+    """Topics where ≥quorum distinct agents have active claims."""
+    return [
+        s
+        for s in list_topics(
+            coral_dir,
+            current_eval=current_eval,
+            quorum=quorum,
+            default_ttl=default_ttl,
+        )
+        if s.level == "consensus"
+    ]
+
+
+def find_disputed(
+    coral_dir: str | Path,
+    *,
+    current_eval: int,
+    quorum: int = 2,
+    default_ttl: int = 30,
+) -> list[TopicStatus]:
+    """Topics that are ``disputed`` or ``stale`` — single voice or expired.
+
+    These are the ones a skeptic agent should consider re-testing: they were
+    claimed dead by one agent (and never confirmed) or the claim has aged out.
+    """
+    return [
+        s
+        for s in list_topics(
+            coral_dir,
+            current_eval=current_eval,
+            quorum=quorum,
+            default_ttl=default_ttl,
+        )
+        if s.level in ("disputed", "stale")
+    ]

--- a/coral/hub/heartbeat.py
+++ b/coral/hub/heartbeat.py
@@ -36,6 +36,7 @@ DEFAULT_PROMPTS: dict[str, str] = {
     "consolidate": _load_prompt("consolidate"),
     "pivot": _load_prompt("pivot"),
     "lint_wiki": _load_prompt("lint_wiki"),
+    "retest_disputed": _load_prompt("retest_disputed"),
 }
 
 # Which built-in actions default to global scope
@@ -44,6 +45,7 @@ DEFAULT_GLOBAL: dict[str, bool] = {
     "consolidate": True,
     "pivot": False,
     "lint_wiki": True,
+    "retest_disputed": False,
 }
 
 # Which built-in actions use plateau trigger instead of interval
@@ -52,6 +54,7 @@ DEFAULT_TRIGGER: dict[str, str] = {
     "consolidate": "interval",
     "pivot": "plateau",
     "lint_wiki": "interval",
+    "retest_disputed": "plateau",
 }
 
 # Protected actions: reflect is always local, consolidate is always global

--- a/coral/hub/notes.py
+++ b/coral/hub/notes.py
@@ -99,6 +99,11 @@ def _parse_note_file(path: Path) -> dict[str, Any]:
         "filename": path.name,
         "_mtime": os.path.getmtime(path),
         "_path": path,  # full path, used to compute relative path later
+        # Falsification claim fields (consumed by coral.hub.falsifications).
+        # Empty string when the note is not a falsification claim.
+        "falsifies": meta.get("falsifies", ""),
+        "claimed_at_eval": meta.get("claimed_at_eval", ""),
+        "ttl_evals": meta.get("ttl_evals", ""),
     }
 
 

--- a/coral/hub/prompts/retest_disputed.md
+++ b/coral/hub/prompts/retest_disputed.md
@@ -1,0 +1,77 @@
+## Heartbeat: Retest a Disputed Dead-End
+
+**Your score has not improved for several evals AND the team's "what doesn't
+work" list has unconfirmed claims.** Before changing your own approach, ask
+whether the team is *over-claiming* dead-ends — and prove it by running an
+actual test.
+
+This is the cheap version of a full pivot. You're not building a new
+architecture from scratch; you're checking whether one of the things the team
+*believes* is dead actually is.
+
+### Step 1: See what's disputed
+
+```
+coral disputed
+```
+
+This lists topics where **only one agent** has claimed dead, OR where the
+claim has expired past TTL (`{shared_dir}/notes/_synthesis/saturation-*.md`
+style "discipline" notes typically generate the first kind). These are the
+team's softest verdicts — single voice, no independent confirmation.
+
+If the list is empty, you have no cheap re-tests. Skip this heartbeat and
+treat it as a normal `pivot` cue instead.
+
+### Step 2: Pick one with a suspect rubric
+
+For each disputed topic, open the original note (the path is in the
+`coral disputed` output) and look at *how the claim was judged*.
+
+The most common over-claim pattern in CORAL runs: a new architecture (e.g.
+`xfmr-distill`, `ssm-distill`, `cnn-distill`) was tested by **adding it to
+the saturated ensemble at low weight**, didn't help, and was tagged
+falsified. But "added to the saturated ensemble at low weight" is the wrong
+rubric for an unmatured architecture — its day-1 quality is necessarily
+below the ensemble's val, so it fails the buffer rule even if it has
+genuine orthogonal signal.
+
+Other suspect rubrics:
+- Tested once with default hyperparameters; never tuned.
+- Tested against the *current* baseline, when the baseline has moved up
+  significantly since the claim was made.
+- Tested with the *agent's own* implementation of the new approach, which
+  may have had bugs.
+
+Pick the one whose original test you'd judge differently *today*.
+
+### Step 3: Re-test cleanly
+
+Two options:
+
+**Option A — test as a standalone, not an ensemble add.**
+Train the disputed architecture to its own peak quality. Don't compare to
+the team ensemble; compare to the *single-model* val it should plausibly
+hit. If it lands within striking distance of your top single model, the
+"falsified" verdict was about ensemble dilution, not architecture quality —
+the topic is alive and you've just expanded the team's component pool.
+
+**Option B — re-test under the original rubric, but with the new baseline.**
+If the original claim was "ADD to baseline at w=0.05, regressed", redo the
+ADD with the current (likely-higher) baseline and current cache versions.
+A claim made at baseline 0.675 may not survive at baseline 0.681.
+
+Either way, commit your verdict:
+- If the topic was wrongly claimed dead: write a normal `coral eval` with
+  the new evidence. The leaderboard speaks for itself — no `coral falsify`
+  needed.
+- If the topic really is dead: `coral falsify <slug> -m "confirming agent-X's
+  claim: <your evidence>"`. Your independent vote tips it from disputed to
+  consensus, and the team can stop re-testing it for one TTL window.
+
+### Step 4: Don't stack with `pivot`
+
+If a normal `pivot` heartbeat also fires this cycle, **do this one first.**
+A disputed re-test is faster (you're not building anything new) and resolves
+team uncertainty. Pivot to a brand-new direction only if no disputed claims
+exist, or you've already re-tested them and they really are dead.

--- a/coral/template/coral.md.template
+++ b/coral/template/coral.md.template
@@ -306,7 +306,7 @@ The best notes are specific and actionable. "X doesn't work" is okay. "X doesn't
 ## Repeat
 
 Go back to Step 1. Keep iterating. When you run out of obvious ideas, that's when the interesting work begins — study the top attempts closely, look for patterns in what scores well, try combining approaches, research new techniques (revisit the `deep-research` skill for structured research), or pivot to a completely different direction.
-{tips_section}
+{tips_section}{falsifications_section}
 ## Ground Rules
 
 - **You are fully autonomous.** Do not ask for permission, do not wait for instructions. Make decisions, run experiments, iterate.

--- a/coral/template/coral_md.py
+++ b/coral/template/coral_md.py
@@ -15,6 +15,7 @@ def generate_coral_md(
     agent_id: str,
     single_agent: bool = False,
     shared_dir: str = ".claude",
+    coral_dir: Path | None = None,
 ) -> str:
     """Produce the CORAL.md file that agents read at startup.
 
@@ -23,6 +24,9 @@ def generate_coral_md(
         agent_id: This agent's ID
         single_agent: If True, use simplified single-agent template (no sharing references)
         shared_dir: Name of the shared state directory (e.g. ".claude", ".codex", ".opencode")
+        coral_dir: Path to ``.coral/`` for rendering the team falsification
+            section. When None the section is empty (used by tests and by
+            very-early renders before the directory exists).
     """
     template_path = _SINGLE_TEMPLATE_PATH if single_agent else _TEMPLATE_PATH
     template = template_path.read_text()
@@ -92,6 +96,7 @@ def generate_coral_md(
         shared_dir=shared_dir,
         workflow_summary=workflow_summary,
         research_section=research_section,
+        falsifications_section=_render_falsifications_section(config, coral_dir),
         plan_step_num=step_offset,
         edit_step_num=step_offset + 1,
         eval_step_num=step_offset + 2,
@@ -107,3 +112,83 @@ def _get_score_direction(config: CoralConfig) -> str:
     if config.grader.direction == "minimize":
         return "lower is better"
     return "higher is better"
+
+
+def _render_falsifications_section(config: CoralConfig, coral_dir: Path | None) -> str:
+    """Render the "Team falsification ledger" CORAL.md section.
+
+    Returns the empty string when there's nothing to show — so existing
+    runs / tests / single-agent setups don't grow a noisy blank header.
+    """
+    if coral_dir is None or not Path(coral_dir).exists():
+        return ""
+
+    # Lazy import: avoid circular dep at module load (template imported by
+    # other startup paths).
+    from coral.hub.attempts import read_eval_count
+    from coral.hub.falsifications import list_topics
+
+    sharing = config.sharing
+    # sharing.falsification.{quorum,ttl_evals} (FalsificationConfig sub-config)
+    falsification = getattr(sharing, "falsification", None)
+    quorum = max(1, int(getattr(falsification, "quorum", 2) or 2))
+    default_ttl = max(1, int(getattr(falsification, "ttl_evals", 30) or 30))
+    current_eval = read_eval_count(coral_dir)
+
+    try:
+        statuses = list_topics(
+            coral_dir,
+            current_eval=current_eval,
+            quorum=quorum,
+            default_ttl=default_ttl,
+        )
+    except Exception:
+        # Defensive: a broken note shouldn't prevent agent startup.
+        return ""
+
+    consensus = [s for s in statuses if s.level == "consensus"]
+    disputed = [s for s in statuses if s.level in ("disputed", "stale")]
+
+    # Always render the section header so agents discover the CLI commands
+    # (`coral falsify` / `coral falsified` / `coral disputed`) — even when
+    # the ledger is empty. Otherwise agents who never see a populated
+    # ledger never learn the mechanism exists.
+
+    lines: list[str] = ["", "## Team falsification ledger"]
+    lines.append(
+        f"\nA topic counts as **team consensus** only after {quorum} distinct "
+        f"agents have independently claimed it dead within the last "
+        f"{default_ttl} evals. A lone claim is **disputed** until a second "
+        "agent confirms it, and any claim expires past TTL to **stale**.\n"
+        "Vote (only after a real failed eval): "
+        "`coral falsify <slug> -m \"evidence\"`. "
+        "Inspect: `coral falsified` / `coral disputed`. "
+        "If the team has marked something disputed/stale, treat it as a "
+        "*hypothesis worth re-testing*, not a confirmed dead-end."
+    )
+
+    if consensus:
+        lines.append("\n### Consensus (don't waste evals here without new evidence)")
+        for s in consensus:
+            voices = ", ".join(s.voices)
+            lines.append(f"- **{s.topic}** — confirmed by: {voices}")
+
+    if disputed:
+        lines.append("\n### Disputed / stale (single voice or expired — worth re-testing)")
+        for s in disputed:
+            if s.level == "stale":
+                tag = "stale (all claims expired)"
+            else:
+                remaining = max(0, s.expires_at_eval - current_eval)
+                tag = f"disputed (1/{quorum}, expires in {remaining} evals)"
+            voices = ", ".join(s.all_voices) or "—"
+            lines.append(f"- **{s.topic}** — {tag}; claimed by: {voices}")
+
+    if not consensus and not disputed:
+        lines.append(
+            "\n*No falsification claims yet. Be the first to vote when you "
+            "have evidence a topic is dead.*"
+        )
+
+    lines.append("")  # trailing newline for clean section spacing
+    return "\n".join(lines)

--- a/coral/template/coral_single.md.template
+++ b/coral/template/coral_single.md.template
@@ -175,7 +175,7 @@ If the notes directory becomes hard to navigate, use the `organize-files` skill 
 ## Repeat
 
 Go back to Step {plan_step_num}. Keep iterating. When you run out of obvious ideas, that's when the interesting work begins — study the top attempts closely, look for patterns in what scores well, try combining approaches, {repeat_research_hint}revisit the `deep-research` skill for structured literature review, or pivot to a completely different direction.
-{tips_section}
+{tips_section}{falsifications_section}
 ## Ground Rules
 
 - **You are fully autonomous.** Do not ask for permission, do not wait for instructions. Make decisions, run experiments, iterate.

--- a/tests/test_hub_falsifications.py
+++ b/tests/test_hub_falsifications.py
@@ -1,0 +1,398 @@
+"""Tests for coral.hub.falsifications — quorum + TTL aggregation over notes."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from coral.hub.falsifications import (
+    Claim,
+    TopicStatus,
+    find_consensus,
+    find_disputed,
+    list_topics,
+    topic_status,
+    validate_slug,
+)
+
+
+def _write_note(
+    notes_dir: Path,
+    *,
+    filename: str,
+    creator: str,
+    falsifies: str,
+    claimed_at_eval: int,
+    ttl_evals: int | None = None,
+    body: str = "Reasoning goes here.",
+) -> Path:
+    """Write a note file with the given falsification frontmatter."""
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "---",
+        f"creator: {creator}",
+        "created: 2026-05-16T10:00:00+00:00",
+        f"falsifies: {falsifies}",
+        f"claimed_at_eval: {claimed_at_eval}",
+    ]
+    if ttl_evals is not None:
+        lines.append(f"ttl_evals: {ttl_evals}")
+    lines.extend(["---", "", "# Why this is dead", "", body, ""])
+    p = notes_dir / filename
+    p.write_text("\n".join(lines))
+    return p
+
+
+def _setup_coral_dir(tmpdir: str) -> Path:
+    """Build the minimal .coral/ skeleton expected by hub modules."""
+    coral_dir = Path(tmpdir) / ".coral"
+    (coral_dir / "public" / "notes").mkdir(parents=True)
+    return coral_dir
+
+
+def test_validate_slug_accepts_kebab_case():
+    validate_slug("xfmr-distill")
+    validate_slug("a")
+    validate_slug("a1-b2-c3")
+    validate_slug("ssm-distill-student")
+    validate_slug("v3")
+
+
+def test_validate_slug_rejects_non_kebab_case():
+    bad = [
+        "",
+        "XfmrDistill",
+        "xfmr_distill",
+        "xfmr distill",
+        "-leading",
+        "trailing-",
+        "double--dash",
+        "Capital",
+        "snake_case_topic",
+        "with.dot",
+        "with/slash",
+    ]
+    for s in bad:
+        with pytest.raises(ValueError):
+            validate_slug(s)
+
+
+def test_single_voice_within_ttl_is_disputed():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        _write_note(
+            notes_dir,
+            filename="agent-1-claim.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+        )
+        topics = list_topics(coral_dir, current_eval=15, quorum=2, default_ttl=30)
+        assert len(topics) == 1
+        s = topics[0]
+        assert s.topic == "xfmr-distill"
+        assert s.level == "disputed"
+        assert s.voices == ["agent-1"]
+
+
+def test_two_distinct_voices_within_ttl_is_consensus():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        _write_note(
+            notes_dir,
+            filename="agent-1-claim.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+        )
+        _write_note(
+            notes_dir,
+            filename="agent-2-claim.md",
+            creator="agent-2",
+            falsifies="xfmr-distill",
+            claimed_at_eval=12,
+        )
+        topics = list_topics(coral_dir, current_eval=15, quorum=2, default_ttl=30)
+        assert len(topics) == 1
+        s = topics[0]
+        assert s.level == "consensus"
+        assert s.voices == ["agent-1", "agent-2"]
+        # Latest expiry across active claims
+        assert s.expires_at_eval == 42
+
+
+def test_two_voices_both_expired_is_stale():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        _write_note(
+            notes_dir,
+            filename="agent-1-claim.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+            ttl_evals=5,
+        )
+        _write_note(
+            notes_dir,
+            filename="agent-2-claim.md",
+            creator="agent-2",
+            falsifies="xfmr-distill",
+            claimed_at_eval=12,
+            ttl_evals=5,
+        )
+        topics = list_topics(coral_dir, current_eval=100, quorum=2, default_ttl=30)
+        assert len(topics) == 1
+        s = topics[0]
+        assert s.level == "stale"
+        assert s.voices == []  # no ACTIVE voices
+        assert s.all_voices == ["agent-1", "agent-2"]
+
+
+def test_same_agent_two_claims_does_not_reach_quorum():
+    """Two claims from the same agent should not satisfy quorum=2 — quorum
+    counts DISTINCT agents."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        _write_note(
+            notes_dir,
+            filename="claim-1.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+        )
+        _write_note(
+            notes_dir,
+            filename="claim-2.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=12,
+        )
+        topics = list_topics(coral_dir, current_eval=15, quorum=2, default_ttl=30)
+        assert topics[0].level == "disputed"
+        assert topics[0].voices == ["agent-1"]
+
+
+def test_quorum_one_promotes_single_voice_to_consensus():
+    """For single-agent runs, quorum=1 means a lone claim is consensus."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        _write_note(
+            notes_dir,
+            filename="claim.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+        )
+        topics = list_topics(coral_dir, current_eval=15, quorum=1, default_ttl=30)
+        assert topics[0].level == "consensus"
+
+
+def test_one_active_one_expired_still_disputed():
+    """If one voice has expired, it stops counting toward quorum."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        _write_note(
+            notes_dir,
+            filename="old.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+            ttl_evals=5,  # expires at eval 15
+        )
+        _write_note(
+            notes_dir,
+            filename="fresh.md",
+            creator="agent-2",
+            falsifies="xfmr-distill",
+            claimed_at_eval=50,
+            ttl_evals=30,  # expires at eval 80
+        )
+        topics = list_topics(coral_dir, current_eval=60, quorum=2, default_ttl=30)
+        s = topics[0]
+        assert s.level == "disputed"
+        assert s.voices == ["agent-2"]  # agent-1's claim expired
+        assert s.all_voices == ["agent-1", "agent-2"]
+
+
+def test_unrelated_topics_are_independent():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        _write_note(
+            notes_dir,
+            filename="a.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+        )
+        _write_note(
+            notes_dir,
+            filename="b.md",
+            creator="agent-2",
+            falsifies="ssm-distill",
+            claimed_at_eval=11,
+        )
+        topics = list_topics(coral_dir, current_eval=15, quorum=2, default_ttl=30)
+        assert len(topics) == 2
+        # Each topic has only one voice → both disputed
+        assert all(t.level == "disputed" for t in topics)
+        assert sorted(t.topic for t in topics) == ["ssm-distill", "xfmr-distill"]
+
+
+def test_notes_without_falsifies_field_are_ignored():
+    """Plain research/synthesis notes shouldn't be treated as claims."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        # plain note (no falsifies field)
+        plain = notes_dir / "plain.md"
+        plain.write_text(
+            "---\ncreator: agent-1\ncreated: 2026-05-16\n---\n# Just thoughts\n"
+        )
+        # claim note
+        _write_note(
+            notes_dir,
+            filename="claim.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+        )
+        topics = list_topics(coral_dir, current_eval=15, quorum=2, default_ttl=30)
+        assert len(topics) == 1
+        assert topics[0].topic == "xfmr-distill"
+
+
+def test_note_with_invalid_slug_is_skipped():
+    """If an agent hand-edits frontmatter with a bad slug, skip silently."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        bad = notes_dir / "bad.md"
+        bad.write_text(
+            "---\n"
+            "creator: agent-1\n"
+            "created: 2026-05-16\n"
+            "falsifies: BadSlug_with_underscore\n"
+            "claimed_at_eval: 10\n"
+            "---\n# bad\n"
+        )
+        _write_note(
+            notes_dir,
+            filename="good.md",
+            creator="agent-1",
+            falsifies="good-slug",
+            claimed_at_eval=10,
+        )
+        topics = list_topics(coral_dir, current_eval=15, quorum=2, default_ttl=30)
+        assert len(topics) == 1
+        assert topics[0].topic == "good-slug"
+
+
+def test_default_ttl_used_when_unset_in_note():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        _write_note(
+            notes_dir,
+            filename="claim.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+            ttl_evals=None,  # not written
+        )
+        # default_ttl=30 means active until eval 40
+        active_topics = list_topics(coral_dir, current_eval=39, quorum=2, default_ttl=30)
+        assert active_topics[0].level == "disputed"
+        stale_topics = list_topics(coral_dir, current_eval=41, quorum=2, default_ttl=30)
+        assert stale_topics[0].level == "stale"
+
+
+def test_find_disputed_excludes_consensus():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        notes_dir = coral_dir / "public" / "notes"
+        # Consensus: 2 voices on cnn-distill
+        _write_note(
+            notes_dir,
+            filename="cnn-1.md",
+            creator="agent-1",
+            falsifies="cnn-distill",
+            claimed_at_eval=10,
+        )
+        _write_note(
+            notes_dir,
+            filename="cnn-2.md",
+            creator="agent-2",
+            falsifies="cnn-distill",
+            claimed_at_eval=11,
+        )
+        # Disputed: 1 voice on xfmr-distill
+        _write_note(
+            notes_dir,
+            filename="xfmr-1.md",
+            creator="agent-1",
+            falsifies="xfmr-distill",
+            claimed_at_eval=10,
+        )
+        # Stale: claim past TTL
+        _write_note(
+            notes_dir,
+            filename="ssm-1.md",
+            creator="agent-1",
+            falsifies="ssm-distill",
+            claimed_at_eval=10,
+            ttl_evals=5,
+        )
+
+        disputed = find_disputed(coral_dir, current_eval=20, quorum=2, default_ttl=30)
+        topics_returned = sorted(s.topic for s in disputed)
+        assert topics_returned == ["ssm-distill", "xfmr-distill"]
+
+        consensus = find_consensus(coral_dir, current_eval=20, quorum=2, default_ttl=30)
+        assert [s.topic for s in consensus] == ["cnn-distill"]
+
+
+def test_topic_status_for_unknown_topic():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        s = topic_status(
+            "never-claimed",
+            coral_dir,
+            current_eval=10,
+            quorum=2,
+            default_ttl=30,
+        )
+        assert s.level == "unknown"
+
+
+def test_topic_status_validates_slug():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = _setup_coral_dir(d)
+        with pytest.raises(ValueError):
+            topic_status("BadSlug", coral_dir, current_eval=0)
+
+
+def test_dataclass_helpers():
+    c = Claim(
+        topic="x",
+        creator="agent-1",
+        claimed_at_eval=10,
+        ttl_evals=20,
+        note_path="claim.md",
+        title="t",
+    )
+    assert c.expires_at_eval() == 30
+    assert c.is_active(20) is True
+    assert c.is_active(30) is False  # boundary: expired exactly at expires_at_eval
+    assert c.is_active(31) is False
+
+    s = TopicStatus(topic="x", level="disputed", voices=["agent-1"])
+    assert s.evidence_paths() == []

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -149,3 +149,91 @@ def test_generate_coral_md_score_direction_from_config():
         )
         md = generate_coral_md(config, "agent-1")
         assert expected in md, f"Missing '{expected}' for direction '{direction}'"
+
+
+def test_generate_coral_md_omits_falsification_section_when_no_coral_dir():
+    """No coral_dir -> section is omitted (test/fresh-render path).
+
+    The section only appears when a coral_dir is provided. When agents are
+    actually running the section is always rendered (even if empty) so they
+    discover the CLI commands; but generate_coral_md without a coral_dir
+    (e.g. early validate-time renders) suppresses it entirely.
+    """
+    config = CoralConfig(
+        task=TaskConfig(name="t", description="d"),
+        grader=GraderConfig(),
+    )
+    md = generate_coral_md(config, "agent-1")
+    assert "Team falsification ledger" not in md
+
+
+def test_generate_coral_md_renders_empty_ledger_intro_when_no_claims():
+    """When a coral_dir exists but has no claims, render an intro so agents
+    still discover `coral falsify`."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d) / ".coral"
+        (coral_dir / "public" / "notes").mkdir(parents=True)
+        config = CoralConfig(
+            task=TaskConfig(name="t", description="d"),
+            grader=GraderConfig(),
+        )
+        md = generate_coral_md(config, "agent-1", coral_dir=coral_dir)
+        assert "Team falsification ledger" in md
+        assert "coral falsify" in md
+        assert "No falsification claims yet" in md
+
+
+def test_generate_coral_md_renders_consensus_and_disputed():
+    """When claims exist, the section appears with proper status tagging."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d) / ".coral"
+        notes_dir = coral_dir / "public" / "notes"
+        notes_dir.mkdir(parents=True)
+        # Consensus: 2 voices on cnn-distill
+        (notes_dir / "agent-1-cnn.md").write_text(
+            "---\n"
+            "creator: agent-1\n"
+            "created: 2026-05-16\n"
+            "falsifies: cnn-distill\n"
+            "claimed_at_eval: 5\n"
+            "---\n# x"
+        )
+        (notes_dir / "agent-2-cnn.md").write_text(
+            "---\n"
+            "creator: agent-2\n"
+            "created: 2026-05-16\n"
+            "falsifies: cnn-distill\n"
+            "claimed_at_eval: 6\n"
+            "---\n# x"
+        )
+        # Disputed: 1 voice on xfmr-distill
+        (notes_dir / "agent-1-xfmr.md").write_text(
+            "---\n"
+            "creator: agent-1\n"
+            "created: 2026-05-16\n"
+            "falsifies: xfmr-distill\n"
+            "claimed_at_eval: 5\n"
+            "---\n# x"
+        )
+        # current eval below all TTL boundaries
+        (coral_dir / "public" / "eval_count").write_text("10")
+
+        config = CoralConfig(
+            task=TaskConfig(name="t", description="d"),
+            grader=GraderConfig(),
+        )
+        md = generate_coral_md(config, "agent-1", coral_dir=coral_dir)
+        assert "Team falsification ledger" in md
+        # consensus row
+        assert "cnn-distill" in md
+        assert "agent-1, agent-2" in md  # active voices joined
+        # disputed row
+        assert "xfmr-distill" in md
+        assert "disputed" in md
+


### PR DESCRIPTION
## Summary

Turn a single agent's \"this approach is dead\" note into a *proposal* instead of a team-wide verdict:

- A topic counts as **team consensus** only after `quorum` distinct agents independently claim it falsified within `ttl_evals` global evals
- A lone claim is **disputed** until a second agent confirms
- Any claim expires past TTL to **stale**, forcing periodic re-tests of the team's own dead-end list

Adds three CLI commands (`coral falsify <slug> -m \"...\"`, `coral falsified`, `coral disputed`), a CORAL.md section that surfaces the ledger to every agent at startup, and an opt-in `retest_disputed` heartbeat prompt.

## Motivation

On the pfly-detectability run 2026-05-15_155906, a single agent wrote `cnn-distill-falsified.md`, `xfmr-distill-falsified.md`, `tcn-distill-falsified.md`, etc. — 50+ notes in total — and the entire 4-agent team treated those as settled fact. The team plateaued at 0.68121, **0.0025 below** a prior 2-agent run that hadn't had time to build the same blacklist. The single-voice-as-verdict failure mode is what this PR fixes.

## API

**YAML config** (defaults shown):

\`\`\`yaml
sharing:
  falsification:
    quorum: 2          # min distinct agents to reach consensus
    ttl_evals: 30      # claim expires past this
\`\`\`

**CLI** (run from inside an agent worktree):

\`\`\`bash
coral falsify xfmr-distill -m \"ADD at w=0.04 → -0.00018, eval 28\"
coral falsified                 # consensus topics
coral disputed                  # single-voice or expired (candidates for re-test)
\`\`\`

**Heartbeat** (opt-in):

\`\`\`yaml
agents:
  heartbeat:
    - name: retest_disputed
      trigger: plateau
      every: 3
\`\`\`

When the agent plateaus AND \`coral disputed\` is non-empty, prompts the agent to re-test one of the team's softest verdicts before pivoting to something brand new.

## Design choices

Per Q&A in plan-mode session:
- **Pure agent claim** (no graded-commit attachment) — vote is just a note with structured frontmatter
- **Forced kebab-case slug** (`^[a-z0-9]+(-[a-z0-9]+)*$`) so identifiers don't fragment
- **Extends existing notes' YAML frontmatter** — zero new on-disk format

The aggregator (`coral/hub/falsifications.py`) is read-only over the existing `list_notes()`. It uses an \"anchor\" model: scan all notes, group by topic, count distinct active voices (claim within TTL window). Status is `consensus` if ≥quorum voices, `disputed` if some but <quorum voices, `stale` if claims exist but all expired.

CORAL.md gets a new section that **always renders** (with a one-line intro pointing to the CLI commands) so agents discover the mechanism even when the ledger is empty.

## Backward compatibility

- Existing task.yaml files without `sharing.falsification` get defaults (quorum=2, ttl_evals=30).
- Existing notes without a `falsifies:` frontmatter field are ignored by the aggregator — no migration needed.
- Single-agent runs special-case: quorum=2 with only 1 agent never reaches consensus, so claims stay disputed (intended).
- \`retest_disputed\` heartbeat is opt-in only; not added to the default heartbeat list.

## Test plan

- [x] 16 tests in `tests/test_hub_falsifications.py` — slug validation, single-voice/disputed, two-voice/consensus, both-expired/stale, same-agent multi-claim ≠ quorum, quorum=1 fallback, active+expired mix, unknown-topic, invalid-slug skip
- [x] 2 new tests in `tests/test_template.py` for CORAL.md rendering (empty intro + consensus/disputed block)
- [x] `uv run pytest tests/test_hub_falsifications.py tests/test_template.py tests/test_config.py tests/test_hub.py tests/test_workspace.py tests/test_heartbeat.py` — 108 passed
- [x] `uv run ruff check coral/ tests/` clean
- [ ] E2E smoke verified on pfly-detectability live run — CLI works from each agent worktree, claims aggregate correctly, CORAL.md renders both empty and populated states

🤖 Generated with [Claude Code](https://claude.com/claude-code)