### PR TITLE
feat: add run-level auto-stop limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ coral agents remove <name> [<name>...]            # Delete one or more by name
 coral start -c task.yaml                          # Launch agents (auto-tmux)
 coral start -c task.yaml agents.count=4 agents.model=opus       # Dotlist overrides
 coral start -c task.yaml run.verbose=true run.ui=true           # Verbose + dashboard
+coral start -c task.yaml run.stop.max_real_attempts=30          # Stop after 30 finalized real attempts
 coral start -c task.yaml run.session=local                      # No tmux session
 coral resume                                      # Resume latest run (sessions restored)
 coral resume -i "Try greedy approaches"           # Inject an instruction at resume

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -53,6 +53,7 @@ from coral.hub.attempts import (
     read_attempts,
     read_eval_count,
 )
+from coral.hub.auto_stop import write_auto_stop
 from coral.hub.heartbeat import (
     DEFAULT_PROMPTS,
     DEFAULT_TRIGGER,
@@ -65,7 +66,7 @@ from coral.hub.heartbeat import (
 )
 from coral.hub.steering import ContinueFromAction, mark_applied, read_pending
 from coral.template.coral_md import generate_coral_md
-from coral.types import BUDGET_CLASS_REAL, get_budget_class
+from coral.types import BUDGET_CLASS_REAL, Attempt, get_budget_class
 from coral.workspace import (
     ProjectPaths,
     apply_runtime_mounts,
@@ -1076,6 +1077,10 @@ class AgentManager:
         selection intentionally ignores those, so using the raw counter can
         consume a cycle before any source island has eligible real signal.
         """
+        return self._get_finalized_real_attempt_count()
+
+    def _read_all_run_attempts(self) -> list[Attempt]:
+        """Read attempts across the whole run, spanning islands when present."""
         assert self.paths is not None
         coral_dir = self.paths.coral_dir
         if (coral_dir / "islands").exists():
@@ -1083,13 +1088,160 @@ class AgentManager:
             for island_dir in sorted((coral_dir / "islands").iterdir()):
                 if island_dir.is_dir():
                     attempts.extend(read_attempts(coral_dir, island_id=island_dir.name))
-        else:
-            attempts = read_attempts(coral_dir)
+            return attempts
+        return read_attempts(coral_dir)
+
+    def _get_finalized_real_attempt_count(self) -> int:
+        """Count run-wide terminal real attempts."""
+        attempts = self._read_all_run_attempts()
         return sum(
             1
             for attempt in attempts
             if attempt.status != "pending" and attempt.budget_class == BUDGET_CLASS_REAL
         )
+
+    def _latest_finalized_real_attempt(self) -> Attempt | None:
+        """Return the newest terminal real attempt, if any."""
+        attempts = [
+            a
+            for a in self._read_all_run_attempts()
+            if a.status != "pending" and a.budget_class == BUDGET_CLASS_REAL
+        ]
+        if not attempts:
+            return None
+        return max(attempts, key=lambda a: a.timestamp or "")
+
+    def _attempt_dict_for_auto_stop(
+        self, attempt: Attempt | dict[str, Any] | None
+    ) -> dict[str, Any]:
+        if attempt is None:
+            return {
+                "attempt_id": None,
+                "agent_id": None,
+                "score": None,
+                "budget_class": None,
+            }
+        if isinstance(attempt, dict):
+            return {
+                "attempt_id": attempt.get("commit_hash"),
+                "agent_id": attempt.get("agent_id"),
+                "score": attempt.get("score"),
+                "budget_class": get_budget_class(attempt.get("metadata")),
+            }
+        return {
+            "attempt_id": attempt.commit_hash,
+            "agent_id": attempt.agent_id,
+            "score": attempt.score,
+            "budget_class": attempt.budget_class,
+        }
+
+    def _score_meets_auto_stop_threshold(self, score: float | int | None, threshold: float) -> bool:
+        if score is None:
+            return False
+        value = float(score)
+        if self.config.grader.direction == "minimize":
+            return value <= threshold
+        return value >= threshold
+
+    def _auto_stop_reason_from_attempt(self, attempt_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Return the auto-stop reason for a newly finalized attempt, if any."""
+        stop_config = self.config.run.stop
+        if stop_config.score_threshold is None and stop_config.max_real_attempts is None:
+            return None
+
+        attempt_info = self._attempt_dict_for_auto_stop(attempt_data)
+        if attempt_info["budget_class"] != BUDGET_CLASS_REAL:
+            return None
+
+        real_attempt_count = self._get_finalized_real_attempt_count()
+        threshold = stop_config.score_threshold
+        if threshold is not None and self._score_meets_auto_stop_threshold(
+            attempt_info["score"], threshold
+        ):
+            return self._build_auto_stop_reason(
+                "score_threshold",
+                attempt_info,
+                real_attempt_count,
+            )
+
+        max_real_attempts = stop_config.max_real_attempts
+        if max_real_attempts is not None and real_attempt_count >= max_real_attempts:
+            return self._build_auto_stop_reason(
+                "max_real_attempts",
+                attempt_info,
+                real_attempt_count,
+            )
+        return None
+
+    def _auto_stop_reason_from_current_state(self) -> dict[str, Any] | None:
+        """Return a restart-time auto-stop reason from persisted attempts, if reached."""
+        stop_config = self.config.run.stop
+        if stop_config.score_threshold is None and stop_config.max_real_attempts is None:
+            return None
+
+        real_attempt_count = self._get_finalized_real_attempt_count()
+        threshold = stop_config.score_threshold
+        if threshold is not None:
+            assert self.paths is not None
+            best = get_leaderboard(
+                self.paths.coral_dir,
+                top_n=1,
+                direction=self.config.grader.direction,
+                include_tune=False,
+            )
+            if best and self._score_meets_auto_stop_threshold(best[0].score, threshold):
+                return self._build_auto_stop_reason(
+                    "score_threshold",
+                    self._attempt_dict_for_auto_stop(best[0]),
+                    real_attempt_count,
+                )
+
+        max_real_attempts = stop_config.max_real_attempts
+        if max_real_attempts is not None and real_attempt_count >= max_real_attempts:
+            return self._build_auto_stop_reason(
+                "max_real_attempts",
+                self._attempt_dict_for_auto_stop(self._latest_finalized_real_attempt()),
+                real_attempt_count,
+            )
+        return None
+
+    def _build_auto_stop_reason(
+        self,
+        reason: str,
+        attempt_info: dict[str, Any],
+        real_attempt_count: int,
+    ) -> dict[str, Any]:
+        stop_config = self.config.run.stop
+        return {
+            "reason": reason,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "attempt_id": attempt_info["attempt_id"],
+            "agent_id": attempt_info["agent_id"],
+            "score": attempt_info["score"],
+            "score_threshold": stop_config.score_threshold,
+            "direction": self.config.grader.direction,
+            "real_attempt_count": real_attempt_count,
+            "max_real_attempts": stop_config.max_real_attempts,
+        }
+
+    def _auto_stop(self, reason: dict[str, Any]) -> None:
+        """Record the auto-stop reason and gracefully stop the run."""
+        assert self.paths is not None
+        write_auto_stop(self.paths.coral_dir, reason)
+        logger.info(
+            "Auto-stop triggered: %s (score=%s, real_attempts=%s)",
+            reason["reason"],
+            reason["score"],
+            reason["real_attempt_count"],
+        )
+        if self.verbose:
+            print(
+                "[coral] Auto-stop: "
+                f"{reason['reason']} "
+                f"(score={reason['score']}, "
+                f"real_attempts={reason['real_attempt_count']})"
+            )
+        self.stop_all()
 
     def _get_heartbeat_runner(self, agent_id: str) -> HeartbeatRunner:
         """Build a HeartbeatRunner by merging local + global heartbeat configs."""
@@ -1925,6 +2077,11 @@ class AgentManager:
         # interrupt-and-resume cycle for the rest of the run.
         seen_attempts = self._filter_scored(self._get_seen_attempts())
 
+        startup_auto_stop = self._auto_stop_reason_from_current_state()
+        if startup_auto_stop is not None:
+            self._auto_stop(startup_auto_stop)
+            return
+
         logger.info(f"Monitoring {len(self.handles)} agent(s) (check every {check_interval}s)...")
 
         while self._running:
@@ -1982,6 +2139,14 @@ class AgentManager:
                         # Append to score history (None for broken evals — they
                         # apply plateau pressure without resetting any anchor).
                         self._agent_score_history.setdefault(committing_agent_id, []).append(score)
+
+                    auto_stop_reason = (
+                        self._auto_stop_reason_from_attempt(attempt_data)
+                        or self._auto_stop_reason_from_current_state()
+                    )
+                    if auto_stop_reason is not None:
+                        self._auto_stop(auto_stop_reason)
+                        break
 
                     score_history = self._agent_score_history.get(committing_agent_id, [])
 

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -36,6 +36,7 @@ from coral.cli._helpers import (
     setup_logging,
 )
 from coral.config import CoralConfig
+from coral.hub.auto_stop import read_auto_stop
 from coral.workspace.project import slugify
 
 
@@ -77,6 +78,27 @@ def _build_coral_command(args: argparse.Namespace) -> list[str]:
     cmd.extend(getattr(args, "overrides", []))
     cmd.append("run.session=local")
     return cmd
+
+
+def _format_auto_stop_summary(state: dict[str, object]) -> str:
+    """Format a persisted auto-stop reason for `coral status`."""
+    reason = state.get("reason") or "unknown"
+    timestamp = state.get("timestamp") or "unknown time"
+    score = state.get("score")
+    real_attempt_count = state.get("real_attempt_count")
+    if reason == "score_threshold":
+        return (
+            "Auto-stop: score threshold reached "
+            f"(score={score}, threshold={state.get('score_threshold')}, "
+            f"direction={state.get('direction')}, at={timestamp})"
+        )
+    if reason == "max_real_attempts":
+        return (
+            "Auto-stop: max real attempts reached "
+            f"(real_attempts={real_attempt_count}, "
+            f"max={state.get('max_real_attempts')}, at={timestamp})"
+        )
+    return f"Auto-stop: {reason} (at={timestamp})"
 
 
 def _start_in_tmux(args: argparse.Namespace, config: CoralConfig) -> None:
@@ -847,6 +869,10 @@ def cmd_status(args: argparse.Namespace) -> None:
             print("Manager: NOT RUNNING (stale PID file)")
         else:
             print("Manager: not running")
+
+    auto_stop = read_auto_stop(coral_dir)
+    if auto_stop:
+        print(_format_auto_stop_summary(auto_stop))
 
     # Agent liveness follows the same scope as attempts/leaderboards. In
     # multi-island mode logs live in islands/<id>/logs/ — public/logs is

--- a/coral/config.py
+++ b/coral/config.py
@@ -253,6 +253,20 @@ class WorkspaceConfig:
 
 
 @dataclass
+class RunStopConfig:
+    """Optional run-level auto-stop conditions."""
+
+    score_threshold: float | None = None
+    max_real_attempts: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_real_attempts is not None and self.max_real_attempts <= 0:
+            raise ValueError(
+                f"run.stop.max_real_attempts must be > 0, got {self.max_real_attempts}"
+            )
+
+
+@dataclass
 class RunConfig:
     """Runtime flags for a CORAL session."""
 
@@ -260,6 +274,11 @@ class RunConfig:
     ui: bool = False
     session: str = "tmux"  # "local", "tmux", or "docker"
     docker_image: str = ""  # empty = auto-build from project Dockerfile
+    stop: RunStopConfig = field(default_factory=RunStopConfig)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.stop, dict):
+            self.stop = RunStopConfig(**self.stop)
 
 
 @dataclass

--- a/coral/hub/auto_stop.py
+++ b/coral/hub/auto_stop.py
@@ -1,0 +1,53 @@
+"""Run-level auto-stop state stored under .coral/public/."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+AUTO_STOP_FILENAME = "auto_stop.json"
+
+
+def auto_stop_path(coral_dir: str | Path) -> Path:
+    """Return the public auto-stop state path for a run."""
+    return Path(coral_dir) / "public" / AUTO_STOP_FILENAME
+
+
+def write_auto_stop(coral_dir: str | Path, payload: dict[str, Any]) -> Path:
+    """Persist an auto-stop reason atomically."""
+    path = auto_stop_path(coral_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{AUTO_STOP_FILENAME}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def read_auto_stop(coral_dir: str | Path) -> dict[str, Any] | None:
+    """Read the auto-stop state, returning None when absent or malformed."""
+    path = auto_stop_path(coral_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None

--- a/docs/content/docs/api/config.mdx
+++ b/docs/content/docs/api/config.mdx
@@ -27,6 +27,7 @@ config = CoralConfig.from_yaml("task.yaml")
 | `agents` | `AgentConfig` | Agent spawning config |
 | `sharing` | `SharingConfig` | Shared state toggles |
 | `workspace` | `WorkspaceConfig` | Workspace layout |
+| `run` | `RunConfig` | Runtime/session flags and run-level stop conditions |
 
 ### Methods
 
@@ -103,4 +104,38 @@ class SharingConfig:
 class WorkspaceConfig:
     results_dir: str       # Where to store results (default: "./results")
     repo_path: str         # Git repository root (default: ".")
+```
+
+## RunConfig
+
+```python
+@dataclass
+class RunConfig:
+    verbose: bool          # Print verbose manager output (default: False)
+    ui: bool               # Start the web dashboard (default: False)
+    session: str           # "local", "tmux", or "docker"
+    docker_image: str      # Docker image override
+    stop: RunStopConfig    # Optional run-level auto-stop conditions
+```
+
+## RunStopConfig
+
+```python
+@dataclass
+class RunStopConfig:
+    score_threshold: float | None     # Stop when best real score reaches this threshold
+    max_real_attempts: int | None     # Stop after this many finalized real attempts
+```
+
+`run.stop.score_threshold` is direction-aware: maximize tasks stop when a
+finalized real attempt has `score >= score_threshold`; minimize tasks stop when
+`score <= score_threshold`. `run.stop.max_real_attempts` counts only finalized
+attempts with `budget_class="real"` across the whole run. Pending attempts,
+`tune` attempts, and `grader_error` attempts do not count.
+
+Examples:
+
+```bash
+coral start -c task.yaml run.stop.score_threshold=0.8
+coral start -c task.yaml run.stop.max_real_attempts=30
 ```

--- a/tests/test_cli_island_scope.py
+++ b/tests/test_cli_island_scope.py
@@ -40,6 +40,7 @@ from coral.cli.query import (
 )
 from coral.cli.start import cmd_status
 from coral.hub.attempts import write_attempt
+from coral.hub.auto_stop import write_auto_stop
 from coral.hub.heartbeat import (
     write_global_heartbeat,
 )
@@ -649,6 +650,38 @@ def test_status_default_hides_tune_attempts(monkeypatch, tmp_path, capsys):
     assert "tune-attempt-island-0" not in out
     assert "tune-attempt-island-1" not in out
     assert "## Leaderboard" not in out
+
+
+def test_status_shows_auto_stop_reason(monkeypatch, tmp_path, capsys):
+    coral_dir = tmp_path / ".coral"
+    (coral_dir / "public" / "attempts").mkdir(parents=True)
+    write_auto_stop(
+        coral_dir,
+        {
+            "reason": "max_real_attempts",
+            "timestamp": "2026-06-24T00:00:00+00:00",
+            "attempt_id": "abc",
+            "agent_id": "agent-1",
+            "score": 0.4,
+            "score_threshold": None,
+            "direction": "maximize",
+            "real_attempt_count": 30,
+            "max_real_attempts": 30,
+        },
+    )
+    monkeypatch.setattr(start_module, "pick_run", lambda: coral_dir)
+    monkeypatch.setattr(
+        start_module,
+        "find_coral_dir_and_island",
+        lambda task=None, run=None: (coral_dir, None),
+    )
+
+    cmd_status(argparse.Namespace(task=None, run=None, all=False))
+
+    out = capsys.readouterr().out
+    assert "Auto-stop: max real attempts reached" in out
+    assert "real_attempts=30" in out
+    assert "max=30" in out
 
 
 def test_status_all_shows_tune_attempts(monkeypatch, tmp_path, capsys):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from coral.config import (
     CoralConfig,
     GraderConfig,
     RunConfig,
+    RunStopConfig,
     TaskConfig,
     WarmStartConfig,
     WorkspaceConfig,
@@ -198,6 +199,8 @@ def test_run_config_defaults():
     assert config.run.verbose is False
     assert config.run.ui is False
     assert config.run.session == "tmux"
+    assert config.run.stop.score_threshold is None
+    assert config.run.stop.max_real_attempts is None
 
 
 def test_run_config_dotlist_override():
@@ -223,6 +226,42 @@ def test_run_config_roundtrip():
     assert restored.run.verbose is True
     assert restored.run.ui is True
     assert restored.run.session == "docker"
+
+
+def test_run_stop_config_roundtrip():
+    config = CoralConfig(
+        task=TaskConfig(name="t", description="d"),
+        run=RunConfig(stop=RunStopConfig(score_threshold=0.8, max_real_attempts=30)),
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+        config.to_yaml(f.name)
+        restored = CoralConfig.from_yaml(f.name)
+
+    assert restored.run.stop.score_threshold == 0.8
+    assert restored.run.stop.max_real_attempts == 30
+
+
+def test_run_stop_dotlist_override():
+    config = CoralConfig(
+        task=TaskConfig(name="t", description="d"),
+    )
+    merged = CoralConfig.merge_dotlist(
+        config,
+        ["run.stop.score_threshold=0.8", "run.stop.max_real_attempts=30"],
+    )
+    assert merged.run.stop.score_threshold == 0.8
+    assert merged.run.stop.max_real_attempts == 30
+
+
+def test_run_stop_max_real_attempts_validation():
+    with pytest.raises(ValueError, match="run.stop.max_real_attempts must be > 0"):
+        CoralConfig.from_dict(
+            {
+                "task": {"name": "t", "description": "d"},
+                "run": {"stop": {"max_real_attempts": 0}},
+            }
+        )
 
 
 def test_to_dict_excludes_task_dir():

--- a/tests/test_manager_auto_stop.py
+++ b/tests/test_manager_auto_stop.py
@@ -97,7 +97,7 @@ def test_auto_stop_counts_only_terminal_real_attempts(tmp_path: Path) -> None:
     mgr = _manager(tmp_path, stop={"score_threshold": 0.8, "max_real_attempts": 2})
     _attempt(mgr, "c" * 40, score=0.99, budget_class=BUDGET_CLASS_TUNE, seconds=1)
     _attempt(mgr, "d" * 40, score=0.99, budget_class=BUDGET_CLASS_GRADER_ERROR, seconds=2)
-    _attempt(mgr, "e" * 40, score=0.99, status="pending", seconds=3)
+    _attempt(mgr, "e" * 40, score=None, status="pending", seconds=3)
     _attempt(mgr, "f" * 40, score=None, status="crashed", seconds=4)
     latest_real = _attempt(mgr, "1" * 40, score=0.2, seconds=5)
 

--- a/tests/test_manager_auto_stop.py
+++ b/tests/test_manager_auto_stop.py
@@ -1,0 +1,140 @@
+"""Tests for run-level auto-stop decisions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from coral.agent.manager import AgentManager
+from coral.config import CoralConfig
+from coral.hub.attempts import write_attempt
+from coral.hub.auto_stop import read_auto_stop
+from coral.types import BUDGET_CLASS_GRADER_ERROR, BUDGET_CLASS_TUNE, Attempt
+from coral.workspace import ProjectPaths
+
+
+def _manager(
+    tmp_path: Path,
+    *,
+    stop: dict[str, object],
+    direction: str = "maximize",
+) -> AgentManager:
+    coral_dir = tmp_path / ".coral"
+    (coral_dir / "public" / "attempts").mkdir(parents=True)
+    (coral_dir / "public" / "logs").mkdir()
+    cfg = CoralConfig.from_dict(
+        {
+            "task": {"name": "t", "description": "d"},
+            "grader": {"direction": direction},
+            "run": {"stop": stop},
+        }
+    )
+    mgr = AgentManager(cfg, verbose=False)
+    mgr.paths = ProjectPaths(
+        results_dir=tmp_path / "results",
+        task_dir=tmp_path,
+        run_dir=tmp_path,
+        coral_dir=coral_dir,
+        agents_dir=tmp_path / "agents",
+        repo_dir=tmp_path / "repo",
+    )
+    return mgr
+
+
+def _attempt(
+    mgr: AgentManager,
+    commit: str,
+    *,
+    score: float | None,
+    status: str = "improved",
+    budget_class: str | None = None,
+    seconds: int = 0,
+) -> Attempt:
+    assert mgr.paths is not None
+    metadata = {"budget_class": budget_class} if budget_class else {}
+    attempt = Attempt(
+        commit_hash=commit,
+        agent_id="agent-1",
+        title=f"attempt {commit}",
+        score=score,
+        status=status,
+        parent_hash=None,
+        timestamp=(datetime(2026, 6, 24, tzinfo=UTC) + timedelta(seconds=seconds)).isoformat(),
+        metadata=metadata,
+    )
+    write_attempt(mgr.paths.coral_dir, attempt)
+    return attempt
+
+
+def test_auto_stop_score_threshold_maximize(tmp_path: Path) -> None:
+    mgr = _manager(tmp_path, stop={"score_threshold": 0.8})
+    attempt = _attempt(mgr, "a" * 40, score=0.81)
+
+    reason = mgr._auto_stop_reason_from_attempt(attempt.to_dict())
+
+    assert reason is not None
+    assert reason["reason"] == "score_threshold"
+    assert reason["attempt_id"] == attempt.commit_hash
+    assert reason["score"] == 0.81
+    assert reason["score_threshold"] == 0.8
+    assert reason["direction"] == "maximize"
+    assert reason["real_attempt_count"] == 1
+
+
+def test_auto_stop_score_threshold_minimize(tmp_path: Path) -> None:
+    mgr = _manager(tmp_path, stop={"score_threshold": 0.2}, direction="minimize")
+    attempt = _attempt(mgr, "b" * 40, score=0.19)
+
+    reason = mgr._auto_stop_reason_from_attempt(attempt.to_dict())
+
+    assert reason is not None
+    assert reason["reason"] == "score_threshold"
+    assert reason["direction"] == "minimize"
+    assert reason["score"] == 0.19
+
+
+def test_auto_stop_counts_only_terminal_real_attempts(tmp_path: Path) -> None:
+    mgr = _manager(tmp_path, stop={"score_threshold": 0.8, "max_real_attempts": 2})
+    _attempt(mgr, "c" * 40, score=0.99, budget_class=BUDGET_CLASS_TUNE, seconds=1)
+    _attempt(mgr, "d" * 40, score=0.99, budget_class=BUDGET_CLASS_GRADER_ERROR, seconds=2)
+    _attempt(mgr, "e" * 40, score=0.99, status="pending", seconds=3)
+    _attempt(mgr, "f" * 40, score=None, status="crashed", seconds=4)
+    latest_real = _attempt(mgr, "1" * 40, score=0.2, seconds=5)
+
+    reason = mgr._auto_stop_reason_from_attempt(latest_real.to_dict())
+
+    assert reason is not None
+    assert reason["reason"] == "max_real_attempts"
+    assert reason["real_attempt_count"] == 2
+    assert reason["attempt_id"] == latest_real.commit_hash
+
+
+def test_auto_stop_current_state_uses_best_real_attempt(tmp_path: Path) -> None:
+    mgr = _manager(tmp_path, stop={"score_threshold": 0.8})
+    _attempt(mgr, "2" * 40, score=0.99, budget_class=BUDGET_CLASS_TUNE, seconds=1)
+    real = _attempt(mgr, "3" * 40, score=0.85, seconds=2)
+
+    reason = mgr._auto_stop_reason_from_current_state()
+
+    assert reason is not None
+    assert reason["reason"] == "score_threshold"
+    assert reason["attempt_id"] == real.commit_hash
+    assert reason["score"] == 0.85
+    assert reason["real_attempt_count"] == 1
+
+
+def test_auto_stop_writes_marker_and_stops(tmp_path: Path) -> None:
+    mgr = _manager(tmp_path, stop={"max_real_attempts": 1})
+    attempt = _attempt(mgr, "4" * 40, score=0.1)
+    reason = mgr._auto_stop_reason_from_attempt(attempt.to_dict())
+    assert reason is not None
+
+    mgr._running = True
+    mgr._auto_stop(reason)
+
+    assert mgr._running is False
+    assert mgr._stopping is True
+    marker = read_auto_stop(mgr.paths.coral_dir)
+    assert marker is not None
+    assert marker["reason"] == "max_real_attempts"
+    assert marker["attempt_id"] == attempt.commit_hash


### PR DESCRIPTION
﻿## Motivation

Long-running CORAL runs currently keep cycling until an operator manually stops them. This adds explicit run-level stop limits so an experiment can end cleanly once it has either reached a target score or consumed a configured number of finalized real attempts.

## Changes

- Adds `run.stop` config with:
  - `score_threshold`: stop when a finalized real attempt reaches the configured score, using `grader.direction` for maximize/minimize comparison.
  - `max_real_attempts`: stop after the run has this many finalized `budget_class="real"` attempts.
- Enforces the stop in `AgentManager.monitor_loop` immediately after scored attempts are observed, before heartbeat prompts, migration, or restart handling can continue the run.
- Re-checks persisted attempts when the manager starts, so resuming a run that already crossed the limit stops again instead of continuing.
- Excludes pending, `tune`, and `grader_error` attempts from the stop count and threshold path.
- Writes `.coral/public/auto_stop.json` with the stop reason and shows that reason in `coral status`.
- Updates config docs and the developer command reference.

## Test plan

Ran from a WSL-native verification copy of this checkout because Windows collection hits existing POSIX-only imports (`fcntl`) and `/mnt/c` editable builds can time out in hatch-vcs:

- `uv run --extra dev ruff check .` (passed)
- `uv run --extra dev ruff format --check .` (passed)
- `uv run --extra dev pytest tests/ -q` (`519 passed, 1 skipped`)

## Affected areas

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [x] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [x] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [x] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

Authored with assistance from Codex. This is opened as a draft for human review before it is marked ready.