### PR TITLE
feat(status): record latest attempt alongside best/worst

### DIFF
--- a/coral/hub/attempts.py
+++ b/coral/hub/attempts.py
@@ -446,6 +446,8 @@ def format_status_summary(
         best = max(scored, key=lambda a: a.score or 0.0) if scored else None
         worst = min(scored, key=lambda a: a.score or 0.0) if scored else None
 
+    latest = max(scored, key=lambda a: a.timestamp) if scored else None
+
     # Per-agent stats
     agents: dict[str, list[Attempt]] = {}
     for a in attempts:
@@ -461,6 +463,10 @@ def format_status_summary(
         )
     if worst and best and worst.commit_hash != best.commit_hash:
         lines.append(f"Worst: {worst.score:.10f}  ({worst.title[:50]})")
+    if latest and (not best or latest.commit_hash != best.commit_hash):
+        lines.append(
+            f"Latest: {latest.score:.10f}  ({latest.title[:50]})  @ {_format_time(latest.timestamp)}"
+        )
 
     if scored:
         first_time = min(a.timestamp for a in attempts)

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from coral.hub.attempts import (
     format_leaderboard,
+    format_status_summary,
     get_agent_attempts,
     get_leaderboard,
     per_agent_class_counts,
@@ -26,7 +27,11 @@ from coral.types import Attempt
 
 
 def _make_attempt(
-    commit: str, agent: str = "agent-1", score: float = 0.5, title: str = "test"
+    commit: str,
+    agent: str = "agent-1",
+    score: float = 0.5,
+    title: str = "test",
+    timestamp: str = "2026-03-11T10:00:00Z",
 ) -> Attempt:
     return Attempt(
         commit_hash=commit,
@@ -35,8 +40,42 @@ def _make_attempt(
         score=score,
         status="improved",
         parent_hash=None,
-        timestamp="2026-03-11T10:00:00Z",
+        timestamp=timestamp,
     )
+
+
+def test_status_summary_records_latest():
+    with tempfile.TemporaryDirectory() as d:
+        write_attempt(
+            d, _make_attempt("aaa", score=0.5, title="first", timestamp="2026-03-11T10:00:00")
+        )
+        write_attempt(
+            d, _make_attempt("bbb", score=0.9, title="best one", timestamp="2026-03-11T11:00:00")
+        )
+        write_attempt(
+            d, _make_attempt("ccc", score=0.3, title="latest one", timestamp="2026-03-11T12:00:00")
+        )
+
+        summary = format_status_summary(d)
+        assert "Best:  0.9000000000  (best one)" in summary
+        # Latest is the most recent by time, distinct from best -> shown on its own line.
+        assert "Latest: 0.3000000000  (latest one)" in summary
+
+
+def test_status_summary_hides_latest_when_it_is_best():
+    with tempfile.TemporaryDirectory() as d:
+        write_attempt(
+            d, _make_attempt("aaa", score=0.5, title="first", timestamp="2026-03-11T10:00:00")
+        )
+        write_attempt(
+            d, _make_attempt("bbb", score=0.9, title="best latest", timestamp="2026-03-11T11:00:00")
+        )
+
+        summary = format_status_summary(d)
+        # Newest attempt is also the best -> no redundant "Latest: <score>" line.
+        # (The unrelated "First attempt | Latest: <time>" line is expected, so match
+        # on the score-bearing prefix, not the bare word "Latest:".)
+        assert not any(line.startswith("Latest: ") for line in summary.splitlines())
 
 
 def test_attempts_crud():


### PR DESCRIPTION
## What

`coral status` summary reported the **Best** and **Worst** scored attempts, but the latest attempt was only reflected as a bare timestamp on the `First attempt | Latest: <time>` line — you couldn't see its score or title at a glance.

This adds a **Latest** line showing the most recent scored attempt's score, title, and time:

```
Best:  0.9000000000  (best one)  @ 07-01 11:00:00
Worst: 0.3000000000  (worst one)
Latest: 0.3000000000  (latest one)  @ 07-01 12:00:00
First attempt: 07-01 10:00:00  |  Latest: 07-01 12:00:00
```

## Details

- `latest` = the most recent **scored** attempt (by timestamp).
- The line is **suppressed when the latest attempt is also the best** (same commit), mirroring how the `Worst` line is hidden when it equals `Best` — avoids a redundant duplicate.
- Respects `direction` (maximize/minimize) implicitly, since Latest is time-based and independent of score direction.

## Tests

Added two regression tests in `tests/test_hub.py`:
- `test_status_summary_records_latest` — Latest ≠ Best → its own line appears.
- `test_status_summary_hides_latest_when_it_is_best` — newest == best → no redundant `Latest: <score>` line.

`uv run pytest tests/test_hub.py` → 15 passed; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)