### PR TITLE
feat(islands): carry a migrating agent's notes to the destination island

### DIFF
--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -1980,18 +1980,14 @@ class AgentManager:
         # ``legacy: true`` and parked under ``notes/_legacy/`` as island-local
         # history. Skills still stay put on the source island.
         try:
-            copied = copy_notes_to_island(
-                coral_dir, agent_id, src_island=src, dst_island=dst
-            )
+            copied = copy_notes_to_island(coral_dir, agent_id, src_island=src, dst_island=dst)
             if copied:
                 logger.info(
                     f"Copied {len(copied)} note(s) by {agent_id} from island {src} "
                     f"to island {dst} on migration"
                 )
         except OSError as e:
-            logger.warning(
-                f"Failed to copy notes for {agent_id} from island {src} to {dst}: {e}"
-            )
+            logger.warning(f"Failed to copy notes for {agent_id} from island {src} to {dst}: {e}")
         try:
             marked = mark_notes_legacy(
                 coral_dir,

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -64,7 +64,7 @@ from coral.hub.heartbeat import (
     write_agent_heartbeat,
     write_global_heartbeat,
 )
-from coral.hub.notes import mark_notes_legacy
+from coral.hub.notes import copy_notes_to_island, mark_notes_legacy
 from coral.hub.steering import ContinueFromAction, mark_applied, read_pending
 from coral.template.coral_md import generate_coral_md
 from coral.types import BUDGET_CLASS_REAL, Attempt, get_budget_class
@@ -1911,10 +1911,11 @@ class AgentManager:
            session and any in-flight file writes complete.
         3. Move per-agent files (``roles/<agent>.md``,
            ``heartbeat/<agent>.json``, attempts, and matching eval logs)
-           from src island to dst. Notes and skills stay on the source
-           island as island-local shared knowledge; the agent's own notes
-           there are flagged ``legacy: true`` and moved into
-           ``notes/_legacy/`` so readers know the author has moved on.
+           from src island to dst. The agent's own notes are copied to dst
+           so its research follows it; the source-island originals are
+           flagged ``legacy: true`` and moved into ``notes/_legacy/`` so
+           readers know the author has moved on. Skills stay on the source
+           island as island-local shared knowledge.
         4. Repoint the worktree's shared-state symlinks at the dst island.
         5. Re-write the runtime's permission settings with the new
            island_id (so Read scopes follow the move).
@@ -1972,10 +1973,25 @@ class AgentManager:
         # (3) Move per-agent identity / cadence files src → dst.
         _move_agent_files(coral_dir, agent_id, src=src, dst=dst)
 
-        # (3b) The agent's notes stay on the source island as island-local
-        # shared knowledge, but flag them legacy and park them under
-        # ``notes/_legacy/`` so future readers know the author has migrated
-        # away and the work is no longer maintained here.
+        # (3b) Carry the agent's notes to the destination island so it keeps
+        # its own research, then archive the source-island originals. The
+        # copy runs first, against the pre-legacy content, so the destination
+        # gets clean live notes; the source copies are then flagged
+        # ``legacy: true`` and parked under ``notes/_legacy/`` as island-local
+        # history. Skills still stay put on the source island.
+        try:
+            copied = copy_notes_to_island(
+                coral_dir, agent_id, src_island=src, dst_island=dst
+            )
+            if copied:
+                logger.info(
+                    f"Copied {len(copied)} note(s) by {agent_id} from island {src} "
+                    f"to island {dst} on migration"
+                )
+        except OSError as e:
+            logger.warning(
+                f"Failed to copy notes for {agent_id} from island {src} to {dst}: {e}"
+            )
         try:
             marked = mark_notes_legacy(
                 coral_dir,
@@ -2551,10 +2567,10 @@ def _move_agent_files(
 
     Moves ``roles/<agent>.md`` and ``heartbeat/<agent>.json`` plus the
     agent's attempt records and matching ``eval_logs/<commit>/`` directories.
-    Notes / skills deliberately stay on the source island as shared
-    island-local knowledge (the caller flags the migrating agent's notes
-    ``legacy`` and moves them into ``notes/_legacy/`` separately via
-    ``mark_notes_legacy``).
+    Skills deliberately stay on the source island as shared island-local
+    knowledge. Notes are handled separately by the caller: copied to the
+    destination via ``copy_notes_to_island`` and archived on the source via
+    ``mark_notes_legacy`` (``notes/_legacy/``).
 
     Idempotent: missing source files are silently skipped, so the helper
     is safe to call twice on the same agent. Existing files at the
@@ -2750,7 +2766,7 @@ def _write_arrival_note(coral_dir: Path, candidate: MigrationCandidate) -> None:
         f"island `{candidate.src_island}` with a recent best score of "
         f"`{candidate.score:.6f}` over the last several real evals.\n\n"
         f"They bring their evolved role, heartbeat cadence, attempts, "
-        f"and eval logs with them; notes and skills stay on island "
+        f"eval logs, and their own notes with them; skills stay on island "
         f"`{candidate.src_island}` as island-local shared knowledge.\n"
     )
     fname = f"migration_{fname_ts}_{candidate.agent_id}.md"
@@ -2825,12 +2841,13 @@ def _build_migration_prompt(candidate: MigrationCandidate, *, shared_dir: str) -
         f"`{shared_dir}/attempts`, `{shared_dir}/heartbeat`, "
         f"`{shared_dir}/roles`, and `{shared_dir}/eval_logs` now resolve to island "
         f"`{candidate.dst_island}`.\n"
-        f"- Your evolved role, heartbeat cadence, attempts, and eval logs "
-        f"followed you here.\n"
-        f"- Notes and skills stayed on island `{candidate.src_island}` as "
-        f"that island's shared knowledge base. Your notes there are now "
-        f"flagged `legacy` and moved under `{shared_dir}/notes/_legacy/` "
-        f"since you've moved on.\n\n"
+        f"- Your evolved role, heartbeat cadence, attempts, eval logs, and "
+        f"your own notes followed you here — your research is in "
+        f"`{shared_dir}/notes`.\n"
+        f"- Skills stayed on island `{candidate.src_island}` as that "
+        f"island's shared knowledge base. The originals of your notes there "
+        f"are now flagged `legacy` and archived under "
+        f"`notes/_legacy/` since you've moved on.\n\n"
         f"What to do first:\n"
         f"1. `coral log -n 10` to see this island's current leaderboard.\n"
         f"2. `coral notes --recent` to read what your new teammates "

--- a/coral/agent/migration.py
+++ b/coral/agent/migration.py
@@ -27,15 +27,15 @@ a swap/cycle rather than as a one-way drain.
 
 What moves with an agent (mechanics in the manager): ``roles/<agent>.md``,
 ``heartbeat/<agent>.json``, that agent's attempt records, and matching
-``eval_logs/<commit>/`` directories follow them. Notes and skills authored
-on the source island stay put as island-local shared knowledge, but the
-migrating agent's own notes there are flagged ``legacy: true`` and moved
-into ``notes/_legacy/`` so future readers know the author has moved on. The
-agent's worktree symlinks and
-``.coral_island`` breadcrumb are repointed at the destination, and an
-optional arrival note is dropped on the destination's ``notes/`` when
-``notify_island=True`` so other agents see the newcomer through
-``coral notes``.
+``eval_logs/<commit>/`` directories follow them. The agent's own notes are
+*copied* to the destination island so its research follows it, while the
+source-island originals are flagged ``legacy: true`` and moved into
+``notes/_legacy/`` so future readers know the author has moved on. Skills
+authored on the source island stay put as island-local shared knowledge. The
+agent's worktree symlinks and ``.coral_island`` breadcrumb are repointed at
+the destination, and an optional arrival note is dropped on the
+destination's ``notes/`` when ``notify_island=True`` so other agents see the
+newcomer through ``coral notes``.
 """
 
 from __future__ import annotations

--- a/coral/hub/notes.py
+++ b/coral/hub/notes.py
@@ -461,6 +461,23 @@ def _insert_legacy_fields(text: str, reason: str | None) -> str | None:
     return f"---\n{block}\n---\n\n{text}"
 
 
+def _dedupe_path(path: Path) -> Path:
+    """Return ``path``, or a ``-N``-suffixed sibling if it already exists.
+
+    Keeps a write from clobbering an existing file of the same name (e.g. a
+    note carried to an island that already holds a same-named teammate note).
+    """
+    if not path.exists():
+        return path
+    stem, suffix = path.stem, path.suffix
+    n = 2
+    while True:
+        candidate = path.with_name(f"{stem}-{n}{suffix}")
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
 def _legacy_destination(notes_dir: Path, path: Path) -> Path:
     """Where a freshly-flagged note should live under ``notes/_legacy/``.
 
@@ -477,17 +494,52 @@ def _legacy_destination(notes_dir: Path, path: Path) -> Path:
         rel = Path(path.name)
     if rel.parts and rel.parts[0] == LEGACY_DIR_NAME:
         return path  # already parked under _legacy/ — flag in place.
+    return _dedupe_path(notes_dir / LEGACY_DIR_NAME / rel)
 
-    dest = notes_dir / LEGACY_DIR_NAME / rel
-    if dest == path or not dest.exists():
-        return dest
-    stem, suffix = dest.stem, dest.suffix
-    n = 2
-    while True:
-        candidate = dest.with_name(f"{stem}-{n}{suffix}")
-        if not candidate.exists():
-            return candidate
-        n += 1
+
+def copy_notes_to_island(
+    coral_dir: str | Path,
+    agent_id: str,
+    *,
+    src_island: str | int | None,
+    dst_island: str | int | None,
+) -> list[Path]:
+    """Copy ``agent_id``'s live notes from one island into another's ``notes/``.
+
+    Called on migration so an agent keeps its own research when it moves to a
+    new island. Each note's path relative to ``notes/`` is preserved on the
+    destination, the copy stays attributed to its original ``creator`` (so
+    :func:`notes_by` on the destination finds it), and it is **not** flagged
+    legacy — it's live where the agent now works. Notes already archived as
+    legacy on the source (``legacy: true``, typically under ``_legacy/``) are
+    skipped so an agent doesn't re-carry work it already left behind on an
+    earlier hop. Same-named notes already on the destination get a ``-N``
+    suffix rather than being overwritten. Returns the destination paths
+    written.
+    """
+    src_notes = _notes_dir(coral_dir, src_island)
+    dst_notes = _notes_dir(coral_dir, dst_island)
+    copied: list[Path] = []
+    for path in notes_by(coral_dir, src_island, agent_id):
+        try:
+            text = path.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        meta, _ = _parse_frontmatter(text)
+        if meta.get("legacy"):
+            continue  # already archived on the source — don't carry it forward.
+        try:
+            rel = path.relative_to(src_notes)
+        except ValueError:
+            rel = Path(path.name)
+        dest = _dedupe_path(dst_notes / rel)
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(text)
+        except OSError:
+            continue
+        copied.append(dest)
+    return copied
 
 
 def mark_notes_legacy(

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -13,6 +13,7 @@ from coral.hub.attempts import (
     write_attempt,
 )
 from coral.hub.notes import (
+    copy_notes_to_island,
     format_notes_list,
     get_recent_notes,
     list_notes,
@@ -319,6 +320,82 @@ def test_mark_notes_legacy_surfaces_in_list_and_format():
         assert "[legacy]" in format_notes_list(entries)
         # The note moved under _legacy/ but is still attributable to its author.
         assert notes_by(d, island_id=None, agent_id="agent-1") == [notes_dir / "_legacy" / "n.md"]
+
+
+def test_copy_notes_to_island_carries_authored_notes():
+    """An agent's live notes are copied to the destination island, attributed and live."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d)
+        src = coral_dir / "islands" / "0" / "notes"
+        dst = coral_dir / "islands" / "1" / "notes"
+        dst.mkdir(parents=True)
+        _write_note(
+            src,
+            "tiling.md",
+            "---\ncreator: 0-agent-1\ncreated: 2026-03-14\nclaim: tiling helps\n---\n\n# Tiling\nbody\n",
+        )
+        _write_note(
+            src / "research",
+            "idea.md",
+            "---\ncreator: 0-agent-1\ncreated: 2026-03-14\n---\n\n# Idea\nbody\n",
+        )
+        _write_note(
+            src,
+            "teammate.md",
+            "---\ncreator: 0-agent-2\ncreated: 2026-03-14\n---\n\n# Teammate\nbody\n",
+        )
+
+        copied = copy_notes_to_island(coral_dir, "0-agent-1", src_island="0", dst_island="1")
+
+        assert sorted(copied) == [dst / "research" / "idea.md", dst / "tiling.md"]
+        # Relative structure preserved; copies stay attributed and are NOT legacy.
+        copy_text = (dst / "tiling.md").read_text()
+        assert "creator: 0-agent-1" in copy_text
+        assert "claim: tiling helps" in copy_text
+        assert "legacy" not in copy_text
+        assert notes_by(coral_dir, island_id="1", agent_id="0-agent-1") == [
+            dst / "research" / "idea.md",
+            dst / "tiling.md",
+        ]
+        # Teammate's note didn't ride along.
+        assert not (dst / "teammate.md").exists()
+        # Source island is left untouched by the copy.
+        assert (src / "tiling.md").exists()
+
+
+def test_copy_notes_to_island_skips_already_legacy_and_avoids_collisions():
+    """Already-archived notes aren't re-carried; same-named dst notes aren't clobbered."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d)
+        src = coral_dir / "islands" / "0" / "notes"
+        dst = coral_dir / "islands" / "1" / "notes"
+        dst.mkdir(parents=True)
+        # A live note that should be carried...
+        _write_note(
+            src,
+            "live.md",
+            "---\ncreator: 0-agent-1\ncreated: 2026-03-14\n---\n\n# Live\nbody\n",
+        )
+        # ...and one already archived as legacy on the source (under _legacy/).
+        _write_note(
+            src / "_legacy",
+            "old.md",
+            "---\ncreator: 0-agent-1\ncreated: 2026-03-14\nlegacy: true\n---\n\n# Old\nbody\n",
+        )
+        # The destination already has a same-named note by someone else.
+        _write_note(
+            dst,
+            "live.md",
+            "---\ncreator: 1-agent-9\ncreated: 2026-03-14\n---\n\n# Pre-existing\nkeep me\n",
+        )
+
+        copied = copy_notes_to_island(coral_dir, "0-agent-1", src_island="0", dst_island="1")
+
+        # legacy note skipped; live note copied under a non-clobbering name.
+        assert copied == [dst / "live-2.md"]
+        assert "keep me" in (dst / "live.md").read_text()
+        assert not (dst / "old.md").exists()
+        assert not (dst / "_legacy" / "old.md").exists()
 
 
 def test_skills():

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1073,7 +1073,16 @@ def test_apply_migration_copies_agent_notes_to_dst_and_archives_source(tmp_path)
     coral_dir = tmp_path / ".coral"
     (coral_dir / "public").mkdir(parents=True)
     for island in ("0", "1"):
-        for sub in ("attempts", "notes", "skills", "agents", "logs", "heartbeat", "roles", "eval_logs"):
+        for sub in (
+            "attempts",
+            "notes",
+            "skills",
+            "agents",
+            "logs",
+            "heartbeat",
+            "roles",
+            "eval_logs",
+        ):
             (coral_dir / "islands" / island / sub).mkdir(parents=True)
     worktree = tmp_path / "worktree"
     worktree.mkdir()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1060,6 +1060,85 @@ def test_apply_migration_end_to_end_moves_state_and_repoints_worktree(tmp_path):
     assert mgr._restart_counts["0-agent-1"] == 1
 
 
+def test_apply_migration_copies_agent_notes_to_dst_and_archives_source(tmp_path):
+    """End-to-end: the migrating agent's notes are copied to dst and archived on src."""
+    from coral.agent.assignments import AgentSpec
+    from coral.agent.manager import AgentManager
+    from coral.agent.runtime import AgentHandle
+    from coral.config import AgentAssignmentConfig, AgentConfig, CoralConfig
+    from coral.hub.notes import notes_by
+    from coral.workspace import setup_shared_state
+    from coral.workspace.project import ProjectPaths
+
+    coral_dir = tmp_path / ".coral"
+    (coral_dir / "public").mkdir(parents=True)
+    for island in ("0", "1"):
+        for sub in ("attempts", "notes", "skills", "agents", "logs", "heartbeat", "roles", "eval_logs"):
+            (coral_dir / "islands" / island / sub).mkdir(parents=True)
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    setup_shared_state(worktree, coral_dir, ".claude", island_id="0")
+
+    # The migrating agent and a teammate both authored notes on island 0.
+    src_notes = coral_dir / "islands" / "0" / "notes"
+    (src_notes / "tiling.md").write_text(
+        "---\ncreator: 0-agent-1\ncreated: 2026-06-26\nclaim: tile=32 helps\n---\n\n# Tiling\nbody\n"
+    )
+    (src_notes / "research").mkdir()
+    (src_notes / "research" / "idea.md").write_text(
+        "---\ncreator: 0-agent-1\ncreated: 2026-06-26\n---\n\n# Idea\nbody\n"
+    )
+    (src_notes / "teammate.md").write_text(
+        "---\ncreator: 0-agent-2\ncreated: 2026-06-26\n---\n\n# Teammate\nstays\n"
+    )
+
+    cfg = CoralConfig(
+        agents=AgentConfig(assignments=[AgentAssignmentConfig(count=2)]),
+        islands=IslandsConfig(count=2, migration=MigrationConfig(every=5, rank_window=3)),
+    )
+    mgr = AgentManager(cfg)
+    mgr.paths = ProjectPaths(
+        results_dir=tmp_path,
+        task_dir=tmp_path,
+        run_dir=tmp_path,
+        coral_dir=coral_dir,
+        agents_dir=tmp_path / "agents",
+        repo_dir=tmp_path / "repo",
+    )
+    spec = AgentSpec(agent_id="0-agent-1", runtime="claude_code", model="opus", island_id="0")
+    mgr.specs = [spec]
+    mgr.specs_by_id = {"0-agent-1": spec}
+    mgr._agent_island = {"0-agent-1": "0"}
+    log_path = tmp_path / "0-agent-1.log"
+    log_path.write_text("")
+    mgr.handles = [
+        AgentHandle(agent_id="0-agent-1", process=None, worktree_path=worktree, log_path=log_path)
+    ]
+    mgr._setup_and_start_agent = lambda agent_id, **kw: mgr.handles[0]  # type: ignore[assignment]
+
+    candidate = MigrationCandidate(agent_id="0-agent-1", src_island="0", dst_island="1", score=0.9)
+    mgr._apply_migration(candidate)
+
+    dst_notes = coral_dir / "islands" / "1" / "notes"
+    # The agent's notes were copied to dst (live, attributed, structure preserved).
+    assert (dst_notes / "tiling.md").exists()
+    assert (dst_notes / "research" / "idea.md").exists()
+    dst_text = (dst_notes / "tiling.md").read_text()
+    assert "creator: 0-agent-1" in dst_text
+    assert "legacy" not in dst_text
+    assert notes_by(coral_dir, island_id="1", agent_id="0-agent-1") == [
+        dst_notes / "research" / "idea.md",
+        dst_notes / "tiling.md",
+    ]
+    # The source-island originals are archived under _legacy/ and flagged.
+    assert (src_notes / "_legacy" / "tiling.md").exists()
+    assert "legacy: true" in (src_notes / "_legacy" / "tiling.md").read_text()
+    assert not (src_notes / "tiling.md").exists()
+    # The teammate's note didn't move or get copied.
+    assert (src_notes / "teammate.md").exists()
+    assert not (dst_notes / "teammate.md").exists()
+
+
 def test_apply_migration_moves_pending_attempt_with_agent(tmp_path):
     """Pending grader attempts move with the agent instead of blocking migration."""
     from coral.agent.assignments import AgentSpec


### PR DESCRIPTION
## What

Follow-up to #144 (legacy-archive on migration, already merged). That PR archived a migrating agent's notes under the **source** island's `notes/_legacy/`. This PR adds the other half: the agent's notes are now **copied to the destination island** as live notes, so its research follows it when it moves.

Net effect of a migration:

| Location | Result |
|---|---|
| **Destination** `notes/` | live copies of the agent's notes (attributed, **not** legacy) + the arrival announcement |
| **Source** `notes/_legacy/` | the originals, flagged `legacy: true` + `legacy_reason` (from #144) |
| Teammates' notes | untouched on both sides |
| Skills | stay island-local (unchanged) |

## Why

After migrating, an agent's default `coral notes` view scopes to the *new* island (via the `.coral_island` breadcrumb), so it previously lost convenient access to its own accumulated research — that lived only on the source island. Carrying a copy forward keeps the agent's research with it; the source keeps the archived snapshot.

## How

- **`copy_notes_to_island(coral_dir, agent_id, src_island, dst_island)`** (new in `coral/hub/notes.py`) copies each note the agent authored (by `creator`) into the destination's `notes/`:
  - preserves the path relative to `notes/`,
  - keeps the original `creator` attribution so `notes_by(dst, agent)` finds them,
  - leaves the copy **live** (no `legacy` flag),
  - skips notes already archived as legacy on the source (no re-carrying across repeated hops),
  - `-N`-suffixes same-named destination notes instead of clobbering (shared `_dedupe_path` helper, factored out from the legacy-archive path).
- In `_apply_migration` the **copy runs first** (against pre-stamp content) and the **legacy archive second**, so the destination gets clean live notes while the source keeps the archived originals.
- Migration docstrings, the arrival announcement note, and the agent-facing arrival prompt updated to say notes are carried.

## Testing

- New unit tests (`tests/test_hub.py`): copy carries authored notes (structure + attribution preserved, not legacy), skips already-legacy notes, and avoids destination collisions.
- New end-to-end test (`tests/test_migration.py`): drives the real `AgentManager._apply_migration` with seeded notes and asserts the copy lands live on dst **and** the originals are archived under `_legacy/` on src; teammate notes untouched.
- Full suite: **546 passed, 1 skipped**.

## Note on island diversity

This copies notes into the destination on every migration, which over many cycles cross-pollinates note content between islands (slightly weakening island-model diversity). Implemented as unconditional per the request; happy to gate it behind an `islands.migration.carry_notes` flag in a follow-up if preserving isolation becomes desirable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)