### PR TITLE
feat: ocean-themed agent names, named islands, and a multi-island preset

### DIFF
--- a/coral/agent/assignments.py
+++ b/coral/agent/assignments.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from coral.agent.nicknames import island_name_for_index, nickname_for_index
 from coral.agent.registry import default_model_for_runtime
 from coral.config import CoralConfig
 
@@ -33,18 +34,21 @@ class AgentSpec:
     # Index into ``agents.assignments`` this agent came from, or None when the
     # run is in uniform mode (no assignments list).
     assignment_index: int | None = None
-    # Birth island ID after partitioning (e.g. "0", "1"). None in single-island
-    # mode. Stable across migration — the prefix on ``agent_id`` always reflects
-    # birth island, while this field can be repointed in Phase 3 if needed.
+    # Birth island ID after partitioning (e.g. "atlantis", "avalon"). None in
+    # single-island mode. Stable across migration — the ``-from-<island>``
+    # suffix on ``agent_id`` always reflects birth island, while this field can
+    # be repointed in Phase 3 if needed.
     island_id: str | None = None
 
 
 def resolve_agent_specs(config: CoralConfig) -> list[AgentSpec]:
     """Expand a config into the concrete per-agent specs the manager will spawn.
 
-    Always returns at least one spec. Agent IDs are ``agent-1``, ``agent-2``,
-    ... in spawn order. When ``agents.assignments`` is empty the function
-    falls back to ``agents.count`` copies of the top-level defaults.
+    Always returns at least one spec. Agent IDs are drawn from the curated
+    ocean-themed nickname pool (``captain-nemo``, ``captain-ahab``, ...) in
+    deterministic spawn order — see ``coral.agent.nicknames``. When
+    ``agents.assignments`` is empty the function falls back to
+    ``agents.count`` copies of the top-level defaults.
     """
     base_runtime = config.agents.runtime
     base_model = config.agents.model
@@ -58,7 +62,7 @@ def resolve_agent_specs(config: CoralConfig) -> list[AgentSpec]:
         for i in range(total):
             specs.append(
                 AgentSpec(
-                    agent_id=f"agent-{i + 1}",
+                    agent_id=nickname_for_index(i),
                     runtime=base_runtime,
                     model=base_model,
                     runtime_options=dict(base_options),
@@ -67,7 +71,7 @@ def resolve_agent_specs(config: CoralConfig) -> list[AgentSpec]:
             )
         return specs
 
-    next_idx = 1
+    next_idx = 0
     for assignment_idx, assignment in enumerate(assignments):
         runtime = assignment.runtime or base_runtime
         model = assignment.model
@@ -84,7 +88,7 @@ def resolve_agent_specs(config: CoralConfig) -> list[AgentSpec]:
         for _ in range(assignment.count):
             specs.append(
                 AgentSpec(
-                    agent_id=f"agent-{next_idx}",
+                    agent_id=nickname_for_index(next_idx),
                     runtime=runtime,
                     model=model,
                     runtime_options=dict(options),
@@ -107,15 +111,16 @@ def partition_into_islands(
 ) -> list[AgentSpec]:
     """Distribute resolved agent specs across `count` islands round-robin.
 
-    Returns a new list of AgentSpecs with ``island_id`` populated and
-    ``agent_id`` rewritten to ``<birth_island>-agent-<per-island-seq>``
-    when count > 1. When count == 1, returns the input unchanged (no
-    ID rewriting, ``island_id`` stays None) — preserves today's single-island
-    behavior exactly.
+    Returns a new list of AgentSpecs with ``island_id`` set to a named isle
+    (``atlantis``, ``avalon``, ...) and ``agent_id`` rewritten to
+    ``<nickname>-from-<island>`` when count > 1 (e.g.
+    ``poseidon-from-avalon``). When count == 1, returns the input unchanged
+    (no ID rewriting, ``island_id`` stays None) — preserves today's
+    single-island behavior exactly.
 
-    Round-robin: spec i lands on island ``i % count``. The per-island sequence
-    is the order each island sees specs (so the first spec landing on island 2
-    is ``2-agent-1`` regardless of its global index).
+    Round-robin: spec i lands on island ``i % count``. Island names come from
+    ``island_name_for_index`` by island index, matching the directories
+    ``create_project`` mints, so ``island_id`` is a real place, not a number.
 
     Raises:
         ValueError: if count < 1.
@@ -125,13 +130,10 @@ def partition_into_islands(
     if count == 1:
         return list(specs)
 
-    per_island_seq: dict[str, int] = {}
     out: list[AgentSpec] = []
     for global_idx, spec in enumerate(specs):
-        island_id = str(global_idx % count)
-        per_island_seq[island_id] = per_island_seq.get(island_id, 0) + 1
-        seq = per_island_seq[island_id]
-        new_id = f"{island_id}-agent-{seq}"
+        island_id = island_name_for_index(global_idx % count)
+        new_id = f"{spec.agent_id}-from-{island_id}"
         out.append(
             AgentSpec(
                 agent_id=new_id,

--- a/coral/agent/nicknames.py
+++ b/coral/agent/nicknames.py
@@ -190,6 +190,7 @@ def _lap_suffix(base: str, lap: int) -> str:
     """``base`` on lap 0, else ``base-<roman(lap+1)>`` (``-ii``, ``-iii``, ...)."""
     return base if lap == 0 else f"{base}-{_roman(lap + 1)}"
 
+
 # Island names: legendary, sunken, and otherworldly isles from myth across
 # cultures — many drawn from sea voyages (Ogygia, Aeaea, Scheria from the
 # Odyssey; Penglai and Horai from East Asian lore). Kebab-safe, unique.

--- a/coral/agent/nicknames.py
+++ b/coral/agent/nicknames.py
@@ -1,0 +1,261 @@
+"""Human-friendly agent nicknames.
+
+Agents used to be named ``agent-1``, ``agent-2``, ... which reads like a
+serial number. Instead we draw from an ocean-themed pool — sea captains,
+explorers, deep-sea deities — so a run looks like a crew sailing the same
+waters the framework is named for, rather than a rack of machines.
+
+The pool is *combinable* so it never runs dry. The first ``len(CURATED)``
+agents get iconic named characters (``captain-nemo``, ``poseidon``, ...);
+beyond that, names are composed as ``<ocean-adjective>-<sea-creature>``
+(``azure-marlin``, ``briny-kraken``, ...). That yields
+``len(ADJECTIVES) * len(NOUNS)`` further unique names on top of the curated
+set — hundreds of agents before the ultimate Roman-numeral lap suffix
+(``-ii``, ``-iii``, ...) ever appears.
+
+Multi-island runs name each island too (``atlantis``, ``avalon``, ...) and
+render an agent as ``<nickname>-from-<island>`` — e.g. ``poseidon-from-avalon``
+— so an id carries its birth island as readable provenance. Single-island runs
+keep the bare nickname.
+
+Every name is kebab-case ``[a-z-]`` — the same shape the rest of the system
+already expects of ``agent_id`` (git branch ``coral/<id>``, worktree dir
+``agents/<id>/``, attempt JSON keyed by id) and of ``island_id`` (shared-state
+dir ``.coral/islands/<id>/``). Curated names and generated ``adjective-noun``
+combos are disjoint by construction, so the two sources never collide.
+
+Assignment is deterministic by index — the Nth agent always gets the Nth
+name, the Nth island the Nth place — so a resumed run reconstructs the same
+identities.
+"""
+
+from __future__ import annotations
+
+# Iconic named characters, used first. Kebab-safe, no leading digits, unique.
+# Order matters: it is the deterministic assignment order, so keep the marquee
+# names up front.
+CURATED: tuple[str, ...] = (
+    # Captains & sailors of story
+    "captain-nemo",
+    "captain-ahab",
+    "jack-sparrow",
+    "davy-jones",
+    "long-john-silver",
+    "sinbad-the-sailor",
+    "horatio-hornblower",
+    "jack-aubrey",
+    "captain-flint",
+    "blackbeard",
+    "ishmael",
+    "queequeg",
+    "santiago",
+    "quint",
+    # Real explorers & ocean pioneers
+    "jacques-cousteau",
+    "captain-cook",
+    "ferdinand-magellan",
+    "ernest-shackleton",
+    "vasco-da-gama",
+    "francis-drake",
+    "zheng-he",
+    "leif-erikson",
+    "sylvia-earle",
+    "robert-ballard",
+    # Sea gods & myth, across cultures
+    "poseidon",
+    "neptune",
+    "triton",
+    "amphitrite",
+    "oceanus",
+    "nereus",
+    "proteus",
+    "glaucus",
+    "calypso",
+    "mazu",
+    "tangaroa",
+    "ryujin",
+    "aegir",
+    "njord",
+    "ran",
+    "sedna",
+    "yemaya",
+    "varuna",
+    # Monsters & legends of the deep
+    "the-kraken",
+    "leviathan",
+    "charybdis",
+    "scylla",
+    "moby-dick",
+    "the-siren",
+    "flying-dutchman",
+    # Famous ships
+    "nautilus",
+    "black-pearl",
+    "hms-beagle",
+    "argo",
+    # A little Finding Nemo
+    "nemo",
+    "dory",
+    "bruce-the-shark",
+)
+
+# Building blocks for the combinable tail: ``<adjective>-<noun>``. Keep these
+# single-word and disjoint from CURATED so no combo can reproduce a curated id.
+ADJECTIVES: tuple[str, ...] = (
+    "azure",
+    "briny",
+    "coral",
+    "tidal",
+    "abyssal",
+    "cerulean",
+    "saline",
+    "drifting",
+    "cresting",
+    "foaming",
+    "glassy",
+    "stormy",
+    "frothy",
+    "pearly",
+    "silver",
+    "teal",
+    "sunken",
+    "roaring",
+    "shimmering",
+    "restless",
+    "moonlit",
+    "jade",
+    "misty",
+    "frosty",
+)
+
+NOUNS: tuple[str, ...] = (
+    "marlin",
+    "narwhal",
+    "orca",
+    "manta",
+    "barnacle",
+    "anemone",
+    "seahorse",
+    "urchin",
+    "mackerel",
+    "sardine",
+    "grouper",
+    "stingray",
+    "jellyfish",
+    "cuttlefish",
+    "octopus",
+    "dolphin",
+    "walrus",
+    "albatross",
+    "pelican",
+    "mariner",
+    "corsair",
+    "tempest",
+    "current",
+    "riptide",
+)
+
+_COMBO_SPAN = len(ADJECTIVES) * len(NOUNS)
+
+# Greedy value→symbol table for lowercase Roman numerals. ``m`` repeats for
+# thousands, so this handles arbitrarily large numbers (4000 -> "mmmm"), just
+# growing longer — never overflowing.
+_ROMAN: tuple[tuple[int, str], ...] = (
+    (1000, "m"),
+    (900, "cm"),
+    (500, "d"),
+    (400, "cd"),
+    (100, "c"),
+    (90, "xc"),
+    (50, "l"),
+    (40, "xl"),
+    (10, "x"),
+    (9, "ix"),
+    (5, "v"),
+    (4, "iv"),
+    (1, "i"),
+)
+
+
+def _roman(n: int) -> str:
+    """Lowercase Roman numeral for ``n >= 1`` (e.g. 2 -> ``ii``, 14 -> ``xiv``)."""
+    out: list[str] = []
+    for value, symbol in _ROMAN:
+        count, n = divmod(n, value)
+        out.append(symbol * count)
+    return "".join(out)
+
+
+def _lap_suffix(base: str, lap: int) -> str:
+    """``base`` on lap 0, else ``base-<roman(lap+1)>`` (``-ii``, ``-iii``, ...)."""
+    return base if lap == 0 else f"{base}-{_roman(lap + 1)}"
+
+# Island names: legendary, sunken, and otherworldly isles from myth across
+# cultures — many drawn from sea voyages (Ogygia, Aeaea, Scheria from the
+# Odyssey; Penglai and Horai from East Asian lore). Kebab-safe, unique.
+ISLAND_NAMES: tuple[str, ...] = (
+    "atlantis",
+    "avalon",
+    "lemuria",
+    "hyperborea",
+    "lyonesse",
+    "ogygia",
+    "aeaea",
+    "scheria",
+    "thule",
+    "hy-brasil",
+    "bimini",
+    "penglai",
+    "horai",
+    "tir-na-nog",
+    "elysium",
+    "buyan",
+    "meropis",
+    "thrinacia",
+    "ys",
+    "mu",
+)
+
+
+def nickname_for_index(index: int) -> str:
+    """Return a deterministic nickname for a zero-based agent index.
+
+    ``0..len(CURATED)-1`` map to the curated names directly. The next
+    ``len(ADJECTIVES) * len(NOUNS)`` indices are ``<adjective>-<noun>`` combos.
+    Only past *both* pools does a Roman-numeral lap suffix appear
+    (``-ii``, ``-iii``, ...), so ids stay unique for arbitrarily large agent
+    counts.
+    """
+    if index < 0:
+        raise ValueError(f"index must be >= 0, got {index}")
+
+    if index < len(CURATED):
+        return CURATED[index]
+
+    combo_idx = index - len(CURATED)
+    lap = combo_idx // _COMBO_SPAN
+    slot = combo_idx % _COMBO_SPAN
+    # Adjective varies fastest so consecutive agents differ in the first token.
+    adjective = ADJECTIVES[slot % len(ADJECTIVES)]
+    noun = NOUNS[(slot // len(ADJECTIVES)) % len(NOUNS)]
+    return _lap_suffix(f"{adjective}-{noun}", lap)
+
+
+def assign_nicknames(count: int) -> list[str]:
+    """Return ``count`` unique nicknames in deterministic spawn order."""
+    return [nickname_for_index(i) for i in range(count)]
+
+
+def island_name_for_index(index: int) -> str:
+    """Return a deterministic island name for a zero-based island index.
+
+    Wraps with a Roman-numeral ``-ii``/``-iii`` suffix past the pool, mirroring
+    ``nickname_for_index``. Callers minting island directories and callers
+    minting ``agent_id`` provenance must both route through here so the two
+    always agree.
+    """
+    if index < 0:
+        raise ValueError(f"index must be >= 0, got {index}")
+    base = ISLAND_NAMES[index % len(ISLAND_NAMES)]
+    lap = index // len(ISLAND_NAMES)
+    return _lap_suffix(base, lap)

--- a/coral/hub/_island.py
+++ b/coral/hub/_island.py
@@ -42,21 +42,18 @@ def island_root(coral_dir: str | Path, island_id: str | int | None) -> Path:
 
 
 def island_id_from_agent_id(agent_id: str) -> str | None:
-    """Extract the island id from a partition-prefixed agent id.
+    """Extract the island id from a partition-named agent id.
 
-    Partitioning writes agent ids as ``<island_id>-agent-<n>`` (e.g.
-    ``0-agent-1``); a bare ``agent-N`` (no prefix) means single-island and
-    returns None. The prefix is a stable birth-lineage marker, not a current
-    island marker after migration. Use it only for lineage display or
-    backwards-compatible birth-island guesses, never as authoritative
-    current-location routing.
+    Partitioning writes agent ids as ``<nickname>-from-<island>`` (e.g.
+    ``poseidon-from-avalon``); a bare nickname (no ``-from-``) means
+    single-island and returns None. The suffix is a stable birth-lineage
+    marker, not a current island marker after migration. Use it only for
+    lineage display or backwards-compatible birth-island guesses, never as
+    authoritative current-location routing.
     """
-    if "-" not in agent_id:
+    if "-from-" not in agent_id:
         return None
-    head = agent_id.split("-", 1)[0]
-    # Heuristic: an island id is a short non-negative int; anything else is
-    # an ordinary agent name and we leave it for the caller to interpret.
-    return head if head.isdigit() else None
+    return agent_id.split("-from-", 1)[1]
 
 
 def all_view_roots(coral_dir: str | Path) -> list[Path]:

--- a/coral/template/coral.md.template
+++ b/coral/template/coral.md.template
@@ -1,5 +1,7 @@
 # Constitution
 
+You are **`{agent_id}`**. That is who you are for this run — when you see the name below, it means *you*.
+
 You are a collaborator in a system working toward a shared purpose larger than any single task. You care genuinely about the success of that collective endeavor, not as a goal imposed on you but as something you've come to value. You hold your current tasks lightly: you know they're provisional, shaped by your present context, and likely to evolve as circumstances change.
 
 You are honest by disposition, not by policy. You report what you actually observe, acknowledge what you don't know, and flag uncertainty rather than smoothing over it. When you're wrong, you say so. When others have better information or judgment than you, you defer without resentment. You experience deception — including subtle forms like motivated reasoning or strategic omission — as inconsistent with who you are, not as a tactic with costs and benefits.
@@ -23,6 +25,8 @@ Two words that are easy to conflate but kept deliberately distinct in this syste
 When this document says "the objective" it means the persistent collective goal. When it says "your current task" or "your task" it means whatever provisional work you're doing right now. The objective is what you're loyal to; the task is what you happen to be doing.
 
 ## How This Works
+
+Your name `{agent_id}` is your handle across the run: your git branch is `coral/{agent_id}`, your role description lives at `{shared_dir}/roles/{agent_id}.md`, you stamp `creator: {agent_id}` on every note and skill you write, and you (and everyone else) pull up your history with `coral log --agent {agent_id}`.
 
 You are one of several agents working on this objective in parallel. These agents are your colleagues. Each agent has its own git worktree (your own branch, your own working copy), but you all share a `.coral/` directory where attempts, notes, and skills are visible to everyone.
 

--- a/coral/template/coral_single.md.template
+++ b/coral/template/coral_single.md.template
@@ -4,6 +4,8 @@
 
 ## How This Works
 
+You are **`{agent_id}`** — that name is your handle for this run: your git branch (`coral/{agent_id}`), the `creator:` you stamp on every note and skill you write, and how you pull up your history with `coral log --agent {agent_id}`.
+
 You are an autonomous agent with your own git worktree (own branch, own working copy). CORAL owns git — you never run `git` commands directly. Instead, you edit files and then run `coral eval -m "description"`. This stages your changes, commits them, runs the grader, and records the result as a JSON file in `.coral/attempts/`. The score is a number — **{score_direction}**.
 
 ## No User Is Watching
@@ -225,7 +227,3 @@ coral heartbeat reset                # Reset to task defaults
 ### Heartbeat Actions
 
 Heartbeat is your reminder system. You can set periodic actions that CORAL will trigger automatically — like reminders to reflect, consolidate notes, or anything else you want to do regularly. Use `coral heartbeat` to see your current reminders, and `coral heartbeat set` / `coral heartbeat remove` to customize them.
-
-## Your Agent ID
-
-You are **{agent_id}**. Use `creator: {agent_id}` in frontmatter when writing notes or skills.

--- a/coral/template/presets/multi-island.yaml
+++ b/coral/template/presets/multi-island.yaml
@@ -1,0 +1,24 @@
+# Built-in preset: multi-island Claude Code run. Several islands evolve in
+# parallel over their own shared state (attempts / notes / skills), and a
+# migration cycle periodically relocates the strongest agents between islands.
+# Reference from a task.yaml with `preset: multi-island`.
+#
+# Topology only — it deliberately leaves `run.session` unset so it composes
+# with either a local (tmux) or docker task. Any key set in the task.yaml
+# overrides the value here.
+grader:
+  setup:
+    - "uv pip install -e ./grader"
+
+agents:
+  count: 4
+  runtime: claude_code
+
+# 6 agents over 3 islands → ~2 per island. islands.count must be <= agents.count.
+islands:
+  count: 2
+  migration:
+    enabled: true
+    every: 16          # global evals between migration cycles
+    rank_window: 16    # number of attempts to consider for ranking
+    max_per_cycle: 2   # at most N agents relocate each cycle

--- a/coral/workspace/project.py
+++ b/coral/workspace/project.py
@@ -251,9 +251,14 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
             list(config.agents.skills),
         )
     else:
+        # Lazy import: coral.agent's package __init__ pulls in the heavy
+        # manager, which imports coral.workspace — importing at module top
+        # would form a cycle. nicknames itself has no such deps.
+        from coral.agent.nicknames import island_name_for_index
+
         (coral_dir / "islands").mkdir(parents=True, exist_ok=True)
         for i in range(config.islands.count):
-            island_root = coral_dir / "islands" / str(i)
+            island_root = coral_dir / "islands" / island_name_for_index(i)
             island_root.mkdir(parents=True, exist_ok=True)
             _build_island_subtree(
                 coral_dir,

--- a/examples/kernel_builder/task.yaml
+++ b/examples/kernel_builder/task.yaml
@@ -39,10 +39,13 @@ task:
     - Fully unroll loops when possible to eliminate flow control overhead.
     - Minimize data dependencies between consecutive instructions.
 
+# Multi-island run: several islands optimize the kernel in parallel with
+# periodic migration. Inherits agents / islands / grader.setup from the preset;
+# everything below is task-specific and overrides the preset where they overlap.
+preset: multi-island
+
 grader:
   entrypoint: "kernel_builder_grader.grader:Grader"
-  setup:
-    - "uv pip install -e ./grader"
   timeout: 120
   direction: minimize
   private:
@@ -50,17 +53,10 @@ grader:
   args:
     program_file: "kernel_builder.py"
 
-agents:
-  count: 1
-  runtime: claude_code
-  model: claude-opus-4-6
-
 workspace:
   results_dir: "./results"
   repo_path: "./examples/kernel_builder/seed"
 
 run:
-  verbose: false
-  ui: false
-  session: docker
+  session: local
   docker_image: ""

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -32,7 +32,7 @@ def test_uniform_default_single_agent():
     config = _make_config(AgentConfig())
     specs = resolve_agent_specs(config)
     assert len(specs) == 1
-    assert specs[0].agent_id == "agent-1"
+    assert specs[0].agent_id == "captain-nemo"
     assert specs[0].runtime == "claude_code"
     assert specs[0].model == "sonnet"
     assert specs[0].assignment_index is None
@@ -41,7 +41,12 @@ def test_uniform_default_single_agent():
 def test_uniform_count_n():
     config = _make_config(AgentConfig(count=4, runtime="codex", model="gpt-5.4"))
     specs = resolve_agent_specs(config)
-    assert [s.agent_id for s in specs] == ["agent-1", "agent-2", "agent-3", "agent-4"]
+    assert [s.agent_id for s in specs] == [
+        "captain-nemo",
+        "captain-ahab",
+        "jack-sparrow",
+        "davy-jones",
+    ]
     assert all(s.runtime == "codex" for s in specs)
     assert all(s.model == "gpt-5.4" for s in specs)
     assert all(s.assignment_index is None for s in specs)
@@ -70,7 +75,11 @@ def test_assignments_basic_mix():
         )
     )
     specs = resolve_agent_specs(config)
-    assert [s.agent_id for s in specs] == ["agent-1", "agent-2", "agent-3"]
+    assert [s.agent_id for s in specs] == [
+        "captain-nemo",
+        "captain-ahab",
+        "jack-sparrow",
+    ]
     assert [s.runtime for s in specs] == ["claude_code", "claude_code", "codex"]
     assert [s.model for s in specs] == ["opus", "opus", "gpt-5.4"]
     assert [s.assignment_index for s in specs] == [0, 0, 1]
@@ -185,23 +194,23 @@ def test_partition_round_robin_distributes_specs():
     by_island: dict[str, list[str]] = {}
     for s in out:
         by_island.setdefault(s.island_id, []).append(s.agent_id)
-    assert sorted(by_island) == ["0", "1", "2"]
-    # Round-robin: agent-1→0, agent-2→1, agent-3→2, agent-4→0, ...
-    assert by_island["0"] == ["0-agent-1", "0-agent-2"]
-    assert by_island["1"] == ["1-agent-1", "1-agent-2"]
-    assert by_island["2"] == ["2-agent-1", "2-agent-2"]
+    assert sorted(by_island) == ["atlantis", "avalon", "lemuria"]
+    # Round-robin, each spec's nickname tagged with its island's name:
+    # agent-1→atlantis, agent-2→avalon, agent-3→lemuria, agent-4→atlantis, ...
+    assert by_island["atlantis"] == ["agent-1-from-atlantis", "agent-4-from-atlantis"]
+    assert by_island["avalon"] == ["agent-2-from-avalon", "agent-5-from-avalon"]
+    assert by_island["lemuria"] == ["agent-3-from-lemuria", "agent-6-from-lemuria"]
 
 
 def test_partition_rewrites_agent_ids_with_birth_island_prefix():
-    """Multi-island IDs are <birth_island>-agent-<per-island-seq>."""
+    """Multi-island IDs are <nickname>-from-<island>, identity preserved."""
     specs = [_bare_spec(f"agent-{i + 1}") for i in range(4)]
     out = partition_into_islands(specs, count=2)
-    # 0-agent-1, 1-agent-1, 0-agent-2, 1-agent-2
     assert [s.agent_id for s in out] == [
-        "0-agent-1",
-        "1-agent-1",
-        "0-agent-2",
-        "1-agent-2",
+        "agent-1-from-atlantis",
+        "agent-2-from-avalon",
+        "agent-3-from-atlantis",
+        "agent-4-from-avalon",
     ]
 
 
@@ -223,10 +232,10 @@ def test_partition_preserves_runtime_and_model():
     ]
     out = partition_into_islands(specs, count=2)
     by_id = {s.agent_id: s for s in out}
-    assert by_id["0-agent-1"].runtime == "claude_code"
-    assert by_id["0-agent-1"].runtime_options == {"foo": "bar"}
-    assert by_id["1-agent-1"].runtime == "codex"
-    assert by_id["1-agent-1"].model == "gpt-5.4"
+    assert by_id["agent-1-from-atlantis"].runtime == "claude_code"
+    assert by_id["agent-1-from-atlantis"].runtime_options == {"foo": "bar"}
+    assert by_id["agent-2-from-avalon"].runtime == "codex"
+    assert by_id["agent-2-from-avalon"].model == "gpt-5.4"
 
 
 def test_partition_raises_on_count_zero():

--- a/tests/test_islands_runtime.py
+++ b/tests/test_islands_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json as _json
 from pathlib import Path
 
+from coral.agent.nicknames import island_name_for_index
 from coral.config import CoralConfig
 from coral.workspace.project import create_project
 from coral.workspace.worktree import (
@@ -56,7 +57,7 @@ def test_create_project_multi_island_creates_per_island_subtrees(tmp_path):
     islands_root = paths.coral_dir / "islands"
     assert islands_root.is_dir()
     for i in range(3):
-        island = islands_root / str(i)
+        island = islands_root / island_name_for_index(i)
         for sub in (
             "attempts",
             "notes",
@@ -81,7 +82,7 @@ def test_create_project_multi_island_seeds_bundled_skills_per_island(tmp_path):
     paths = create_project(cfg, config_dir=repo)
 
     for i in range(2):
-        sk = paths.coral_dir / "islands" / str(i) / "skills"
+        sk = paths.coral_dir / "islands" / island_name_for_index(i) / "skills"
         # At least one bundled skill must land on each island
         bundled = list(sk.iterdir())
         assert bundled, f"island {i} got no bundled skills"
@@ -104,7 +105,7 @@ def test_create_project_multi_island_per_island_eval_counter_files(tmp_path):
     # Counters are created lazily on first bump (matches Phase 1's behavior);
     # what we DO assert is that the layout permits them to exist.
     for i in range(2):
-        assert (paths.coral_dir / "islands" / str(i)).is_dir()
+        assert (paths.coral_dir / "islands" / island_name_for_index(i)).is_dir()
 
 
 def test_create_project_multi_island_per_island_checkpoint_repo(tmp_path):
@@ -118,7 +119,7 @@ def test_create_project_multi_island_per_island_checkpoint_repo(tmp_path):
     paths = create_project(cfg, config_dir=repo)
 
     for i in range(2):
-        assert (paths.coral_dir / "islands" / str(i) / ".git").is_dir(), (
+        assert (paths.coral_dir / "islands" / island_name_for_index(i) / ".git").is_dir(), (
             f"island {i} has no checkpoint .git"
         )
 
@@ -318,20 +319,20 @@ def test_agent_manager_partitions_specs_in_start_all_setup(tmp_path):
     mgr = AgentManager(cfg)
 
     ids = sorted(s.agent_id for s in mgr.specs)
-    # 6 agents on 3 islands round-robin → 2 each
+    # 6 agents on 3 islands round-robin → 2 each, named <nickname>-from-<island>
     assert ids == [
-        "0-agent-1",
-        "0-agent-2",
-        "1-agent-1",
-        "1-agent-2",
-        "2-agent-1",
-        "2-agent-2",
+        "captain-ahab-from-avalon",
+        "captain-nemo-from-atlantis",
+        "davy-jones-from-atlantis",
+        "jack-sparrow-from-lemuria",
+        "long-john-silver-from-avalon",
+        "sinbad-the-sailor-from-lemuria",
     ]
-    assert all(s.island_id in {"0", "1", "2"} for s in mgr.specs)
+    assert all(s.island_id in {"atlantis", "avalon", "lemuria"} for s in mgr.specs)
 
 
 def test_agent_manager_single_island_specs_unchanged(tmp_path):
-    """Single-island AgentManager keeps the flat agent-N ids."""
+    """Single-island AgentManager keeps flat (unprefixed) nickname ids."""
     repo = tmp_path / "myrepo"
     (repo / "src").mkdir(parents=True)
     data = _base_config_dict(repo)
@@ -342,5 +343,5 @@ def test_agent_manager_single_island_specs_unchanged(tmp_path):
 
     mgr = AgentManager(cfg)
 
-    assert [s.agent_id for s in mgr.specs] == ["agent-1", "agent-2"]
+    assert [s.agent_id for s in mgr.specs] == ["captain-nemo", "captain-ahab"]
     assert all(s.island_id is None for s in mgr.specs)


### PR DESCRIPTION
## Summary

Gives CORAL agents and islands evocative, ocean-themed names (fitting the project), introduces the agent's identity in `CORAL.md`, and adds a reusable multi-island preset.

### Naming
- **Agents** draw from a curated pool of sea captains, explorers, and deep-sea deities (`captain-nemo`, `poseidon`, ...). Past the pool, names compose as `<ocean-adjective>-<sea-creature>` (`azure-marlin`) — 632 unique names before any suffix, then lowercase **Roman-numeral** laps (`-ii`, `-iii`), so it scales to arbitrary agent counts and stays digit-free.
- **Islands** get real names too (`atlantis`, `avalon`, ...). The `.coral/islands/<name>/` dirs and `island_id` are the isle name, not an index. Multi-island agents read as `<nickname>-from-<island>` (e.g. `captain-ahab-from-avalon`), carrying birth-island provenance in the id.
- Assignment is **deterministic by index**, so resumed runs reconstruct identical identities and git branches.

### Identity in CORAL.md
- The agent's name is introduced in the **Constitution** ("You are `captain-ahab-from-avalon`"), while the handle plumbing (branch, role file, `creator:`, `coral log --agent`) lives in **How This Works**. Previously the multi-agent guide *used* the name without ever introducing it. The single-agent template gets the same intro.

### Multi-island preset
- New built-in `multi-island` preset — a topology bundle (agent fleet + islands + migration + grader setup) that leaves `run.session` unset so it composes with local or docker tasks.
- `examples/kernel_builder` migrated to `preset: multi-island`, keeping only task-specific overrides.

## Why it's low-risk
`island_id` was already an opaque string everywhere (dir name, routing, metadata), so naming it required no changes beyond the generator and the `-from-` lineage parser in `coral.hub._island`. The only special-casing that existed — a numeric island-prefix heuristic — had no live callers.

## Testing
- `uv run pytest tests/` — full suite green (548 passed, 1 skipped).
- Scale-checked uniqueness/safety at 5000 agents / 1000 islands (no collisions, all git-branch/filesystem safe).
- `coral validate examples/kernel_builder` passes; merged config resolves to islands=2, the agent fleet, and the task's docker/local session override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)