### PR TITLE
fix(hub): skip notes index and raw sources

### DIFF
--- a/coral/hub/notes.py
+++ b/coral/hub/notes.py
@@ -89,14 +89,41 @@ def _notes_dir(coral_dir: str | Path, island_id: str | int | None = None) -> Pat
     return p
 
 
-def _is_user_note(p: Path) -> bool:
+_SYSTEM_NOTE_FILENAMES = {"notes.md", "index.md"}
+_SYSTEM_NOTE_TOP_LEVEL_DIRS = {"raw"}
+
+
+def _is_user_note(p: Path, notes_dir: Path) -> bool:
     """Whether a markdown file under notes/ should be treated as a user-authored note.
 
-    Excludes the legacy single-file ``notes.md`` and any file whose name starts
-    with ``_`` (convention for system-managed files like `_synthesis/`,
-    `_connections.md`, `_open-questions.md`).
+    Excludes the legacy single-file ``notes.md``, generated ``index.md``, raw
+    source captures, and files whose name starts with ``_`` (convention for
+    aggregate/system-managed files like ``_connections.md`` and
+    ``_open-questions.md``).
     """
-    return p.name != "notes.md" and not p.name.startswith("_")
+    if p.name in _SYSTEM_NOTE_FILENAMES or p.name.startswith("_"):
+        return False
+    rel = p.relative_to(notes_dir)
+    return not (rel.parts and rel.parts[0] in _SYSTEM_NOTE_TOP_LEVEL_DIRS)
+
+
+def _iter_user_note_files(notes_dir: Path) -> list[Path]:
+    """Return user note markdown files, pruning system directories while walking."""
+    if not notes_dir.is_dir():
+        return []
+    files: list[Path] = []
+    for root, dirs, names in os.walk(notes_dir):
+        root_path = Path(root)
+        if root_path == notes_dir:
+            dirs[:] = sorted(d for d in dirs if d not in _SYSTEM_NOTE_TOP_LEVEL_DIRS)
+        else:
+            dirs.sort()
+        for name in sorted(names):
+            if name.endswith(".md"):
+                p = root_path / name
+                if _is_user_note(p, notes_dir):
+                    files.append(p)
+    return files
 
 
 def _lenient_frontmatter(front: str) -> dict[str, Any]:
@@ -202,7 +229,7 @@ def _collect_from_dir(directory: Path) -> list[dict[str, Any]]:
     if not directory.is_dir():
         return []
 
-    md_files = sorted(f for f in directory.rglob("*.md") if _is_user_note(f))
+    md_files = _iter_user_note_files(directory)
 
     if md_files:
         entries = [_parse_note_file(f) for f in md_files]
@@ -401,9 +428,7 @@ def notes_by(
     """
     notes_dir = _notes_dir(coral_dir, island_id)
     matched: list[Path] = []
-    for md_file in sorted(notes_dir.rglob("*.md")):
-        if not _is_user_note(md_file):
-            continue
+    for md_file in _iter_user_note_files(notes_dir):
         try:
             text = md_file.read_text()
         except (OSError, UnicodeDecodeError):
@@ -428,9 +453,7 @@ def notes_unattributed(
     """
     notes_dir = _notes_dir(coral_dir, island_id)
     missing: list[Path] = []
-    for md_file in sorted(notes_dir.rglob("*.md")):
-        if not _is_user_note(md_file):
-            continue
+    for md_file in _iter_user_note_files(notes_dir):
         try:
             text = md_file.read_text()
         except (OSError, UnicodeDecodeError):

--- a/coral/template/skills/create-notes/scripts/lint.py
+++ b/coral/template/skills/create-notes/scripts/lint.py
@@ -34,6 +34,7 @@ inside .coral/public/skills/create-notes/scripts/ on every island.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from datetime import datetime
@@ -121,10 +122,30 @@ def _coerce(val: str) -> Any:
 # split in coral.hub.notes._is_user_note, plus index.md which is owned
 # by organize-files.
 SYSTEM_FILENAMES = {"notes.md", "index.md"}
+SYSTEM_TOP_LEVEL_DIRS = {"raw"}
 
 
-def _is_user_note(p: Path) -> bool:
-    return p.name not in SYSTEM_FILENAMES and not p.name.startswith("_")
+def _is_user_note(p: Path, notes_root: Path) -> bool:
+    if p.name in SYSTEM_FILENAMES or p.name.startswith("_"):
+        return False
+    rel = p.relative_to(notes_root)
+    return not (rel.parts and rel.parts[0] in SYSTEM_TOP_LEVEL_DIRS)
+
+
+def _iter_user_note_files(notes_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for root, dirs, names in os.walk(notes_root):
+        root_path = Path(root)
+        if root_path == notes_root:
+            dirs[:] = sorted(d for d in dirs if d not in SYSTEM_TOP_LEVEL_DIRS)
+        else:
+            dirs.sort()
+        for name in sorted(names):
+            if name.endswith(".md"):
+                p = root_path / name
+                if _is_user_note(p, notes_root):
+                    files.append(p)
+    return files
 
 
 def _iso_parseable(value: Any) -> bool:
@@ -259,9 +280,8 @@ def _collect_targets(args_paths: list[str]) -> list[tuple[Path, Path]]:
     for raw in inputs:
         p = Path(raw)
         if p.is_dir():
-            for f in sorted(p.rglob("*.md")):
-                if _is_user_note(f):
-                    pairs.append((f, p))
+            for f in _iter_user_note_files(p):
+                pairs.append((f, p))
         elif p.is_file() and p.suffix == ".md":
             # Walk up to find a directory named "notes"; fall back to parent.
             root = p.parent
@@ -269,7 +289,8 @@ def _collect_targets(args_paths: list[str]) -> list[tuple[Path, Path]]:
                 if ancestor.name == "notes":
                     root = ancestor
                     break
-            pairs.append((p, root))
+            if _is_user_note(p, root):
+                pairs.append((p, root))
         else:
             print(f"warning: {raw} is neither a directory nor a .md file", file=sys.stderr)
     return pairs

--- a/coral/template/skills/create-notes/scripts/unattributed.py
+++ b/coral/template/skills/create-notes/scripts/unattributed.py
@@ -28,16 +28,37 @@ inside .coral/public/skills/create-notes/scripts/ on every island.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
 DEFAULT_NOTES_DIR = ".coral/public/notes"
 
 SYSTEM_FILENAMES = {"notes.md", "index.md"}
+SYSTEM_TOP_LEVEL_DIRS = {"raw"}
 
 
-def _is_user_note(p: Path) -> bool:
-    return p.name not in SYSTEM_FILENAMES and not p.name.startswith("_")
+def _is_user_note(p: Path, notes_root: Path) -> bool:
+    if p.name in SYSTEM_FILENAMES or p.name.startswith("_"):
+        return False
+    rel = p.relative_to(notes_root)
+    return not (rel.parts and rel.parts[0] in SYSTEM_TOP_LEVEL_DIRS)
+
+
+def _iter_user_note_files(notes_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for root, dirs, names in os.walk(notes_root):
+        root_path = Path(root)
+        if root_path == notes_root:
+            dirs[:] = sorted(d for d in dirs if d not in SYSTEM_TOP_LEVEL_DIRS)
+        else:
+            dirs.sort()
+        for name in sorted(names):
+            if name.endswith(".md"):
+                p = root_path / name
+                if _is_user_note(p, notes_root):
+                    files.append(p)
+    return files
 
 
 def _creator_field(text: str) -> str:
@@ -79,9 +100,7 @@ def main() -> int:
         return 2
 
     missing: list[Path] = []
-    for md in sorted(root.rglob("*.md")):
-        if not _is_user_note(md):
-            continue
+    for md in _iter_user_note_files(root):
         try:
             text = md.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):

--- a/tests/test_creator_stamping.py
+++ b/tests/test_creator_stamping.py
@@ -7,13 +7,25 @@ This test is the regression gate for that instruction surviving future
 prompt edits.
 """
 
+import importlib.util
+import tempfile
 from pathlib import Path
+from types import ModuleType
 
 COMMON_INSTRUCTION_KEYWORDS = ["creator:", "frontmatter"]
 
 
+def _load_script(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _check_prompt(path: Path) -> None:
-    text = path.read_text().lower()
+    text = path.read_text(encoding="utf-8").lower()
     for kw in COMMON_INSTRUCTION_KEYWORDS:
         assert kw in text, f"{path} must mention {kw!r} so agents stamp the creator field"
 
@@ -35,7 +47,7 @@ def test_bundled_skill_md_files_have_no_creator_frontmatter():
     migration's `skills_by` filter correctly excludes them."""
     bundled = Path("coral/template/skills").rglob("SKILL.md")
     for skill_md in bundled:
-        text = skill_md.read_text()
+        text = skill_md.read_text(encoding="utf-8")
         # Only inspect frontmatter (first --- block); body may legitimately mention "creator"
         if not text.startswith("---"):
             continue
@@ -44,3 +56,40 @@ def test_bundled_skill_md_files_have_no_creator_frontmatter():
         assert "\ncreator:" not in front and not front.startswith("creator:"), (
             f"{skill_md} has stray `creator:` in frontmatter — would migrate as agent-authored"
         )
+
+
+def test_create_notes_scripts_skip_index_and_raw_sources():
+    lint = _load_script(Path("coral/template/skills/create-notes/scripts/lint.py"))
+    unattributed = _load_script(Path("coral/template/skills/create-notes/scripts/unattributed.py"))
+
+    with tempfile.TemporaryDirectory() as d:
+        notes_dir = Path(d) / "notes"
+        raw_dir = notes_dir / "raw"
+        research_dir = notes_dir / "research"
+        synthesis_dir = notes_dir / "_synthesis"
+        raw_dir.mkdir(parents=True)
+        research_dir.mkdir()
+        synthesis_dir.mkdir()
+        (notes_dir / "index.md").write_text(
+            "# Index\n\n- [Research](research/useful.md)", encoding="utf-8"
+        )
+        (raw_dir / "paper.md").write_text("# Raw source without frontmatter\n", encoding="utf-8")
+        (research_dir / "useful.md").write_text(
+            "# User note without frontmatter\n", encoding="utf-8"
+        )
+        (synthesis_dir / "team-roster.md").write_text(
+            "# Synthesis note without frontmatter\n", encoding="utf-8"
+        )
+
+        lint_targets = lint._collect_targets([str(notes_dir)])
+        assert [(p.relative_to(root).as_posix(), root) for p, root in lint_targets] == [
+            ("_synthesis/team-roster.md", notes_dir),
+            ("research/useful.md", notes_dir),
+        ]
+        assert lint._collect_targets([str(notes_dir / "index.md")]) == []
+        assert lint._collect_targets([str(raw_dir / "paper.md")]) == []
+        unattributed_targets = [
+            p.relative_to(notes_dir).as_posix()
+            for p in unattributed._iter_user_note_files(notes_dir)
+        ]
+        assert unattributed_targets == ["_synthesis/team-roster.md", "research/useful.md"]

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -234,10 +234,10 @@ def test_notes_skip_index_and_raw_sources():
         )
 
         entries = list_notes(d)
-        assert [e["relative_path"] for e in entries] == [
+        assert {e["relative_path"] for e in entries} == {
             str(Path("_synthesis") / "team-roster.md"),
             str(Path("research") / "useful-idea.md"),
-        ]
+        }
         assert search_notes(d, "needle-only-in-raw") == []
         assert [e["relative_path"] for e in search_notes(d, "roster")] == [
             str(Path("_synthesis") / "team-roster.md")

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -12,7 +12,15 @@ from coral.hub.attempts import (
     search_attempts,
     write_attempt,
 )
-from coral.hub.notes import format_notes_list, get_recent_notes, list_notes, read_note, search_notes
+from coral.hub.notes import (
+    format_notes_list,
+    get_recent_notes,
+    list_notes,
+    notes_by,
+    notes_unattributed,
+    read_note,
+    search_notes,
+)
 from coral.hub.skills import get_skill_tree, list_skills, read_skill
 from coral.types import Attempt
 
@@ -200,6 +208,45 @@ def test_notes_empty():
         entries = list_notes(d)
         assert entries == []
         assert format_notes_list(entries) == "No notes yet."
+
+
+def test_notes_skip_index_and_raw_sources():
+    with tempfile.TemporaryDirectory() as d:
+        notes_dir = Path(d) / "public" / "notes"
+        raw_dir = notes_dir / "raw"
+        research_dir = notes_dir / "research"
+        synthesis_dir = notes_dir / "_synthesis"
+        raw_dir.mkdir(parents=True)
+        research_dir.mkdir()
+        synthesis_dir.mkdir()
+        (notes_dir / "index.md").write_text(
+            "# Notes Index\n\n- [Useful idea](research/useful-idea.md)\n"
+        )
+        (raw_dir / "paper.md").write_text(
+            "---\ncreator: raw-agent\n---\n\n# Raw paper\n\nneedle-only-in-raw\n"
+        )
+        (raw_dir / "unstamped.md").write_text("# Raw source without frontmatter\n")
+        (research_dir / "useful-idea.md").write_text(
+            "---\ncreator: agent-1\n---\n\n# Useful idea\n"
+        )
+        (synthesis_dir / "team-roster.md").write_text(
+            "---\ncreator: synthesizer\n---\n\n# Team roster\n"
+        )
+
+        entries = list_notes(d)
+        assert [e["relative_path"] for e in entries] == [
+            str(Path("_synthesis") / "team-roster.md"),
+            str(Path("research") / "useful-idea.md"),
+        ]
+        assert search_notes(d, "needle-only-in-raw") == []
+        assert [e["relative_path"] for e in search_notes(d, "roster")] == [
+            str(Path("_synthesis") / "team-roster.md")
+        ]
+        assert notes_by(d, None, "raw-agent") == []
+        assert [p.relative_to(notes_dir) for p in notes_by(d, None, "synthesizer")] == [
+            Path("_synthesis") / "team-roster.md"
+        ]
+        assert notes_unattributed(d, None) == []
 
 
 def test_skills():


### PR DESCRIPTION
## Motivation

The notes hub was treating generated note metadata and raw source captures as ordinary notes in discovery paths. `notes/index.md` is a table of contents and top-level `notes/raw/` contains immutable source material, but those files could still appear in listing, search, and attribution flows as if they were authored research or experiment notes.

This fixes the hub behavior to match the bundled notes workflow, reducing noisy `(unknown)` entries and preventing raw source text from being searched or attributed as a normal note.

## Changes

- Exclude generated `index.md` and top-level `raw/` markdown files from hub note discovery, search, recent/read-all, `notes_by`, and `notes_unattributed`.
- Prune `raw/` while walking note trees instead of discovering raw files and filtering them afterward.
- Keep compatibility behavior intact: legacy `notes.md` fallback parsing still works, `_synthesis/<topic>.md` remains visible as a real note, and underscore-prefixed aggregate files remain excluded.
- Align the bundled `create-notes` lint and unattributed scripts with the same user-note predicate while keeping them self-contained for copied agent worktrees.
- Add regression tests for index/raw exclusion, unstamped raw files, raw attribution exclusion, `_synthesis` inclusion, and direct-file lint inputs.

## Test plan

- `uv run --extra dev pytest tests/test_hub.py tests/test_creator_stamping.py -q`
  - 18 passed
- Clean WSL clone with this diff applied: `uv run --extra dev pytest tests/test_hub.py tests/test_creator_stamping.py tests/test_islands.py -q`
  - 42 passed
- Clean WSL clone with this diff applied: `uv run --extra dev pytest tests/ -v`
  - 541 passed, 1 skipped, 2 existing `datetime.utcnow()` deprecation warnings
- Clean WSL clone with this diff applied: `uv run --extra dev ruff check .`
  - All checks passed
- Clean WSL clone with this diff applied: `uv run --extra dev ruff format --check .`
  - 117 files already formatted

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is local hub and bundled skill helper behavior covered by regression tests and full local lint/test validation.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [x] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [x] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: tests

## Checklist

- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract - noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex-GPT--5-000000)