### PR TITLE
feat(agent,docker): OS-user isolation for agent workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 ### 🔥 News
 
+- **[2026-06-24]** Docker session can now isolate the agent from the grader: set `agents.isolate_user=agent` to run each agent as an unprivileged user (manager and grader stay root), so agents can no longer read `.coral/private/` (grader venv, answer keys) — not even via Bash.
 - **[2026-06-13]** Legacy `eval/grader.py` grader auto-discovery is deprecated and removed — wire graders via `grader.entrypoint` pointing at a packaged grader. See the [custom grader guide](https://docs.coralxyz.com/guides/custom-grader).
 - **[2026-06-06]** CORAL v0.6.0 adds multi-island runs: partition agents into isolated islands with scoped attempts, notes, skills, heartbeat state, and migration between islands for broader exploration.
 - **[2026-04-24]** Rubric judges — two reusable LLM-judge grader packages for open-ended tasks (reports, memos, legal analysis). See the [Rubric Judges guide](https://docs.coralxyz.com/guides/rubric-judge).

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,6 +30,7 @@
 
 ### 🔥 News
 
+- **[2026-06-24]** Docker 会话支持隔离 agent 与 grader：设置 `agents.isolate_user=agent` 即可让每个 agent 以非特权用户运行（manager 与 grader 仍为 root），agent 将无法读取 `.coral/private/`（grader 虚拟环境、答案 key）—— 即使通过 Bash 也不行。
 - **[2026-06-13]** 旧版 `eval/grader.py` grader 自动发现已废弃并移除 —— 改用 `grader.entrypoint` 指向打包的 grader。详见 [自定义 Grader 文档](https://docs.coralxyz.com/guides/custom-grader)。
 - **[2026-04-24]** 新增 Rubric 评审 —— 两个开箱即用的 LLM 评审 grader 包，专为开放式任务（报告、备忘、法律分析）设计。详见 [Rubric Judges 文档](https://docs.coralxyz.com/guides/rubric-judge)。
 - **[2026-04-03]** 我们的论文 "CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery" 现已发布！请查看 [Arxiv](https://arxiv.org/abs/2604.01658v1)。

--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -15,7 +15,7 @@ from coral.agent.exit_classifier import (
     claude_code_log_has_session_error,
 )
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, write_coral_log_entry
+from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -112,6 +112,7 @@ class ClaudeCodeRuntime:
         task_description: str | None = None,
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
+        run_as_user: dict[str, Any] | None = None,
     ) -> AgentHandle:
         """Start a Claude Code agent in the given worktree."""
         agent_id_file = worktree_path / ".coral_agent_id"
@@ -183,6 +184,11 @@ class ClaudeCodeRuntime:
         if gateway_api_key:
             agent_env["ANTHROPIC_API_KEY"] = gateway_api_key
 
+        # OS-user isolation: drop the agent subprocess to the unprivileged user
+        # (no-op when run_as_user is None). Adjusts HOME so Claude Code finds its
+        # creds/session in the agent's home; returns Popen user=/group= kwargs.
+        user_kwargs = apply_run_as_user(agent_env, run_as_user)
+
         log_file = open(log_path, "w", buffering=1)  # line-buffered
 
         # Open per-agent stderr capture under public/diagnostics/<agent_id>/agent.err
@@ -218,6 +224,7 @@ class ClaudeCodeRuntime:
                 stderr=stderr_target,
                 start_new_session=True,  # own process group for clean SIGINT
                 env=agent_env,
+                **user_kwargs,
             )
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
@@ -255,6 +262,7 @@ class ClaudeCodeRuntime:
                 stderr=stderr_target,
                 start_new_session=True,  # own process group for clean SIGINT
                 env=agent_env,
+                **user_kwargs,
             )
             log_file_ref = log_file
 

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, write_coral_log_entry
+from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -94,6 +94,7 @@ class CodexRuntime:
         task_description: str | None = None,
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
+        run_as_user: dict[str, Any] | None = None,
     ) -> AgentHandle:
         """Start a Codex agent in the given worktree.
 
@@ -166,6 +167,11 @@ class CodexRuntime:
         if gateway_api_key:
             agent_env["OPENAI_API_KEY"] = gateway_api_key
 
+        # OS-user isolation: drop the agent subprocess to the unprivileged user
+        # (no-op when run_as_user is None). Adjusts HOME so codex finds its creds
+        # in the agent's home; returns Popen user=/group= kwargs.
+        user_kwargs = apply_run_as_user(agent_env, run_as_user)
+
         log_file = open(log_path, "w", buffering=1)
 
         # Per-agent stderr capture under public/diagnostics/<agent_id>/agent.err.
@@ -195,6 +201,7 @@ class CodexRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
@@ -231,6 +238,7 @@ class CodexRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
             log_file_ref = log_file
 

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, write_coral_log_entry
+from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -132,6 +132,7 @@ class CursorAgentRuntime:
         # kwargs so the manager can keep a uniform call signature.
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
+        run_as_user: dict[str, Any] | None = None,
     ) -> AgentHandle:
         agent_id_file = worktree_path / ".coral_agent_id"
         agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
@@ -194,6 +195,11 @@ class CursorAgentRuntime:
         venv_bin = str(worktree_path / ".venv" / "bin")
         agent_env["PATH"] = venv_bin + ":" + agent_env.get("PATH", "")
 
+        # OS-user isolation: drop the agent subprocess to the unprivileged
+        # user (no-op when run_as_user is None). Sets HOME so the CLI finds
+        # its creds in the agent's home; returns Popen user=/group= kwargs.
+        user_kwargs = apply_run_as_user(agent_env, run_as_user)
+
         log_file = open(log_path, "w", buffering=1)
 
         err_path: Path | None = None
@@ -222,6 +228,7 @@ class CursorAgentRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
@@ -258,6 +265,7 @@ class CursorAgentRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
             log_file_ref = log_file
 

--- a/coral/agent/builtin/kiro.py
+++ b/coral/agent/builtin/kiro.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, write_coral_log_entry
+from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -65,6 +65,7 @@ class KiroRuntime:
         # through a single signature without runtime-specific dispatch.
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
+        run_as_user: dict[str, Any] | None = None,
     ) -> AgentHandle:
         agent_id_file = worktree_path / ".coral_agent_id"
         agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
@@ -95,6 +96,11 @@ class KiroRuntime:
 
         agent_env = _clean_env()
 
+        # OS-user isolation: drop the agent subprocess to the unprivileged
+        # user (no-op when run_as_user is None). Sets HOME so the CLI finds
+        # its creds in the agent's home; returns Popen user=/group= kwargs.
+        user_kwargs = apply_run_as_user(agent_env, run_as_user)
+
         log_file = open(log_path, "w", buffering=1)
 
         # Per-agent stderr capture under public/diagnostics/<agent_id>/agent.err.
@@ -123,6 +129,7 @@ class KiroRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
 
             def _tee_output(proc, log_f, agent):
@@ -152,6 +159,7 @@ class KiroRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
             log_file_ref = log_file
 

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, write_coral_log_entry
+from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -91,6 +91,7 @@ class OpenCodeRuntime:
         task_description: str | None = None,
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
+        run_as_user: dict[str, Any] | None = None,
     ) -> AgentHandle:
         """Start an OpenCode agent in the given worktree."""
         agent_id_file = worktree_path / ".coral_agent_id"
@@ -150,6 +151,11 @@ class OpenCodeRuntime:
         if gateway_api_key:
             agent_env["OPENAI_API_KEY"] = gateway_api_key
 
+        # OS-user isolation: drop the agent subprocess to the unprivileged
+        # user (no-op when run_as_user is None). Sets HOME so the CLI finds
+        # its creds in the agent's home; returns Popen user=/group= kwargs.
+        user_kwargs = apply_run_as_user(agent_env, run_as_user)
+
         log_file = open(log_path, "w", buffering=1)
 
         # Per-agent stderr capture under public/diagnostics/<agent_id>/agent.err.
@@ -179,6 +185,7 @@ class OpenCodeRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
@@ -215,6 +222,7 @@ class OpenCodeRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
             log_file_ref = log_file
 

--- a/coral/agent/builtin/pi_agent.py
+++ b/coral/agent/builtin/pi_agent.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, write_coral_log_entry
+from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -113,6 +113,7 @@ class PiAgentRuntime:
         task_description: str | None = None,
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
+        run_as_user: dict[str, Any] | None = None,
     ) -> AgentHandle:
         """Start a Pi agent in the given worktree."""
         agent_id_file = worktree_path / ".coral_agent_id"
@@ -174,6 +175,11 @@ class PiAgentRuntime:
         if gateway_api_key:
             agent_env["OPENAI_API_KEY"] = gateway_api_key
 
+        # OS-user isolation: drop the agent subprocess to the unprivileged
+        # user (no-op when run_as_user is None). Sets HOME so the CLI finds
+        # its creds in the agent's home; returns Popen user=/group= kwargs.
+        user_kwargs = apply_run_as_user(agent_env, run_as_user)
+
         log_file = open(log_path, "w", buffering=1)
 
         err_path: Path | None = None
@@ -202,6 +208,7 @@ class PiAgentRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
@@ -238,6 +245,7 @@ class PiAgentRuntime:
                 stderr=stderr_target,
                 start_new_session=True,
                 env=agent_env,
+                **user_kwargs,
             )
             log_file_ref = log_file
 

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -592,6 +592,13 @@ class AgentManager:
         )
         (worktree_path / instruction_file).write_text(coral_md)
 
+        # OS-user isolation: chown agent-facing paths to the unprivileged user
+        # and lock .coral/private/ to root, then run the agent subprocess as
+        # that user. Manager/grader stay root. No-op when isolate_user is unset.
+        run_as_user = self._apply_user_isolation(
+            worktree_path, island_id, shared_dir_name
+        )
+
         # Start agent
         if island_id is not None:
             log_dir = self.paths.coral_dir / "islands" / str(island_id) / "logs"
@@ -613,10 +620,44 @@ class AgentManager:
             task_description=self.config.task.description,
             gateway_url=gateway_url,
             gateway_api_key=gateway_api_key,
+            run_as_user=run_as_user,
         )
         # Record fresh process start time for the exit-classifier uptime check.
         self._started_at[agent_id] = time.time()
         return handle
+
+    def _apply_user_isolation(
+        self,
+        worktree_path: Path,
+        island_id: str | int | None,
+        shared_dir_name: str,
+    ) -> dict | None:
+        """Apply the OS-user isolation ownership model and return spawn creds.
+
+        Returns ``{"uid", "gid", "home"}`` for the runtime to drop the agent
+        subprocess to, or None when ``agents.isolate_user`` is unset.
+        """
+        from coral.workspace import user_isolation as ui
+
+        isolate_user = getattr(self.config.agents, "isolate_user", "")
+        if not ui.is_enabled(isolate_user):
+            return None
+
+        spec = ui.resolve(isolate_user)  # raises if not root / user missing
+        ui.apply_ownership(
+            worktree_path,
+            self.paths.coral_dir,
+            self.paths.repo_dir,
+            spec,
+            island_id=island_id,
+        )
+        home = ui.provision_home_state(spec, shared_dir_name)
+        logger.info(
+            "Agent workspace isolated as user %s (uid=%d); private/ locked to root",
+            spec.name,
+            spec.uid,
+        )
+        return {"name": spec.name, "uid": spec.uid, "gid": spec.gid, "home": home}
 
     def _restart_agent(
         self,

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -595,9 +595,7 @@ class AgentManager:
         # OS-user isolation: chown agent-facing paths to the unprivileged user
         # and lock .coral/private/ to root, then run the agent subprocess as
         # that user. Manager/grader stay root. No-op when isolate_user is unset.
-        run_as_user = self._apply_user_isolation(
-            worktree_path, island_id, shared_dir_name
-        )
+        run_as_user = self._apply_user_isolation(worktree_path, island_id, shared_dir_name)
 
         # Start agent
         if island_id is not None:

--- a/coral/agent/runtime.py
+++ b/coral/agent/runtime.py
@@ -35,6 +35,7 @@ class AgentRuntime(Protocol):
         task_description: str | None = None,
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
+        run_as_user: dict[str, Any] | None = None,
     ) -> AgentHandle: ...
 
     def extract_session_id(self, log_path: Path) -> str | None: ...
@@ -52,6 +53,25 @@ class AgentRuntime(Protocol):
         config/skill discovery: `.claude`, `.codex`, `.opencode`, etc.
         """
         ...
+
+
+def apply_run_as_user(env: dict[str, str], run_as_user: dict[str, Any] | None) -> dict[str, Any]:
+    """Translate a ``run_as_user`` spec into Popen kwargs, adjusting ``env``.
+
+    ``run_as_user`` is ``{"uid", "gid", "home"}`` from the manager's
+    OS-user-isolation path (or None). When set, the child is launched as that
+    uid/gid (Popen drops privileges before exec — requires a root parent) and
+    its HOME/USER are pointed at the agent's home so the runtime CLI finds its
+    credentials there. Returns kwargs to splat into ``subprocess.Popen(...)``;
+    empty dict when isolation is off.
+    """
+    if not run_as_user:
+        return {}
+    home = run_as_user.get("home")
+    if home:
+        env["HOME"] = home
+        env["USER"] = env["LOGNAME"] = run_as_user.get("name", "agent")
+    return {"user": run_as_user["uid"], "group": run_as_user["gid"]}
 
 
 @dataclass

--- a/coral/cli/_helpers.py
+++ b/coral/cli/_helpers.py
@@ -228,6 +228,20 @@ def save_docker_container_name(save_dir: Path, container_name: str) -> None:
     marker.write_text(container_name)
 
 
+def docker_private_volume_name(host_run_dir: Path) -> str:
+    """Stable Docker volume name backing this run's ``.coral/private/``.
+
+    Keyed to the run dir so it survives start→resume of the same run. The volume
+    holds the grader venv + answer keys on a container-local Linux fs (not the
+    host bind mount), so its root:root 700 permissions are enforced even where
+    the host share fakes ownership (macOS Docker Desktop).
+    """
+    import hashlib
+
+    digest = hashlib.md5(str(host_run_dir.resolve()).encode()).hexdigest()[:12]
+    return f"coral-priv-{digest}"
+
+
 def kill_docker_container(coral_dir: Path) -> None:
     """Stop and remove the Docker container associated with this run."""
     for search_dir in [coral_dir / "public", coral_dir.parent]:
@@ -249,6 +263,12 @@ def kill_docker_container(coral_dir: Path) -> None:
                 )
                 if stopped:
                     print(f"Stopped Docker container: {container_name}")
+            # Remove the private-state volume backing this run (best-effort;
+            # absent on non-isolated / older runs).
+            subprocess.run(
+                [*docker_cmd(), "volume", "rm", docker_private_volume_name(coral_dir.parent)],
+                capture_output=True,
+            )
             marker.unlink(missing_ok=True)
             return
 

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from coral.agent.state import read_agent_state
 from coral.cli._helpers import (
     docker_cmd,
+    docker_private_volume_name,
     find_coral_dir,
     find_coral_dir_and_island,
     find_tmux_session,
@@ -178,12 +179,23 @@ def _build_docker_cmd(
         "-d",
         "--name",
         container_name,
+        # Task dir (incl. grader source) under a container-local 700-root dir
+        # baked into the image, so the unprivileged agent user cannot traverse
+        # to the grader source — even on macOS where the host share fakes
+        # ownership. Only root (setup, building the grader venv) reads it.
         "-v",
-        f"{config_dir}:/task:ro",
+        f"{config_dir}:/coral-setup/task:ro",
         "-v",
         f"{host_run_dir}:/app/run:rw",
         "-v",
         f"{repo_path}:/repo:rw",
+        # Back .coral/private/ with a named Docker volume (container-local Linux
+        # fs) instead of the host bind mount, so its root:root 700 perms are
+        # actually enforced — the host share (macOS Docker Desktop "fakeowner")
+        # does not enforce uid/gid, which would otherwise leak the grader venv +
+        # answer keys to the agent. Keyed to the run dir so it survives resume.
+        "-v",
+        f"{docker_private_volume_name(host_run_dir)}:/app/run/.coral/private",
     ]
 
     # Mount runtime-specific credentials
@@ -277,10 +289,15 @@ def _start_in_docker(args: argparse.Namespace, config: CoralConfig) -> None:
         [
             "start",
             "--config",
-            f"/task/{config_path.name}",
+            f"/coral-setup/task/{config_path.name}",
             "workspace.run_dir=/app/run",
             "workspace.repo_path=/repo",
             "run.session=local",
+            # Secure-by-default in Docker: run the agent as the image's
+            # unprivileged `agent` user so it cannot read root-owned
+            # .coral/private/. Listed before user overrides, so an explicit
+            # `agents.isolate_user=` (empty) on the CLI opts back out.
+            "agents.isolate_user=agent",
         ]
     )
     docker_cmd.extend(getattr(args, "overrides", []))

--- a/coral/config.py
+++ b/coral/config.py
@@ -146,6 +146,14 @@ class AgentConfig:
     gateway: GatewayConfig = field(default_factory=GatewayConfig)
     warmstart: WarmStartConfig = field(default_factory=WarmStartConfig)
     runtime_options: dict[str, Any] = field(default_factory=dict)
+    # OS-user isolation: when set (e.g. "agent"), the agent subprocess is run as
+    # this unprivileged user while the manager/grader stay root. The agent's
+    # worktree + shared state + repo are chowned to it; ``.coral/private/``
+    # (grader venv, answer keys) is kept root-owned mode 700 so the agent
+    # cannot read it even via Bash. Requires CORAL to run as root (the Docker
+    # session does); empty = no isolation (current behavior). The Docker image
+    # provides the ``agent`` user.
+    isolate_user: str = ""
     # Mix-and-match: when non-empty, each entry spawns its own runtime/model
     # combo. ``agents.count`` is ignored (total = sum of assignment counts).
     # Empty fields on an assignment inherit the agents.* defaults below.

--- a/coral/workspace/user_isolation.py
+++ b/coral/workspace/user_isolation.py
@@ -1,0 +1,142 @@
+"""OS-user isolation for agent workspaces (Docker session).
+
+The agent subprocess runs as an unprivileged user (e.g. ``agent``) while the
+manager and grader daemon stay root. Standard Unix ownership then enforces the
+one boundary that matters: the agent cannot read ``.coral/private/`` (grader
+venv, answer keys) — not even via Bash — because it is root-owned mode 700,
+while the grader (root) reads it freely.
+
+Ownership model (applied per spawn, idempotent):
+  - agent's worktree, the island state root (public/ or islands/<id>/), and the
+    run's repo/ are chowned to the agent user — it commits, writes attempts,
+    checkpoints shared state.
+  - ``.coral/private/`` is forced back to root:root mode 700.
+  - root can read/write everything regardless, so the grader is unaffected.
+
+Requires CORAL to run as root (true inside the Docker session). When
+``agents.isolate_user`` is set but CORAL is not root, this raises rather than
+silently running the agent with full privileges.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pwd
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UserSpec:
+    name: str
+    uid: int
+    gid: int
+    home: str
+
+
+class UserIsolationError(RuntimeError):
+    """Raised when isolate_user is requested but cannot be honored."""
+
+
+def is_enabled(isolate_user: str | None) -> bool:
+    return bool(isolate_user)
+
+
+def resolve(username: str) -> UserSpec:
+    """Look up the target user, validating prerequisites.
+
+    Raises UserIsolationError if CORAL is not root (can't drop privileges) or
+    the user does not exist (the Docker image must provide it).
+    """
+    if os.geteuid() != 0:
+        raise UserIsolationError(
+            f"agents.isolate_user={username!r} requires CORAL to run as root so it "
+            "can chown the workspace and drop the agent to that user. This is the "
+            "Docker session's model; on the host, run without isolate_user."
+        )
+    try:
+        pw = pwd.getpwnam(username)
+    except KeyError as e:
+        raise UserIsolationError(
+            f"isolate_user={username!r}: no such user. The Docker image must create it."
+        ) from e
+    return UserSpec(name=username, uid=pw.pw_uid, gid=pw.pw_gid, home=pw.pw_dir)
+
+
+def _chown_tree(path: Path, spec: UserSpec) -> None:
+    if not path.exists():
+        return
+    subprocess.run(
+        ["chown", "-R", f"{spec.uid}:{spec.gid}", str(path)],
+        capture_output=True,
+        check=False,
+    )
+
+
+def _lock_private(private_dir: Path) -> None:
+    """Force the private dir root-owned and unreadable to non-root."""
+    if not private_dir.exists():
+        return
+    subprocess.run(["chown", "-R", "0:0", str(private_dir)], capture_output=True, check=False)
+    # 700 on the top dir is the gate; the agent can't traverse into it at all.
+    os.chmod(private_dir, 0o700)
+
+
+def apply_ownership(
+    worktree_path: Path,
+    coral_dir: Path,
+    repo_dir: Path,
+    spec: UserSpec,
+    *,
+    island_id: str | int | None = None,
+) -> None:
+    """Chown agent-facing paths to ``spec`` and lock ``.coral/private/`` to root.
+
+    Idempotent and safe to call per spawn. Shared paths (state root, repo) are
+    re-chowned to the same user each time, which is harmless.
+    """
+    from coral.hub._island import island_root
+
+    state_root = island_root(coral_dir, island_id)
+
+    # Agent-owned: its worktree, the shared state it reads/writes, the repo it
+    # commits to. The grader is root, so root-vs-agent ownership of repo/ is
+    # fine — root bypasses permission bits.
+    _chown_tree(worktree_path, spec)
+    _chown_tree(state_root, spec)
+    _chown_tree(repo_dir, spec)
+
+    # The one hard boundary.
+    _lock_private(coral_dir / "private")
+
+    # Mixed ownership (root grader operating an agent-owned repo, and vice
+    # versa) trips git's dubious-ownership guard. Trust all repos system-wide;
+    # these are throwaway per-run repos, not a security surface.
+    subprocess.run(
+        ["git", "config", "--system", "--add", "safe.directory", "*"],
+        capture_output=True,
+        check=False,
+    )
+
+
+def provision_home_state(spec: UserSpec, shared_dir_name: str) -> str:
+    """Give the agent user a writable home copy of the runtime's creds/state.
+
+    The Docker entrypoint stages credentials into root's home
+    (``/root/.codex``, ``/root/.claude``, ...). The agent runs with
+    ``HOME=<spec.home>`` and looks there instead, so mirror the runtime's state
+    dir into the agent's home and chown it. Returns the agent HOME to set in the
+    subprocess env.
+    """
+    home = Path(spec.home)
+    home.mkdir(parents=True, exist_ok=True)
+    src = Path("/root") / shared_dir_name
+    dst = home / shared_dir_name
+    if src.is_dir() and not dst.exists():
+        subprocess.run(["cp", "-a", str(src), str(dst)], capture_output=True, check=False)
+    _chown_tree(home, spec)
+    return str(home)

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -47,6 +47,16 @@ fi\n' > /etc/profile.d/coral-venv.sh && chmod +x /etc/profile.d/coral-venv.sh
 
 # Entrypoint copies mounted credentials into a writable ~/.claude,
 # then runs coral. Host's ~/.claude is mounted at /claude-config (ro).
+# Unprivileged user for OS-isolated agents (agents.isolate_user=agent).
+# The manager/grader stay root; only the agent subprocess drops to this user,
+# which cannot read root-owned .coral/private/ (grader venv, answer keys).
+RUN useradd -m -s /bin/bash agent
+
+# Container-local 700-root dir holding the bind-mounted task/grader source.
+# The agent user cannot traverse it (overlay perms are enforced even when the
+# host share fakes ownership), so grader source/answer keys stay hidden.
+RUN mkdir -p /coral-setup && chmod 700 /coral-setup
+
 ENV CORAL_IN_DOCKER=1
 COPY docker/claude/entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/docker/codex/Dockerfile
+++ b/docker/codex/Dockerfile
@@ -45,6 +45,16 @@ if [ -d /app/.venv/bin ]; then\n\
     PATH="/app/.venv/bin:$PATH"\n\
 fi\n' > /etc/profile.d/coral-venv.sh && chmod +x /etc/profile.d/coral-venv.sh
 
+# Unprivileged user for OS-isolated agents (agents.isolate_user=agent).
+# The manager/grader stay root; only the agent subprocess drops to this user,
+# which cannot read root-owned .coral/private/ (grader venv, answer keys).
+RUN useradd -m -s /bin/bash agent
+
+# Container-local 700-root dir holding the bind-mounted task/grader source.
+# The agent user cannot traverse it (overlay perms are enforced even when the
+# host share fakes ownership), so grader source/answer keys stay hidden.
+RUN mkdir -p /coral-setup && chmod 700 /coral-setup
+
 ENV CORAL_IN_DOCKER=1
 COPY docker/codex/entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/docker/opencode/Dockerfile
+++ b/docker/opencode/Dockerfile
@@ -45,6 +45,16 @@ if [ -d /app/.venv/bin ]; then\n\
     PATH="/app/.venv/bin:$PATH"\n\
 fi\n' > /etc/profile.d/coral-venv.sh && chmod +x /etc/profile.d/coral-venv.sh
 
+# Unprivileged user for OS-isolated agents (agents.isolate_user=agent).
+# The manager/grader stay root; only the agent subprocess drops to this user,
+# which cannot read root-owned .coral/private/ (grader venv, answer keys).
+RUN useradd -m -s /bin/bash agent
+
+# Container-local 700-root dir holding the bind-mounted task/grader source.
+# The agent user cannot traverse it (overlay perms are enforced even when the
+# host share fakes ownership), so grader source/answer keys stay hidden.
+RUN mkdir -p /coral-setup && chmod 700 /coral-setup
+
 ENV CORAL_IN_DOCKER=1
 COPY docker/opencode/entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh


### PR DESCRIPTION
Fixes #136 .

## What

Run the agent subprocess as an **unprivileged user** (`agents.isolate_user`, default off) while the manager and grader daemon stay root. Standard Unix ownership then enforces the one boundary that matters: **the agent cannot read `.coral/private/` (grader venv, answer keys) — not even via Bash** — while the grader (root) reads it freely. Secure-by-default in the Docker session.

## Why

Agent isolation was advisory only — the harness `Read`-deny rules are trivially bypassed by `cat`/`grep` in Bash, so an agent could read the grader's answer key and game the leaderboard. This enforces the boundary at the OS level.

(We evaluated `@anthropic-experimental/sandbox-runtime` first; it works for FS isolation but is a Node/research-preview dependency, breaks codex's app-server under its macOS seatbelt profile, and means fighting each CLI's runtime behavior. Unix uid separation inside the existing Docker session is more mature, dependency-free, and codex/claude run as normal processes.)

## How

- **config**: `agents.isolate_user` (e.g. `"agent"`); empty = current behavior.
- **`workspace/user_isolation.py`**: chown the worktree + island state + repo to the agent, lock `.coral/private/` to `root:root 700`, provision the runtime's home creds. `resolve()` requires root + a real user (fails loud, never silently runs unsandboxed).
- **runtime**: `apply_run_as_user()` helper + `run_as_user` threaded through all six runtimes' `start()`; Popen drops via `user=/group=`. Kept **off** the `@runtime_checkable` protocol so existing custom runtimes still load.
- **cli/start.py**: Docker session passes `agents.isolate_user=agent` by default (overridable). Two host-bind-mount leaks closed for macOS Docker Desktop's permission-faking `fakeowner` share:
  - `.coral/private/` backed by a **named volume** (container-local ext4) so its 700 perms are actually enforced; keyed to the run dir (survives resume), removed on `coral stop`.
  - task/grader source mounted under a **700-root overlay dir** (`/coral-setup`) baked into the image, so the agent can't traverse to the grader source.
- **Dockerfiles** (claude/codex/opencode): add the `agent` user + `/coral-setup`.

## Verification

- `ruff` clean; existing test suite passes.
- **E2E on macOS** (kernel_builder + codex): codex runs as `uid 1000`, lands a graded eval (`score 11910, class real`), and **both `.coral/private/` and the grader source are unreadable to the agent throughout**. Control test confirms perms are enforced on container-local fs (overlay/volume) where the host `fakeowner` share is not.

## Notes

- Isolation is enforced wherever the filesystem enforces DAC (Linux prod bind mounts, and the container-local volume/overlay used here). The named-volume + `/coral-setup` design makes it hold on macOS Docker Desktop too.
- On the host (non-root) without Docker, setting `isolate_user` fails loud — it's a Docker-session feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)