### PR TITLE
fix(agent): delegate session_id extraction to runtime on interrupt

### DIFF
--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import subprocess
 import sys
@@ -14,10 +15,46 @@ from coral.agent.exit_classifier import (
     claude_code_log_has_session_error,
 )
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, _extract_session_id, write_coral_log_entry
+from coral.agent.runtime import AgentHandle, write_coral_log_entry
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_claude_code_session_id(log_path: Path) -> str | None:
+    """Extract session_id from a Claude Code stream-json log.
+
+    Checks (in order): result lines, then any line with a session_id
+    (system init, assistant messages, etc.) — scanning from the end.
+    """
+    try:
+        lines = log_path.read_text().strip().splitlines()
+        # First pass: look for a "result" line (most authoritative)
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                if data.get("type") == "result" and data.get("session_id"):
+                    return data["session_id"]
+            except json.JSONDecodeError:
+                continue
+        # Second pass: fall back to any line with session_id
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                sid = data.get("session_id")
+                if sid:
+                    return sid
+            except json.JSONDecodeError:
+                continue
+    except Exception as e:
+        logger.debug(f"Failed to extract session_id from {log_path}: {e}")
+    return None
 
 
 class ClaudeCodeRuntime:
@@ -32,7 +69,7 @@ class ClaudeCodeRuntime:
         return ".claude"
 
     def extract_session_id(self, log_path: Path) -> str | None:
-        return _extract_session_id(log_path)
+        return _extract_claude_code_session_id(log_path)
 
     def classify_exit(
         self,

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -568,8 +568,11 @@ class AgentManager:
         handle = self.handles[idx]
         agent_id = handle.agent_id
 
-        # SIGINT the agent — Claude Code saves session gracefully
-        session_id = handle.interrupt()
+        # SIGINT the agent — it saves the session so we can resume it.
+        # Each CLI emits a different log format, so extract the session_id
+        # via the owning runtime after interrupt() returns.
+        handle.interrupt()
+        session_id = self._runtime_for(agent_id).extract_session_id(handle.log_path)
         self._restart_counts[agent_id] = self._restart_counts.get(agent_id, 0) + 1
 
         if session_id:

--- a/coral/agent/runtime.py
+++ b/coral/agent/runtime.py
@@ -118,14 +118,15 @@ class AgentHandle:
             except Exception:
                 pass
 
-    def interrupt(self) -> str | None:
+    def interrupt(self) -> None:
         """Interrupt a running agent via SIGINT (like Ctrl+C).
 
         Claude Code handles SIGINT gracefully — it saves the session so it can
-        be resumed later. Returns the session_id extracted from the log, or None.
+        be resumed later. Callers extract the session_id themselves via the
+        runtime (each CLI emits a different log format).
         """
         if not self.process or not self.alive:
-            return _extract_session_id(self.log_path)
+            return
 
         pid = self.process.pid
         logger.info(f"Interrupting agent {self.agent_id} (PID {pid}) with SIGINT")
@@ -160,8 +161,6 @@ class AgentHandle:
                 self.err_file.close()  # type: ignore[attr-defined]
             except Exception:
                 pass
-
-        return _extract_session_id(self.log_path)
 
     def __del__(self) -> None:
         """Safety net: ensure process and file handles are cleaned up on GC."""
@@ -211,39 +210,3 @@ def write_coral_log_entry(
         entry["task_description"] = task_description
     log_file.write(json.dumps(entry) + "\n")
     log_file.flush()
-
-
-def _extract_session_id(log_path: Path) -> str | None:
-    """Extract session_id from a stream-json log.
-
-    Checks (in order): result lines, then any line with a session_id
-    (system init, assistant messages, etc.) — scanning from the end.
-    """
-    try:
-        lines = log_path.read_text().strip().splitlines()
-        # First pass: look for a "result" line (most authoritative)
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                data = json.loads(line)
-                if data.get("type") == "result" and data.get("session_id"):
-                    return data["session_id"]
-            except json.JSONDecodeError:
-                continue
-        # Second pass: fall back to any line with session_id
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                data = json.loads(line)
-                sid = data.get("session_id")
-                if sid:
-                    return sid
-            except json.JSONDecodeError:
-                continue
-    except Exception as e:
-        logger.debug(f"Failed to extract session_id from {log_path}: {e}")
-    return None


### PR DESCRIPTION
AgentHandle.interrupt() was hard-coded to the Claude-Code-shaped _extract_session_id helper, which only looks for the "session_id" key and "type": "result" lines. On every other runtime (OpenCode emits "sessionID", Pi nests session ids inside {"type":"session"}, Kiro has no session API, etc.) the helper returned None, so every stall-triggered restart logged "No session_id for X, starting fresh" and discarded the in-progress session.

Bind the owning runtime to AgentHandle at construction and have interrupt() delegate to runtime.extract_session_id. The fallback preserves current behavior when a handle is constructed without a runtime bound.

Verified end-to-end with a fake OpenCode log (sessionID):
- unbound handle still returns None (pre-existing behavior)
- OpenCodeRuntime-bound handle returns the correct session id
- 289 tests pass, ruff clean

<!--
Thanks for contributing to CORAL! A few notes before you submit:

- See CONTRIBUTING.md for the full workflow.
- Keep PRs scoped. Unrelated cleanups belong in a separate PR.
- Make sure `uv run pytest tests/ -v` and `uv run ruff check .` pass locally.
- If you used an AI coding agent to author this PR, also read AGENTS.md.
-->

## Motivation

<!-- Why is this change needed? Link related issues (e.g. "Closes #123"). -->

## Changes

<!-- What does this PR actually do? High-level summary, not a file-by-file rehash. -->

## Test plan

<!--
How did you verify this works? Concrete commands + results, not "I tested it".
Examples:
  - `uv run pytest tests/grader/ -v` (all green)
  - Smoke-ran `coral start -c examples/mnist/task.yaml agents.count=1` to first finalized score
  - `coral validate examples/<new-task>/`
-->

## Affected areas

<!-- Tick what this PR touches so reviewers know where to focus. -->

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other: <!-- specify -->

## Checklist

- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
