### PR TITLE
fix(claude_code): force agent autonomy via --permission-mode auto

### DIFF
--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -139,6 +139,17 @@ class ClaudeCodeRuntime:
             prompt,
             "--model",
             model,
+            # Grant the agent autonomy. `auto` MUST be set on the CLI: in
+            # headless `-p` mode Claude Code silently downgrades a project-level
+            # `permissions.defaultMode: "auto"` (from .claude/settings.local.json
+            # or settings.json) back to `default`, because a repo-checked-in
+            # settings file isn't trusted to escalate to auto — only the user's
+            # own ~/.claude/settings.json or this flag can. Without it agents run
+            # in `default` mode and any tool not in the settings allow-list
+            # (e.g. MCP tools) is denied with no human to approve it. The
+            # allow/deny rules in settings.local.json still apply on top.
+            "--permission-mode",
+            "auto",
         ]
         # 0 = no cap — let the underlying `claude` CLI run until it exits
         # naturally. The manager still restarts on any exit, preserving context

--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -372,14 +372,14 @@ def setup_claude_settings(
     """Write Claude Code settings.json with permissions and gateway env.
 
     Scopes the agent's tools via allow/deny rules (replacing
-    --dangerously-skip-permissions).  Note: the ``defaultMode: "auto"`` written
-    here is NOT honored in headless ``-p`` mode — Claude Code silently downgrades
-    a project-level auto back to ``default`` (only ~/.claude/settings.json or the
-    ``--permission-mode`` CLI flag may escalate to auto), so the runtime passes
-    ``--permission-mode auto`` on the command line. The allow/deny rules below do
-    take effect and are the real scoping mechanism.  When a gateway is
-    configured, sets ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY in the settings
-    ``env`` so they override the user's global ``~/.claude/settings.json``.
+    --dangerously-skip-permissions).  The permission *mode* is deliberately NOT
+    set here: a project-level ``defaultMode: "auto"`` is silently downgraded to
+    ``default`` in headless ``-p`` mode (only ~/.claude/settings.json or the
+    ``--permission-mode`` CLI flag may escalate to auto), so the runtime sets it
+    via ``--permission-mode auto`` on the command line instead. The allow/deny
+    rules below do take effect and are the real scoping mechanism.  When a
+    gateway is configured, sets ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY in the
+    settings ``env`` so they override the user's global ``~/.claude/settings.json``.
 
     In multi-island runs (``island_id`` set), Read scopes only to the
     agent's own island root (``.coral/islands/<id>/``) — sibling islands
@@ -431,8 +431,11 @@ def setup_claude_settings(
     if not research:
         deny_rules.extend(["WebSearch", "WebFetch"])
 
+    # No ``defaultMode`` here: a project-level ``auto`` is silently downgraded
+    # to ``default`` in headless ``-p`` mode, so it would be a misleading no-op.
+    # The mode is set authoritatively via ``--permission-mode auto`` on the
+    # ``claude`` CLI (see coral/agent/builtin/claude_code.py).
     permissions: dict = {
-        "defaultMode": "auto",
         "allow": allow_rules,
         "deny": deny_rules,
     }

--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -371,10 +371,15 @@ def setup_claude_settings(
 ) -> None:
     """Write Claude Code settings.json with permissions and gateway env.
 
-    Grants the agent all tool permissions via allow rules (replacing
-    --dangerously-skip-permissions).  When a gateway is configured, sets
-    ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY in the settings ``env`` so
-    they override the user's global ``~/.claude/settings.json``.
+    Scopes the agent's tools via allow/deny rules (replacing
+    --dangerously-skip-permissions).  Note: the ``defaultMode: "auto"`` written
+    here is NOT honored in headless ``-p`` mode — Claude Code silently downgrades
+    a project-level auto back to ``default`` (only ~/.claude/settings.json or the
+    ``--permission-mode`` CLI flag may escalate to auto), so the runtime passes
+    ``--permission-mode auto`` on the command line. The allow/deny rules below do
+    take effect and are the real scoping mechanism.  When a gateway is
+    configured, sets ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY in the settings
+    ``env`` so they override the user's global ``~/.claude/settings.json``.
 
     In multi-island runs (``island_id`` set), Read scopes only to the
     agent's own island root (``.coral/islands/<id>/``) — sibling islands

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -439,8 +439,10 @@ def test_setup_claude_settings_permissions():
 
         assert "hooks" not in settings
 
-        # Auto mode is always enabled
-        assert settings["permissions"]["defaultMode"] == "auto"
+        # No defaultMode written: a project-level "auto" is silently downgraded
+        # to "default" in headless -p mode, so the runtime sets the mode via
+        # the --permission-mode CLI flag instead (see claude_code.py).
+        assert "defaultMode" not in settings["permissions"]
 
 
 def test_setup_claude_settings_no_research():


### PR DESCRIPTION
## Problem

Claude Code agents were running in **`default`** permission mode for entire runs instead of the intended **`auto`** mode. The symptom: tools not in the settings allow-list — notably **MCP tools** — were denied with no human in the loop to approve them.

Root cause: `setup_claude_settings()` writes `permissions.defaultMode: "auto"` into the worktree's `.claude/settings.local.json`, but in headless `claude -p` mode **a project-level `auto` is silently downgraded to `default`**. Claude Code won't let a repo-checked-in settings file escalate to the privileged `auto` mode — only the user's own `~/.claude/settings.json` or an explicit `--permission-mode` CLI flag can. Less-privileged modes (`default`, `plan`, `acceptEdits`) *are* honored from project settings; `auto` specifically is gated.

This was confirmed empirically against the stream-json `init.permissionMode` field (ground truth for the effective mode):

| `defaultMode` source | result |
|---|---|
| project `.claude/settings.local.json` → `auto` | **`default`** (silently downgraded) |
| project `.claude/settings.json` (shared) → `auto` | **`default`** (silently downgraded) |
| `~/.claude/settings.json` (user-global) → `auto` | `auto` ✓ |
| CLI `--permission-mode auto` | `auto` ✓ (overrides all) |

A real run showed the impact directly: ~247 sessions in `default` (MCP calls denied), then after the operator manually set `auto` in their user-global `~/.claude/settings.json`, the next ~20 sessions came up in `auto` and MCP calls succeeded.

## Fix

Pass `--permission-mode auto` on the `claude` CLI in `claude_code.py`. The CLI flag is the one `auto` source that doesn't depend on the operator's personal `~/.claude` state, is reproducible across machines, and fails loud on an unsupported value instead of silently falling back to `default`.

The `allow`/`deny` rules in `settings.local.json` still apply on top, so worktree-scoping and the git/private-dir denies are unaffected — they remain the real scoping mechanism. The now-misleading docstring in `setup_claude_settings()` is updated to note that the `defaultMode: "auto"` it writes is not honored headless.

Considered but rejected: adding specific MCP tool names to `allow_rules`. That list is generic framework code and shouldn't hardcode one run's MCP server; the CLI flag fixes autonomy for all tools/MCP servers, not just one.

## Test

- `uv run ruff check` passes on both changed files.
- Verified locally: with a project `settings.local.json` pinned to `default`, `--permission-mode auto` still yields `permissionMode = auto` in the `init` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)