### PR TITLE
fix(cli): preserve run.session=local through resume

### DIFF
--- a/coral/cli/__init__.py
+++ b/coral/cli/__init__.py
@@ -181,6 +181,16 @@ Run 'coral <command> --help' for details on any command."""
         formatter_class=_CommandHelpFormatter,
     )
     p_start.add_argument("--config", "-c", required=True, help="Path to task config YAML")
+    # Internal: the tmux/docker wrapper sets this so the inner (run.session=local)
+    # process knows which session mode to restore into the saved config. Not for
+    # direct use — inferring from in_tmux()/in_docker() would misfire when a user
+    # runs run.session=local from their own tmux session or container.
+    p_start.add_argument(
+        "--wrapped-session",
+        dest="wrapped_session",
+        choices=["tmux", "docker"],
+        help=argparse.SUPPRESS,
+    )
     p_start.add_argument(
         "overrides",
         nargs="*",

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -91,6 +91,9 @@ def _build_coral_command(args: argparse.Namespace) -> list[str]:
     """Reconstruct the coral start command with run.session=local added."""
     cmd = [_resolved_python(), "-m", "coral.cli", "start"]
     cmd.extend(["--config", str(Path(args.config).resolve())])
+    # Tell the inner process it was launched by the tmux wrapper so it restores
+    # run.session=tmux in the saved config (see cmd_start's restore block).
+    cmd.extend(["--wrapped-session", "tmux"])
     # Forward user overrides, then force local (inner process is already in tmux)
     cmd.extend(getattr(args, "overrides", []))
     cmd.append("run.session=local")
@@ -329,6 +332,9 @@ def _start_in_docker(args: argparse.Namespace, config: CoralConfig) -> None:
             "start",
             "--config",
             f"/coral-setup/task/{config_path.name}",
+            # Restore run.session=docker in the saved config (see cmd_start).
+            "--wrapped-session",
+            "docker",
             "workspace.run_dir=/app/run",
             "workspace.repo_path=/repo",
             "run.session=local",
@@ -443,13 +449,15 @@ def cmd_start(args: argparse.Namespace) -> None:
             file=sys.stderr,
         )
 
-    # Inner process: run.session=local was set to avoid recursion.
-    # Restore the original session mode so the saved config preserves user intent
-    # (otherwise `coral resume` won't re-launch in the same wrapper).
-    if in_tmux():
-        config.run.session = "tmux"
-    elif in_docker():
-        config.run.session = "docker"
+    # Inner process: the tmux/docker wrapper appended run.session=local to avoid
+    # recursion and passed --wrapped-session so we can restore the real mode in
+    # the saved config (otherwise `coral resume` won't re-launch in the same
+    # wrapper). We rely on that explicit marker rather than in_tmux()/in_docker():
+    # a user running run.session=local from their own tmux session or container
+    # genuinely wants local, and must not have it rewritten to tmux/docker.
+    wrapped_session = getattr(args, "wrapped_session", None)
+    if wrapped_session:
+        config.run.session = wrapped_session
 
     # Mandatory in the Docker session: the agent always runs isolated.
     _enforce_docker_isolation(config)

--- a/tests/test_start_session_mode.py
+++ b/tests/test_start_session_mode.py
@@ -1,0 +1,127 @@
+"""`coral start` must persist the session mode the user actually asked for.
+
+The tmux/docker wrappers relaunch an inner process with ``run.session=local``
+(to avoid recursion) and pass ``--wrapped-session`` so the inner process can
+restore the real mode into the saved config. That restore must key on the
+explicit marker — NOT ``in_tmux()``/``in_docker()`` — otherwise a user who runs
+``run.session=local`` from their own tmux session or container silently gets
+``tmux``/``docker`` persisted, and ``coral resume`` re-launches in the wrong
+wrapper.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import coral.cli.start as start_mod
+from coral.config import CoralConfig
+
+
+def _drive_cmd_start(monkeypatch, tmp_path, *, session, wrapped_session, in_tmux, in_docker):
+    """Run cmd_start through the real restore path, returning the config the
+    manager was constructed with."""
+    base = CoralConfig()
+    base.task.name = "t"
+    base.task.description = "t"
+    base.run.session = session
+
+    monkeypatch.setattr(start_mod.CoralConfig, "from_yaml", classmethod(lambda cls, path: base))
+    monkeypatch.setattr(start_mod, "in_tmux", lambda: in_tmux)
+    monkeypatch.setattr(start_mod, "in_docker", lambda: in_docker)
+    monkeypatch.setattr(start_mod, "has_tmux", lambda: True)
+    monkeypatch.setattr("coral.cli.validation.validate_task", lambda task_dir: [])
+
+    captured = {}
+
+    class FakeManager:
+        def __init__(self, config, verbose=False, config_dir=None):
+            captured["config"] = config
+            self.specs = []
+            self.paths = SimpleNamespace(run_dir=tmp_path, coral_dir=tmp_path / ".coral")
+
+        def start_all(self):
+            return []
+
+        def monitor_loop(self):
+            pass
+
+        def wait_for_completion(self):
+            pass
+
+    monkeypatch.setattr("coral.agent.manager.AgentManager", FakeManager)
+
+    args = SimpleNamespace(
+        config=str(tmp_path / "task.yaml"),
+        overrides=[],
+        wrapped_session=wrapped_session,
+    )
+    start_mod.cmd_start(args)
+    return captured["config"]
+
+
+def test_local_from_users_own_tmux_stays_local(monkeypatch, tmp_path):
+    """The reported bug: run.session=local launched from inside the user's own
+    tmux (no wrapper) must NOT be rewritten to tmux."""
+    config = _drive_cmd_start(
+        monkeypatch,
+        tmp_path,
+        session="local",
+        wrapped_session=None,
+        in_tmux=True,
+        in_docker=False,
+    )
+    assert config.run.session == "local"
+
+
+def test_tmux_wrapper_restores_tmux(monkeypatch, tmp_path):
+    """The inner process launched by the tmux wrapper (session=local +
+    --wrapped-session tmux) restores tmux so resume re-launches in tmux."""
+    config = _drive_cmd_start(
+        monkeypatch,
+        tmp_path,
+        session="local",
+        wrapped_session="tmux",
+        in_tmux=True,
+        in_docker=False,
+    )
+    assert config.run.session == "tmux"
+
+
+def test_docker_wrapper_restores_docker(monkeypatch, tmp_path):
+    config = _drive_cmd_start(
+        monkeypatch,
+        tmp_path,
+        session="local",
+        wrapped_session="docker",
+        in_tmux=False,
+        in_docker=True,
+    )
+    assert config.run.session == "docker"
+
+
+def test_plain_local_stays_local(monkeypatch, tmp_path):
+    config = _drive_cmd_start(
+        monkeypatch,
+        tmp_path,
+        session="local",
+        wrapped_session=None,
+        in_tmux=False,
+        in_docker=False,
+    )
+    assert config.run.session == "local"
+
+
+@pytest.mark.parametrize("mode", ["tmux", "docker"])
+def test_wrappers_pass_wrapped_session_flag(mode):
+    """The wrappers must actually emit --wrapped-session <mode> so the inner
+    process can restore it. Guards against a wrapper dropping the marker."""
+    import inspect
+
+    if mode == "tmux":
+        src = inspect.getsource(start_mod._build_coral_command)
+    else:
+        src = inspect.getsource(start_mod._start_in_docker)
+    assert "--wrapped-session" in src
+    assert f'"{mode}"' in src


### PR DESCRIPTION
## Problem

A run started with `run.session=local` could be silently persisted as `tmux`, causing `coral resume` to re-launch it in a tmux session.

## Root cause

The tmux/docker wrappers relaunch an inner `coral start` with `run.session=local` (to avoid recursion). The inner process then "restores" the real session mode into the saved config so `coral resume` re-launches in the same wrapper. That restore keyed on `in_tmux()`/`in_docker()`:

```python
if in_tmux():
    config.run.session = "tmux"
```

But `in_tmux()` is also true when a user runs `coral start ... run.session=local` from **their own** tmux session — no coral wrapper is involved, yet their intended `local` got rewritten to `tmux` and written to `config.yaml`. On resume, `coral resume` reads `tmux` and launches a tmux session.

## Fix

The wrappers now pass an explicit `--wrapped-session {tmux,docker}` marker to the inner process via argv (env vars don't reliably propagate into tmux panes when a server already exists), and the restore keys on that marker instead of environment inference:

```python
wrapped_session = getattr(args, "wrapped_session", None)
if wrapped_session:
    config.run.session = wrapped_session
```

The restore now fires only when coral itself created the wrapper. A user's explicit `local` is preserved. This also hardens the docker path (running `local` inside a generic non-coral container no longer gets rewritten to `docker`).

## Changes

- `coral/cli/__init__.py` — hidden `--wrapped-session` flag on the `start` subcommand
- `coral/cli/start.py` — `_build_coral_command` (tmux) and `_start_in_docker` emit the flag; restore block keys on it
- `tests/test_start_session_mode.py` — regression tests for the reported bug plus wrapper-restore and plain-local cases

## Testing

- `uv run pytest tests/` → 554 passed, 1 skipped
- `uv run ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)