### PR TITLE
feat(docs): add Vercel Web Analytics to docs site

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,4 +1,5 @@
 import { RootProvider } from 'fumadocs-ui/provider/next';
+import { Analytics } from '@vercel/analytics/next';
 import type { ReactNode } from 'react';
 import './global.css';
 
@@ -31,6 +32,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         style={{ fontFamily: "'DM Sans', system-ui, sans-serif" }}
       >
         <RootProvider theme={{ enabled: false }}>{children}</RootProvider>
+        <Analytics />
       </body>
     </html>
   );

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,8 +7,10 @@
     "": {
       "name": "coral-docs",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@types/mdx": "^2.0.13",
+        "@vercel/analytics": "^1.4.0",
         "fumadocs-core": "^15.0.0",
         "fumadocs-mdx": "^11.0.0",
         "fumadocs-ui": "^15.0.0",
@@ -2492,6 +2494,44 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@types/mdx": "^2.0.13",
+    "@vercel/analytics": "^1.4.0",
     "fumadocs-core": "^15.0.0",
     "fumadocs-mdx": "^11.0.0",
     "fumadocs-ui": "^15.0.0",


### PR DESCRIPTION
## What

Adds [Vercel Web Analytics](https://vercel.com/docs/analytics) to the docs site so visitor/pageview stats show up in the project's **Analytics** tab on Vercel.

## Changes

- `docs/app/layout.tsx` — import and mount `<Analytics />` in the root layout (covers every docs page)
- `docs/package.json` / `package-lock.json` — add `@vercel/analytics` dependency

## Follow-up (manual)

Enable analytics in the Vercel project: **Project → Analytics → Enable**. Data appears after the next deploy.

## Note on IPs

Vercel Web Analytics is GDPR-friendly and **does not expose raw IP addresses** — it reports aggregated visitors/pageviews/top-pages/referrers/countries/devices (IPs are hashed). If raw per-request IPs are needed, that requires logging `x-forwarded-for` via middleware into Vercel Runtime Logs, which is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)