### PR TITLE
fix(graders): read harbor v0.13 n_completed_trials from stats

### DIFF
--- a/examples/swebench-verified/grader/src/swebench_verified_grader/grader.py
+++ b/examples/swebench-verified/grader/src/swebench_verified_grader/grader.py
@@ -189,12 +189,18 @@ class Grader(TaskGrader):
     def _parse_job_result(
         self, job_result: dict, job_dir: Path, elapsed: float, tier_name: str = "",
     ) -> tuple[float, str]:
-        """Parse harbor job result.json and return (pass_rate, feedback)."""
-        stats = job_result.get("stats", job_result)
-        n_trials = stats.get("n_trials", 0)
-        n_errors = stats.get("n_errors", 0)
+        """Parse harbor job result.json and return (pass_rate, feedback).
 
-        if n_trials == 0:
+        Harbor v0.13 result.json schema:
+          - top: n_total_trials, n_errors (may be None when no errors)
+          - stats: n_completed_trials, n_errored_trials, n_pending_trials, ...
+          - stats.evals[<key>]: n_trials (per-eval count), n_errors, pass_at_k, reward_stats
+        """
+        stats = job_result.get("stats", job_result)
+        n_completed = stats.get("n_completed_trials", 0)
+        n_errors = stats.get("n_errored_trials", 0) or 0
+
+        if n_completed == 0:
             return (0.0, "No trials completed")
 
         # Aggregate pass rate from evals
@@ -238,7 +244,7 @@ class Grader(TaskGrader):
         # Build feedback
         lines = [
             f"## SWE-bench Results ({tier_name}): {overall_rate:.1%} pass rate",
-            f"Completed {n_trials} trials in {elapsed:.0f}s "
+            f"Completed {n_completed} trials in {elapsed:.0f}s "
             f"({n_errors} errors)",
             "",
         ]

--- a/examples/terminal-bench/grader/src/terminal_bench_grader/grader.py
+++ b/examples/terminal-bench/grader/src/terminal_bench_grader/grader.py
@@ -190,15 +190,22 @@ class Grader(TaskGrader):
     def _parse_job_result(
         self, job_result: dict, job_dir: Path, elapsed: float, tier_name: str = "",
     ) -> tuple[float, str]:
-        """Parse harbor job result.json and return (pass_rate, feedback)."""
-        n_trials = job_result.get("n_trials", 0)
-        n_errors = job_result.get("n_errors", 0)
+        """Parse harbor job result.json and return (pass_rate, feedback).
 
-        if n_trials == 0:
+        Harbor v0.13 result.json schema:
+          - top: n_total_trials, n_errors (may be None when no errors)
+          - stats: n_completed_trials, n_errored_trials, n_pending_trials, ...
+          - stats.evals[<key>]: n_trials (per-eval count), n_errors, pass_at_k, reward_stats
+        """
+        stats = job_result.get("stats", job_result)
+        n_completed = stats.get("n_completed_trials", 0)
+        n_errors = stats.get("n_errored_trials", 0) or 0
+
+        if n_completed == 0:
             return (0.0, "No trials completed")
 
         # Aggregate pass rate from evals
-        evals = job_result.get("evals", {})
+        evals = stats.get("evals", {})
         total_passed = 0
         total_trials = 0
         reward_details = []
@@ -239,7 +246,7 @@ class Grader(TaskGrader):
         # Build feedback
         lines = [
             f"## Terminal-bench Results ({tier_name}): {overall_rate:.1%} pass rate",
-            f"Completed {n_trials} trials in {elapsed:.0f}s "
+            f"Completed {n_completed} trials in {elapsed:.0f}s "
             f"({n_errors} errors)",
             "",
         ]

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -74,9 +74,7 @@ def _make_swebench_result(n_completed: int = 5, n_passed: int = 2) -> dict:
                     "reward_stats": {
                         "reward": {
                             "1.0": [f"trial-{i}" for i in range(n_passed)],
-                            "0.0": [
-                                f"trial-{i}" for i in range(n_passed, n_completed)
-                            ],
+                            "0.0": [f"trial-{i}" for i in range(n_passed, n_completed)],
                         }
                     },
                     "exception_stats": {},
@@ -115,9 +113,7 @@ def _make_terminal_bench_result(n_completed: int = 4, n_passed: int = 2) -> dict
                     "reward_stats": {
                         "reward": {
                             "1.0": [f"trial-{i}" for i in range(n_passed)],
-                            "0.0": [
-                                f"trial-{i}" for i in range(n_passed, n_completed)
-                            ],
+                            "0.0": [f"trial-{i}" for i in range(n_passed, n_completed)],
                         }
                     },
                     "exception_stats": {},
@@ -135,8 +131,8 @@ def test_swebench_parse_job_result_uses_completed_trials():
     because the old code did `stats.get("n_trials", 0)` which is None in
     harbor v0.13, triggering the "No trials completed" early return.
     """
-    Grader = _swebench_grader()
-    grader = Grader.__new__(Grader)  # bypass __init__ — _parse_job_result is pure
+    grader_cls = _swebench_grader()
+    grader = grader_cls.__new__(grader_cls)  # bypass __init__ — _parse_job_result is pure
     grader.config = GraderConfig(args={})
 
     with tempfile.TemporaryDirectory() as job_dir:
@@ -156,8 +152,8 @@ def test_swebench_parse_job_result_uses_completed_trials():
 
 def test_swebench_parse_job_result_zero_completed_returns_zero():
     """If n_completed_trials really is 0 (eval was a total failure), score 0.0."""
-    Grader = _swebench_grader()
-    grader = Grader.__new__(Grader)
+    grader_cls = _swebench_grader()
+    grader = grader_cls.__new__(grader_cls)
     grader.config = GraderConfig(args={})
 
     with tempfile.TemporaryDirectory() as job_dir:
@@ -180,7 +176,9 @@ def test_swebench_parse_with_real_harbor_result():
     Skipped if results/ is missing (e.g. CI without local eval logs).
     """
     repo_root = Path(__file__).resolve().parent.parent
-    target = repo_root / "results" / "swebench-verified" / "latest" / ".coral" / "public" / "eval_logs"
+    target = (
+        repo_root / "results" / "swebench-verified" / "latest" / ".coral" / "public" / "eval_logs"
+    )
     real = None
     for p in target.glob("*/harbor_logs/eval_*/result.json"):
         if p.parent.parent.parent.name.startswith("172a1463"):
@@ -190,8 +188,8 @@ def test_swebench_parse_with_real_harbor_result():
         pytest.skip("results for attempt 172a1463 not present")
     job_dir = real.parent
 
-    Grader = _swebench_grader()
-    grader = Grader.__new__(Grader)
+    grader_cls = _swebench_grader()
+    grader = grader_cls.__new__(grader_cls)
     grader.config = GraderConfig(args={})
 
     job_result = json.loads(real.read_text())
@@ -199,16 +197,14 @@ def test_swebench_parse_with_real_harbor_result():
         job_result, job_dir, elapsed=1983.0, tier_name="Tier 1"
     )
     # The saved attempt had 5 trials, 2 passing (per reward_stats) → 0.4.
-    assert pass_rate == pytest.approx(0.4), (
-        f"expected 0.4 from real harbor output, got {pass_rate}"
-    )
+    assert pass_rate == pytest.approx(0.4), f"expected 0.4 from real harbor output, got {pass_rate}"
     assert "No trials completed" not in feedback
 
 
 def test_terminal_bench_parse_job_result_uses_completed_trials():
     """Same regression as swebench, for terminal-bench grader."""
-    Grader = _terminal_bench_grader()
-    grader = Grader.__new__(Grader)
+    grader_cls = _terminal_bench_grader()
+    grader = grader_cls.__new__(grader_cls)
     grader.config = GraderConfig(args={})
 
     with tempfile.TemporaryDirectory() as job_dir:
@@ -217,16 +213,14 @@ def test_terminal_bench_parse_job_result_uses_completed_trials():
             result, Path(job_dir), elapsed=1200.0, tier_name="Tier 1"
         )
 
-    assert pass_rate == pytest.approx(0.5), (
-        f"expected 2/4 = 50% pass rate, got {pass_rate:.1%}"
-    )
+    assert pass_rate == pytest.approx(0.5), f"expected 2/4 = 50% pass rate, got {pass_rate:.1%}"
     assert "Completed 4 trials" in feedback
     assert "No trials completed" not in feedback
 
 
 def test_terminal_bench_parse_job_result_zero_completed_returns_zero():
-    Grader = _terminal_bench_grader()
-    grader = Grader.__new__(Grader)
+    grader_cls = _terminal_bench_grader()
+    grader = grader_cls.__new__(grader_cls)
     grader.config = GraderConfig(args={})
 
     with tempfile.TemporaryDirectory() as job_dir:
@@ -237,7 +231,6 @@ def test_terminal_bench_parse_job_result_zero_completed_returns_zero():
 
     assert pass_rate == 0.0
     assert "No trials completed" in feedback
-
 
 
 def test_function_grader_sync():

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1,6 +1,8 @@
 """Tests for grader system."""
 
 import asyncio
+import json
+import sys
 import tempfile
 from pathlib import Path
 
@@ -13,6 +15,229 @@ from coral.grader.protocol import GraderInterface
 from coral.grader.subprocess_grader import SubprocessGrader
 from coral.grader.task_grader import DEFAULT_TUNE_DESCRIPTION, TaskGrader
 from coral.types import ScoreBundle, Task
+
+# --- Harbor grader schema tests (swebench-verified, terminal-bench) ----------
+#
+# These graders parse harbor v0.13's job result.json. The schema moved
+# `n_trials` from the top level (and from `stats`) into `stats.n_completed_trials`
+# — graders that read the old `n_trials` field hit an early "No trials completed"
+# return and score 0.0 even when trials actually completed and passed.
+# Regression: attempt 172a1463 ran 5 swebench trials, 2 passed (40%),
+# but the grader returned 0.0 because `stats["n_trials"]` was None.
+_EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+
+def _import_grader(task_dir_name: str, module: str):
+    """Import a task's grader module by adding its src/ to sys.path.
+
+    Avoids needing an editable install of the grader package for the test suite.
+    """
+    src = _EXAMPLES / task_dir_name / "grader" / "src"
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    return __import__(module, fromlist=["Grader"])
+
+
+def _swebench_grader():
+    return _import_grader("swebench-verified", "swebench_verified_grader.grader").Grader
+
+
+def _terminal_bench_grader():
+    return _import_grader("terminal-bench", "terminal_bench_grader.grader").Grader
+
+
+def _make_swebench_result(n_completed: int = 5, n_passed: int = 2) -> dict:
+    """Build a synthetic harbor v0.13 job result.json payload (swebench shape)."""
+    return {
+        "id": "test-job",
+        "started_at": "2026-06-02T00:00:00+00:00",
+        "finished_at": "2026-06-02T00:30:00+00:00",
+        "updated_at": "2026-06-02T00:30:00+00:00",
+        "n_total_trials": n_completed,
+        "n_errors": None,
+        "stats": {
+            "n_completed_trials": n_completed,
+            "n_errored_trials": 0,
+            "n_pending_trials": 0,
+            "n_running_trials": 0,
+            "n_cancelled_trials": 0,
+            "n_retries": 0,
+            "n_cache_tokens": 0,
+            "n_input_tokens": 0,
+            "n_output_tokens": 0,
+            "cost_usd": 0.0,
+            "evals": {
+                "terminus-2__MiniMax-M3__swebench-verified": {
+                    "n_trials": n_completed,
+                    "n_errors": 0,
+                    "pass_at_k": {},  # harbor v0.13 leaves this empty for swebench
+                    "reward_stats": {
+                        "reward": {
+                            "1.0": [f"trial-{i}" for i in range(n_passed)],
+                            "0.0": [
+                                f"trial-{i}" for i in range(n_passed, n_completed)
+                            ],
+                        }
+                    },
+                    "exception_stats": {},
+                    "metrics": {},
+                }
+            },
+        },
+    }
+
+
+def _make_terminal_bench_result(n_completed: int = 4, n_passed: int = 2) -> dict:
+    """Build a synthetic harbor v0.13 job result.json payload (terminal-bench shape)."""
+    return {
+        "id": "test-job",
+        "started_at": "2026-06-02T00:00:00+00:00",
+        "finished_at": "2026-06-02T00:30:00+00:00",
+        "updated_at": "2026-06-02T00:30:00+00:00",
+        "n_total_trials": n_completed,
+        "n_errors": None,
+        "stats": {
+            "n_completed_trials": n_completed,
+            "n_errored_trials": 0,
+            "n_pending_trials": 0,
+            "n_running_trials": 0,
+            "n_cancelled_trials": 0,
+            "n_retries": 0,
+            "n_cache_tokens": 0,
+            "n_input_tokens": 0,
+            "n_output_tokens": 0,
+            "cost_usd": 0.0,
+            "evals": {
+                "terminus-2__MiniMax-M3__terminal-bench": {
+                    "n_trials": n_completed,
+                    "n_errors": 0,
+                    "pass_at_k": {"1": n_passed / n_completed if n_completed else 0.0},
+                    "reward_stats": {
+                        "reward": {
+                            "1.0": [f"trial-{i}" for i in range(n_passed)],
+                            "0.0": [
+                                f"trial-{i}" for i in range(n_passed, n_completed)
+                            ],
+                        }
+                    },
+                    "exception_stats": {},
+                    "metrics": {},
+                }
+            },
+        },
+    }
+
+
+def test_swebench_parse_job_result_uses_completed_trials():
+    """Grader must read stats.n_completed_trials, not the legacy n_trials field.
+
+    Regression: attempt 172a1463 (5 trials, 2 passed → 40%) was scored 0.0
+    because the old code did `stats.get("n_trials", 0)` which is None in
+    harbor v0.13, triggering the "No trials completed" early return.
+    """
+    Grader = _swebench_grader()
+    grader = Grader.__new__(Grader)  # bypass __init__ — _parse_job_result is pure
+    grader.config = GraderConfig(args={})
+
+    with tempfile.TemporaryDirectory() as job_dir:
+        job_dir_p = Path(job_dir)
+        result = _make_swebench_result(n_completed=5, n_passed=2)
+        pass_rate, feedback = grader._parse_job_result(
+            result, job_dir_p, elapsed=1983.0, tier_name="Tier 1"
+        )
+
+    assert pass_rate == pytest.approx(0.4), (
+        f"expected 2/5 = 40% pass rate, got {pass_rate:.1%}. "
+        "Did n_completed_trials get parsed correctly?"
+    )
+    assert "Completed 5 trials" in feedback
+    assert "No trials completed" not in feedback
+
+
+def test_swebench_parse_job_result_zero_completed_returns_zero():
+    """If n_completed_trials really is 0 (eval was a total failure), score 0.0."""
+    Grader = _swebench_grader()
+    grader = Grader.__new__(Grader)
+    grader.config = GraderConfig(args={})
+
+    with tempfile.TemporaryDirectory() as job_dir:
+        result = _make_swebench_result(n_completed=0, n_passed=0)
+        pass_rate, feedback = grader._parse_job_result(
+            result, Path(job_dir), elapsed=60.0, tier_name="Tier 1"
+        )
+
+    assert pass_rate == 0.0
+    assert "No trials completed" in feedback
+
+
+def test_swebench_parse_with_real_harbor_result():
+    """Round-trip the actual result.json from the regression-1 attempt.
+
+    attempt 172a1463 ran 5 swebench trials, 2 passed, and the grader scored
+    it 0.0 due to the n_trials field mismatch. This test pins the corrected
+    behavior — the real harbor output now parses to 0.4 (2/5).
+
+    Skipped if results/ is missing (e.g. CI without local eval logs).
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    target = repo_root / "results" / "swebench-verified" / "latest" / ".coral" / "public" / "eval_logs"
+    real = None
+    for p in target.glob("*/harbor_logs/eval_*/result.json"):
+        if p.parent.parent.parent.name.startswith("172a1463"):
+            real = p
+            break
+    if real is None:
+        pytest.skip("results for attempt 172a1463 not present")
+    job_dir = real.parent
+
+    Grader = _swebench_grader()
+    grader = Grader.__new__(Grader)
+    grader.config = GraderConfig(args={})
+
+    job_result = json.loads(real.read_text())
+    pass_rate, feedback = grader._parse_job_result(
+        job_result, job_dir, elapsed=1983.0, tier_name="Tier 1"
+    )
+    # The saved attempt had 5 trials, 2 passing (per reward_stats) → 0.4.
+    assert pass_rate == pytest.approx(0.4), (
+        f"expected 0.4 from real harbor output, got {pass_rate}"
+    )
+    assert "No trials completed" not in feedback
+
+
+def test_terminal_bench_parse_job_result_uses_completed_trials():
+    """Same regression as swebench, for terminal-bench grader."""
+    Grader = _terminal_bench_grader()
+    grader = Grader.__new__(Grader)
+    grader.config = GraderConfig(args={})
+
+    with tempfile.TemporaryDirectory() as job_dir:
+        result = _make_terminal_bench_result(n_completed=4, n_passed=2)
+        pass_rate, feedback = grader._parse_job_result(
+            result, Path(job_dir), elapsed=1200.0, tier_name="Tier 1"
+        )
+
+    assert pass_rate == pytest.approx(0.5), (
+        f"expected 2/4 = 50% pass rate, got {pass_rate:.1%}"
+    )
+    assert "Completed 4 trials" in feedback
+    assert "No trials completed" not in feedback
+
+
+def test_terminal_bench_parse_job_result_zero_completed_returns_zero():
+    Grader = _terminal_bench_grader()
+    grader = Grader.__new__(Grader)
+    grader.config = GraderConfig(args={})
+
+    with tempfile.TemporaryDirectory() as job_dir:
+        result = _make_terminal_bench_result(n_completed=0, n_passed=0)
+        pass_rate, feedback = grader._parse_job_result(
+            result, Path(job_dir), elapsed=60.0, tier_name="Tier 1"
+        )
+
+    assert pass_rate == 0.0
+    assert "No trials completed" in feedback
+
 
 
 def test_function_grader_sync():


### PR DESCRIPTION
## Summary

Both `swebench-verified` and `terminal-bench` graders parsed harbor's job
result.json with the legacy `n_trials` field, which is no longer present at
the top level or under `stats` in harbor v0.13. The live schema moved:

| field             | old location | new location                  |
|-------------------|--------------|-------------------------------|
| completed count   | top + stats  | `stats.n_completed_trials`    |
| error count       | top + stats  | `stats.n_errored_trials`      |
| evals dict        | top          | `stats.evals`                 |

`n_trials` and `n_errors` still appear *per-eval* under `stats.evals[<key>]`
— the legacy field was only dropped from the rollup.

## Symptom

Any attempt that completed ≥1 trial scored **0.0** with the feedback
"No trials completed", because the early-return path fired before the
pass-rate aggregation ran. Most visible example: attempt `172a1463` in
the swebench-verified multi-island run ran 5 trials with 2 passing (40%)
but was recorded as `score: 0.0`.

## Fix

- `examples/swebench-verified/grader/.../grader.py`: read
  `stats.n_completed_trials` and `stats.n_errored_trials`
- `examples/terminal-bench/grader/.../grader.py`: switch from
  `job_result.{n_trials,n_errors,evals}` to `stats.{...}` and use the
  new field names
- `tests/test_grader.py`: regression tests using a synthetic harbor v0.13
  result.json (5/4 completed, partial pass) plus a fidelity test that
  re-parses the saved attempt `172a1463` result.json → 0.4 (not 0.0)

## Test plan

```
uv run pytest tests/test_grader.py -v
# 19 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)