### PR TITLE
fix(ci): create GitHub Release from scheduled auto-tagger

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -102,9 +102,12 @@ jobs:
     name: Build & publish
     needs: tag
     if: needs.tag.outputs.tagged == 'true'
-    # Reuse the existing release pipeline. It checks out at this run's commit,
-    # where the tag we just pushed now lives, so hatch-vcs derives the correct
-    # version.
+    # Reuse the existing release pipeline. Pass the tag we just pushed so the
+    # release job checks it out (hatch-vcs derives the correct version) and the
+    # gh-release action attaches the GitHub Release to it — github.ref here is
+    # the scheduled branch, not a tag, so it can't infer the tag on its own.
     uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.tag.outputs.version }}
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,14 @@ on:
   # the `push: tags` event above, so the scheduled auto-tagger calls us here
   # instead of relying on the tag push to kick off a release.
   workflow_call:
+    inputs:
+      tag:
+        description: >-
+          Tag to release. Required when called from a non-tag event (e.g. the
+          scheduled auto-tagger), where github.ref points at a branch and the
+          release action can't infer the tag on its own.
+        type: string
+        required: false
 
 permissions:
   contents: write
@@ -23,6 +31,10 @@ jobs:
           # hatch-vcs derives the package version from git history, so we need
           # the full history (including tags) — not a shallow clone.
           fetch-depth: 0
+          # On a tag push github.ref already points at the tag; when called
+          # with an explicit tag (scheduled auto-tagger), check that tag out so
+          # hatch-vcs derives the released version rather than the branch head.
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -37,5 +49,8 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          # Fall back to github.ref_name on a tag push; use the passed tag when
+          # invoked from a non-tag event, where the action can't infer it.
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: dist/*


### PR DESCRIPTION
## Problem

The scheduled auto-release run pushes a new tag and builds the package, but **no GitHub Release is created**. The most recent run pushed `v0.7.2` yet the release step failed with **"GitHub Releases requires a tag"**, so `v0.7.2` was missing from the Releases page.

Root cause: when `auto-release.yml` calls `release.yml` via `workflow_call` on a **scheduled** run, `github.ref` points at the branch (`main`), not a tag. `softprops/action-gh-release` infers the tag from `github.ref`, so it has nothing to attach the release to.

## Fix

Thread the tag through the reusable-workflow call explicitly:

- **release.yml** — add a `tag` `workflow_call` input, check that tag out (`ref: ${{ inputs.tag || github.ref }}`), and pass `tag_name: ${{ inputs.tag || github.ref_name }}` to the release action. The `|| github.ref_name` fallback keeps the normal `push: tags` trigger working unchanged.
- **auto-release.yml** — pass `tag: ${{ needs.tag.outputs.version }}` into the call.

## Note

`v0.7.2` was backfilled manually (release + built artifacts) so the Releases page is already current. The next scheduled run will bump to `v0.7.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)