### PR TITLE
feat(agent): default max_turns to 0 (no per-session cap)

### DIFF
--- a/coral/_version.py
+++ b/coral/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '0.5.2.dev2+g35c7fbbe7.d20260509'
-__version_tuple__ = version_tuple = (0, 5, 2, 'dev2', 'g35c7fbbe7.d20260509')
+__version__ = version = '0.5.2.dev28+g712f593d3.d20260531'
+__version_tuple__ = version_tuple = (0, 5, 2, 'dev28', 'g712f593d3.d20260531')
 
 __commit_id__ = commit_id = None

--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -102,7 +102,7 @@ class ClaudeCodeRuntime:
         coral_md_path: Path,
         model: str = "opus",
         runtime_options: dict[str, Any] | None = None,
-        max_turns: int = 200,
+        max_turns: int = 0,
         log_dir: Path | None = None,
         verbose: bool = False,
         resume_session_id: str | None = None,
@@ -138,12 +138,19 @@ class ClaudeCodeRuntime:
             prompt,
             "--model",
             model,
-            "--max-turns",
-            str(max_turns),
-            "--output-format",
-            "stream-json",
-            "--verbose",
         ]
+        # 0 = no cap — let the underlying `claude` CLI run until it exits
+        # naturally. The manager still restarts on any exit, preserving context
+        # via --resume below.
+        if max_turns > 0:
+            cmd.extend(["--max-turns", str(max_turns)])
+        cmd.extend(
+            [
+                "--output-format",
+                "stream-json",
+                "--verbose",
+            ]
+        )
 
         # Extra paths added to the Claude Code session sandbox via --add-dir.
         # Lets callers (e.g. judge graders) grant tool access to a sibling

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -84,7 +84,7 @@ class CodexRuntime:
         coral_md_path: Path,
         model: str = "gpt-5.4",
         runtime_options: dict[str, Any] | None = None,
-        max_turns: int = 200,
+        max_turns: int = 0,
         log_dir: Path | None = None,
         verbose: bool = False,
         resume_session_id: str | None = None,

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -118,7 +118,7 @@ class CursorAgentRuntime:
         coral_md_path: Path,
         model: str = "auto",
         runtime_options: dict[str, Any] | None = None,
-        max_turns: int = 200,
+        max_turns: int = 0,
         log_dir: Path | None = None,
         verbose: bool = False,
         resume_session_id: str | None = None,

--- a/coral/agent/builtin/kiro.py
+++ b/coral/agent/builtin/kiro.py
@@ -52,7 +52,7 @@ class KiroRuntime:
         coral_md_path: Path,
         model: str = "default",
         runtime_options: dict[str, Any] | None = None,
-        max_turns: int = 200,
+        max_turns: int = 0,
         log_dir: Path | None = None,
         verbose: bool = False,
         resume_session_id: str | None = None,

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -81,7 +81,7 @@ class OpenCodeRuntime:
         coral_md_path: Path,
         model: str = "gpt-5",
         runtime_options: dict[str, Any] | None = None,
-        max_turns: int = 200,
+        max_turns: int = 0,
         log_dir: Path | None = None,
         verbose: bool = False,
         resume_session_id: str | None = None,

--- a/coral/agent/builtin/pi_agent.py
+++ b/coral/agent/builtin/pi_agent.py
@@ -103,7 +103,7 @@ class PiAgentRuntime:
         coral_md_path: Path,
         model: str = "zai/glm-5.1",
         runtime_options: dict[str, Any] | None = None,
-        max_turns: int = 200,
+        max_turns: int = 0,
         log_dir: Path | None = None,
         verbose: bool = False,
         resume_session_id: str | None = None,

--- a/coral/agent/runtime.py
+++ b/coral/agent/runtime.py
@@ -25,7 +25,7 @@ class AgentRuntime(Protocol):
         coral_md_path: Path,
         model: str = "sonnet",
         runtime_options: dict[str, Any] | None = None,
-        max_turns: int = 200,
+        max_turns: int = 0,
         log_dir: Path | None = None,
         verbose: bool = False,
         resume_session_id: str | None = None,

--- a/coral/config.py
+++ b/coral/config.py
@@ -150,7 +150,10 @@ class AgentConfig:
     # combo. ``agents.count`` is ignored (total = sum of assignment counts).
     # Empty fields on an assignment inherit the agents.* defaults below.
     assignments: list[AgentAssignmentConfig] = field(default_factory=list)
-    max_turns: int = 200
+    # Max agent turns per session before the runtime exits and the manager
+    # restarts the agent (preserving context via --resume). 0 = no cap, let
+    # the underlying CLI run until it exits naturally.
+    max_turns: int = 0
     # Stall watchdog: restart an agent that produces no output for this many
     # seconds. 0 disables the watchdog. Default 1200s (20 min) catches deadlocks
     # faster than the prior 3600s while still being well above legitimate quiet

--- a/examples/README.md
+++ b/examples/README.md
@@ -71,7 +71,7 @@ agents:
   count: 1                           # Number of concurrent agents (default: 1)
   runtime: claude_code               # "claude_code", "opencode", or "codex" (default: claude_code)
   model: sonnet                      # Model name or path (default: sonnet)
-  max_turns: 200                     # Max agent turns before stopping (default: 200)
+  max_turns: 0                       # Max agent turns per session (default: 0 = no cap)
   timeout: 3600                      # Agent-level timeout in seconds (default: 3600)
   research: true                     # Enable web search / literature review (default: true)
   stagger_seconds: 0                 # Delay between spawning each agent (default: 0)


### PR DESCRIPTION
The per-session turn cap was a hygiene/circuit-breaker anchor: every 200 turns the claude subprocess would exit, the manager would restart it, and context was preserved via --resume. But with --resume reliably preserving conversation history, the cap mostly added churn — the agent's own context window is the real bound, and our stall watchdog plus restart-burst breaker still catch dead/crashing agents.

Default to 0 (= unlimited). For the claude_code runtime, skip the --max-turns flag entirely when max_turns is 0 so the underlying CLI uses its native (unlimited) default. Update the README example to match.

<!--
Thanks for contributing to CORAL! A few notes before you submit:

- See CONTRIBUTING.md for the full workflow.
- Keep PRs scoped. Unrelated cleanups belong in a separate PR.
- Make sure `uv run pytest tests/ -v` and `uv run ruff check .` pass locally.
- If you used an AI coding agent to author this PR, also read AGENTS.md.
-->

## Motivation

<!-- Why is this change needed? Link related issues (e.g. "Closes #123"). -->

## Changes

<!-- What does this PR actually do? High-level summary, not a file-by-file rehash. -->

## Test plan

<!--
How did you verify this works? Concrete commands + results, not "I tested it".
Examples:
  - `uv run pytest tests/grader/ -v` (all green)
  - Smoke-ran `coral start -c examples/mnist/task.yaml agents.count=1` to first finalized score
  - `coral validate examples/<new-task>/`
-->

## Affected areas

<!-- Tick what this PR touches so reviewers know where to focus. -->

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other: <!-- specify -->

## Checklist

- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
