### PR TITLE
feat(docker): isolate the agent as the unprivileged user by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ### 🔥 News
 
-- **[2026-06-24]** Docker session can now isolate the agent from the grader: set `agents.isolate_user=agent` to run each agent as an unprivileged user (manager and grader stay root), so agents can no longer read `.coral/private/` (grader venv, answer keys) — not even via Bash.
+- **[2026-06-24]** The Docker session now isolates the agent from the grader: each agent runs as an unprivileged user (manager and grader stay root), so agents can no longer read `.coral/private/` (grader venv, answer keys) — not even via Bash. On the host this stays opt-in via `agents.isolate_user`.
 - **[2026-06-13]** Legacy `eval/grader.py` grader auto-discovery is deprecated and removed — wire graders via `grader.entrypoint` pointing at a packaged grader. See the [custom grader guide](https://docs.coralxyz.com/guides/custom-grader).
 - **[2026-06-06]** CORAL v0.6.0 adds multi-island runs: partition agents into isolated islands with scoped attempts, notes, skills, heartbeat state, and migration between islands for broader exploration.
 - **[2026-04-24]** Rubric judges — two reusable LLM-judge grader packages for open-ended tasks (reports, memos, legal analysis). See the [Rubric Judges guide](https://docs.coralxyz.com/guides/rubric-judge).

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,7 +30,7 @@
 
 ### 🔥 News
 
-- **[2026-06-24]** Docker 会话支持隔离 agent 与 grader：设置 `agents.isolate_user=agent` 即可让每个 agent 以非特权用户运行（manager 与 grader 仍为 root），agent 将无法读取 `.coral/private/`（grader 虚拟环境、答案 key）—— 即使通过 Bash 也不行。
+- **[2026-06-24]** Docker 会话现在会隔离 agent 与 grader：每个 agent 以非特权用户运行（manager 与 grader 仍为 root），agent 将无法读取 `.coral/private/`（grader 虚拟环境、答案 key）—— 即使通过 Bash 也不行。在宿主机上仍可通过 `agents.isolate_user` 选择启用。
 - **[2026-06-13]** 旧版 `eval/grader.py` grader 自动发现已废弃并移除 —— 改用 `grader.entrypoint` 指向打包的 grader。详见 [自定义 Grader 文档](https://docs.coralxyz.com/guides/custom-grader)。
 - **[2026-04-24]** 新增 Rubric 评审 —— 两个开箱即用的 LLM 评审 grader 包，专为开放式任务（报告、备忘、法律分析）设计。详见 [Rubric Judges 文档](https://docs.coralxyz.com/guides/rubric-judge)。
 - **[2026-04-03]** 我们的论文 "CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery" 现已发布！请查看 [Arxiv](https://arxiv.org/abs/2604.01658v1)。

--- a/coral/cli/_helpers.py
+++ b/coral/cli/_helpers.py
@@ -193,6 +193,17 @@ def in_docker() -> bool:
     return Path("/.dockerenv").exists()
 
 
+def in_coral_docker_session() -> bool:
+    """True only inside CORAL's own Docker session, not any container.
+
+    Set by ``_build_docker_cmd`` via ``-e CORAL_IN_DOCKER=1``. Unlike
+    ``in_docker()``, this excludes generic containers (a plain ``/.dockerenv``)
+    that lack the baked-in ``agent`` user — so mandatory OS-user isolation is
+    forced only where the image guarantees it can be honored.
+    """
+    return os.environ.get("CORAL_IN_DOCKER") == "1"
+
+
 def is_docker_container_running(container_name: str) -> bool:
     """Check if a Docker container is currently running."""
     result = subprocess.run(

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -22,6 +22,7 @@ from coral.cli._helpers import (
     has_docker,
     has_docker_marker,
     has_tmux,
+    in_coral_docker_session,
     in_docker,
     in_tmux,
     is_docker_run_alive,
@@ -67,6 +68,22 @@ def _tmux_env() -> dict[str, str]:
     env = dict(os.environ)
     env.pop("TMUX", None)  # Allow creating sessions even if nested
     return env
+
+
+def _enforce_docker_isolation(config: CoralConfig) -> None:
+    """Apply OS-user isolation inside CORAL's Docker session.
+
+    The agent must not be able to read root-owned ``.coral/private/`` (grader
+    venv, answer keys), so inside the container ``agents.isolate_user`` is set to
+    the image's unprivileged user, overriding any config or CLI value. No-op
+    everywhere else; on the host ``agents.isolate_user`` stays opt-in. The image
+    guarantees the unprivileged user exists and the manager runs as root.
+    """
+    if not in_coral_docker_session():
+        return
+    from coral.workspace.user_isolation import DOCKER_ISOLATION_USER
+
+    config.agents.isolate_user = DOCKER_ISOLATION_USER
 
 
 def _build_coral_command(args: argparse.Namespace) -> list[str]:
@@ -293,14 +310,12 @@ def _start_in_docker(args: argparse.Namespace, config: CoralConfig) -> None:
             "workspace.run_dir=/app/run",
             "workspace.repo_path=/repo",
             "run.session=local",
-            # Secure-by-default in Docker: run the agent as the image's
-            # unprivileged `agent` user so it cannot read root-owned
-            # .coral/private/. Listed before user overrides, so an explicit
-            # `agents.isolate_user=` (empty) on the CLI opts back out.
-            "agents.isolate_user=agent",
         ]
     )
     docker_cmd.extend(getattr(args, "overrides", []))
+    # OS-user isolation is forced on inside the container by
+    # _enforce_docker_isolation (mandatory, non-overridable); no need to (and no
+    # way to) pass it as a removable CLI override here.
 
     _run_docker_container(docker_cmd, container_name)
 
@@ -413,6 +428,9 @@ def cmd_start(args: argparse.Namespace) -> None:
         config.run.session = "tmux"
     elif in_docker():
         config.run.session = "docker"
+
+    # Mandatory in the Docker session: the agent always runs isolated.
+    _enforce_docker_isolation(config)
 
     from coral.agent.manager import AgentManager
     from coral.cli.validation import validate_task
@@ -649,6 +667,12 @@ def cmd_resume(args: argparse.Namespace) -> None:
         print(f"[coral] Resuming run: {paths.run_dir}")
         print(f"[coral] Task:    {config.task.name}")
         print(f"[coral] Model:   {config.agents.model}")
+
+    # Mandatory in the Docker session: re-assert isolation on every resume so an
+    # override (or a config from before this was enforced) can never disable it.
+    _enforce_docker_isolation(config)
+    if in_coral_docker_session():
+        config.to_yaml(config_path)
 
     instruction = getattr(args, "instruction", None)
     resume_from = getattr(args, "resume_from", None)

--- a/coral/config.py
+++ b/coral/config.py
@@ -150,9 +150,10 @@ class AgentConfig:
     # this unprivileged user while the manager/grader stay root. The agent's
     # worktree + shared state + repo are chowned to it; ``.coral/private/``
     # (grader venv, answer keys) is kept root-owned mode 700 so the agent
-    # cannot read it even via Bash. Requires CORAL to run as root (the Docker
-    # session does); empty = no isolation (current behavior). The Docker image
-    # provides the ``agent`` user.
+    # cannot read it even via Bash. Requires CORAL to run as root.
+    # This field is the HOST opt-in (empty = no isolation). In CORAL's Docker
+    # session this value is forced to the image's ``agent`` user regardless of
+    # what is set here.
     isolate_user: str = ""
     # Mix-and-match: when non-empty, each entry spawns its own runtime/model
     # combo. ``agents.count`` is ignored (total = sum of assignment counts).

--- a/coral/workspace/user_isolation.py
+++ b/coral/workspace/user_isolation.py
@@ -29,6 +29,11 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# The unprivileged user baked into the Docker images. The Docker session runs
+# the agent as this user; on the host, ``agents.isolate_user`` stays opt-in
+# (empty = no isolation).
+DOCKER_ISOLATION_USER = "agent"
+
 
 @dataclass(frozen=True)
 class UserSpec:

--- a/tests/test_docker_isolation.py
+++ b/tests/test_docker_isolation.py
@@ -1,0 +1,133 @@
+"""OS-user isolation is mandatory (not a tunable) in CORAL's Docker session."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+
+import coral.cli.start as start_mod
+from coral.cli._helpers import in_coral_docker_session
+from coral.cli.start import _enforce_docker_isolation
+from coral.config import CoralConfig
+from coral.workspace.user_isolation import DOCKER_ISOLATION_USER
+
+
+def _config(isolate_user: str) -> CoralConfig:
+    cfg = CoralConfig()
+    cfg.agents.isolate_user = isolate_user
+    return cfg
+
+
+def test_in_coral_docker_session_keys_on_env(monkeypatch):
+    monkeypatch.delenv("CORAL_IN_DOCKER", raising=False)
+    assert in_coral_docker_session() is False
+    monkeypatch.setenv("CORAL_IN_DOCKER", "1")
+    assert in_coral_docker_session() is True
+    # A generic container marker alone must NOT count as CORAL's session.
+    monkeypatch.setenv("CORAL_IN_DOCKER", "0")
+    assert in_coral_docker_session() is False
+
+
+def test_host_isolation_stays_opt_in(monkeypatch):
+    monkeypatch.delenv("CORAL_IN_DOCKER", raising=False)
+
+    cfg = _config("")
+    _enforce_docker_isolation(cfg)
+    assert cfg.agents.isolate_user == ""  # no-op: opt-out preserved
+
+    cfg = _config("alice")
+    _enforce_docker_isolation(cfg)
+    assert cfg.agents.isolate_user == "alice"  # no-op: host value preserved
+
+
+@pytest.mark.parametrize("requested", ["", "alice", "root", DOCKER_ISOLATION_USER])
+def test_docker_session_forces_isolation(monkeypatch, requested):
+    """Inside CORAL's Docker session isolation is forced on regardless of input.
+
+    Covers the opt-out attempt (``agents.isolate_user=``) and any alternate user
+    a CLI override might try to slip in — all collapse to the image's user.
+    """
+    monkeypatch.setenv("CORAL_IN_DOCKER", "1")
+    cfg = _config(requested)
+    _enforce_docker_isolation(cfg)
+    assert cfg.agents.isolate_user == DOCKER_ISOLATION_USER
+
+
+# --- Wiring tests: the pure helper is correct, but isolation is only mandatory
+# if the entrypoints actually call it. These guard against the call site being
+# removed (which silently re-enables the user opt-out) — a regression the unit
+# tests above cannot see because they invoke the helper directly. ---
+
+
+def _calls_enforce(func) -> bool:
+    """True if ``func``'s body contains a direct _enforce_docker_isolation call."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_enforce_docker_isolation"
+        for node in ast.walk(tree)
+    )
+
+
+def test_both_entrypoints_wire_enforcement():
+    # Removing the call from either path re-opens the opt-out the helper closes.
+    assert _calls_enforce(start_mod.cmd_start), "cmd_start must enforce docker isolation"
+    assert _calls_enforce(start_mod.cmd_resume), "cmd_resume must enforce docker isolation"
+
+
+def test_start_in_docker_injects_no_removable_override():
+    # The host-side docker launcher must NOT pass agents.isolate_user as a CLI
+    # override — that was the removable opt-out. Enforcement now happens inside
+    # the container, so the launcher must not reference the knob at all.
+    assert "isolate_user" not in inspect.getsource(start_mod._start_in_docker)
+
+
+def test_cmd_start_forces_isolation_despite_override(monkeypatch, tmp_path):
+    """End-to-end: CORAL_IN_DOCKER=1 + a CLI override trying to set a different
+    isolation user still reaches the manager pinned to the image's user.
+
+    Drives cmd_start through the real override-merge + _enforce_docker_isolation
+    path, capturing the config the manager is constructed with. Catches both a
+    removed call site and any way an override could bypass the boundary.
+    """
+    monkeypatch.setenv("CORAL_IN_DOCKER", "1")
+
+    base = CoralConfig()
+    base.task.name = "t"  # mandatory fields; needed for the override-merge to resolve
+    base.task.description = "t"
+    base.run.session = "local"  # inner-process mode; skip the docker/tmux dispatch
+    monkeypatch.setattr(start_mod.CoralConfig, "from_yaml", classmethod(lambda cls, path: base))
+    monkeypatch.setattr(start_mod, "in_tmux", lambda: False)
+    monkeypatch.setattr("coral.cli.validation.validate_task", lambda task_dir: [])
+
+    captured = {}
+
+    class FakeManager:
+        def __init__(self, config, verbose=False, config_dir=None):
+            captured["config"] = config
+            self.specs = []
+            self.paths = SimpleNamespace(run_dir=tmp_path, coral_dir=tmp_path / ".coral")
+
+        def start_all(self):
+            return []
+
+        def monitor_loop(self):
+            pass
+
+        def wait_for_completion(self):
+            pass
+
+    monkeypatch.setattr("coral.agent.manager.AgentManager", FakeManager)
+
+    args = SimpleNamespace(
+        config=str(tmp_path / "task.yaml"),
+        overrides=["agents.isolate_user=alice"],  # user attempts an alternate user
+    )
+    start_mod.cmd_start(args)
+
+    assert captured["config"].agents.isolate_user == DOCKER_ISOLATION_USER


### PR DESCRIPTION
## What

In CORAL's Docker session, the agent now always runs as the image's unprivileged `agent` user — `agents.isolate_user` is set to `agent` inside the container regardless of config or CLI overrides. The agent therefore cannot read root-owned `.coral/private/` (grader venv, answer keys), not even via Bash. On the host, `agents.isolate_user` stays opt-in (empty = no isolation).

## Why

[#138](https://github.com/Human-Agent-Society/CORAL/pull/138) added OS-user isolation but wired it in `_start_in_docker` as a `agents.isolate_user=agent` CLI override placed *before* the user's overrides — so a user could cancel it with `agents.isolate_user=`, and resume didn't re-assert it at all. This makes isolation the standard behavior of the Docker session by enforcing it at the single point of truth (inside the container, as root), where it can't be bypassed by an override or a stale config.

## Changes

- **`coral/cli/start.py`** — `_enforce_docker_isolation()` sets `agents.isolate_user` to the image user when running in CORAL's Docker session, overriding any config/CLI value. Called in `cmd_start` and `cmd_resume` before the manager is built. Removed the removable override injection from `_start_in_docker`.
- **`coral/cli/_helpers.py`** — `in_coral_docker_session()` keys on `CORAL_IN_DOCKER=1` (narrower than `in_docker()`, which also matches `/.dockerenv`) so a *generic* container without the `agent` user isn't forced into broken isolation.
- **`coral/workspace/user_isolation.py`** — `DOCKER_ISOLATION_USER` constant.
- **`coral/config.py`** — document that the field is the host opt-in and is forced in Docker.
- **`README.md` / `README_CN.md`** — updated news entry.
- **`tests/test_docker_isolation.py`** — helper unit tests; an AST guard that both `cmd_start` and `cmd_resume` call the enforcer; an end-to-end `cmd_start` test (a CLI override setting a different user still lands as `agent` at the manager); and a guard that `_start_in_docker` injects no removable override.

## Testing

- `uv run pytest tests/` — 519 passed, 1 skipped.
- `uv run ruff check .` / `ruff format --check` — clean.
- Empirically confirmed the new tests catch the regression: removing the `cmd_start` enforcement call fails 2 tests; restoring passes all 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)