### PR TITLE
feat(migration): standard bystander-resync phase with pluggable ops

### DIFF
--- a/coral/_version.py
+++ b/coral/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '0.7.3.dev4+gfb0a612b3.d20260701'
-__version_tuple__ = version_tuple = (0, 7, 3, 'dev4', 'gfb0a612b3.d20260701')
+__version__ = version = '0.7.5.dev4+g343f3e9ea'
+__version_tuple__ = version_tuple = (0, 7, 5, 'dev4', 'g343f3e9ea')
 
 __commit_id__ = commit_id = None

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -14,6 +14,7 @@ import subprocess
 import threading
 import time
 from collections import deque
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,7 @@ from coral.agent.heartbeat import HeartbeatRunner
 from coral.agent.migration import (
     IslandRoster,
     MigrationCandidate,
+    MigrationResyncOp,
     MigrationRunner,
     choose_roster_balanced_subset,
 )
@@ -789,8 +791,15 @@ class AgentManager:
         idx: int,
         prompt: str,
         prompt_source: str | None = None,
+        pre_restart_ops: Sequence[Callable[[str], None]] = (),
     ) -> AgentHandle:
-        """Interrupt a running agent and resume with a feedback prompt."""
+        """Interrupt a running agent and resume with a feedback prompt.
+
+        ``pre_restart_ops`` run (with the agent id) in the quiet window
+        after the interrupt and before the restart — the slot for surgery
+        that needs the agent's process down, e.g. migration resync ops
+        rewriting launch-injected state.
+        """
         handle = self.handles[idx]
         agent_id = handle.agent_id
 
@@ -799,6 +808,8 @@ class AgentManager:
         # via the owning runtime after interrupt() returns.
         handle.interrupt()
         session_id = self._runtime_for(agent_id).extract_session_id(handle.log_path)
+        for op in pre_restart_ops:
+            op(agent_id)
         self._restart_counts[agent_id] = self._restart_counts.get(agent_id, 0) + 1
 
         if session_id:
@@ -1880,17 +1891,77 @@ class AgentManager:
                 )
             return False
 
+        applied: list[MigrationCandidate] = []
+        ok = True
         for candidate in migrations:
             try:
                 self._apply_migration(candidate, assume_preflight=True)
+                applied.append(candidate)
             except Exception as e:
                 logger.exception(
                     f"Migration {candidate.agent_id} {candidate.src_island}→"
                     f"{candidate.dst_island} failed: {e}"
                 )
-                return False
-        self._deferred_candidates = []
-        return True
+                ok = False
+                break
+        # Even a partially-applied batch changed the partition — resync
+        # bystanders for whatever actually moved.
+        self._resync_bystanders_after_migration(applied)
+        if ok:
+            self._deferred_candidates = []
+        return ok
+
+    def _migration_resync_ops(self) -> list[MigrationResyncOp]:
+        """Registry of resync ops for the standard bystander-resync phase.
+
+        Each op names a piece of launch-injected per-agent state that can
+        only follow an island-partition change through a restart; an op
+        contributes a ``prepare`` hook only for work the restart pipeline
+        (``_setup_and_start_agent``) does not already cover. No applicable
+        ops → the phase is a no-op.
+        """
+        ops: list[MigrationResyncOp] = []
+        if self._sandbox is not None:
+            # Sandbox read boundaries are baked into per-agent settings at
+            # launch; the restart regenerates them via prepare_agent, so no
+            # prepare hook is needed.
+            ops.append(MigrationResyncOp(name="sandbox"))
+        return ops
+
+    def _resync_bystanders_after_migration(self, applied: list[MigrationCandidate]) -> None:
+        """Standard post-migration phase: restart live bystanders on the
+        affected islands so launch-injected per-agent state follows the new
+        partition.
+
+        What needs resyncing is defined by :meth:`_migration_resync_ops` —
+        with no applicable ops (e.g. sandboxing disabled) this is a no-op.
+        Migrants are excluded (:meth:`_apply_migration` already restarted
+        them with fresh state); dead and paused agents pick everything up
+        on their own (re)start path. Sessions are resumed, so no work is
+        lost. Disable via ``islands.migration.resync_bystanders``.
+        """
+        ops = self._migration_resync_ops()
+        if not applied or not ops or not self.migration_config.resync_bystanders:
+            return
+        affected = {c.src_island for c in applied} | {c.dst_island for c in applied}
+        migrated = {c.agent_id for c in applied}
+        op_names = ", ".join(op.name for op in ops)
+        pre_restart_ops = [op.prepare for op in ops if op.prepare is not None]
+        for idx, handle in enumerate(self.handles):
+            agent_id = handle.agent_id
+            if agent_id in migrated or not handle.alive or self._is_paused(agent_id):
+                continue
+            if self._agent_island.get(agent_id) in affected:
+                logger.info(
+                    f"Migration resync ({op_names}): restarting {agent_id} "
+                    f"(island partition changed)"
+                )
+                self.handles[idx] = self._interrupt_and_resume(
+                    idx,
+                    prompt=_build_resync_prompt(op_names),
+                    prompt_source="migration:resync",
+                    pre_restart_ops=pre_restart_ops,
+                )
 
     def _migration_block_reason(self, candidate: MigrationCandidate) -> str | None:
         """Return why ``candidate`` cannot safely migrate right now, if any."""
@@ -2954,4 +3025,14 @@ def _build_migration_prompt(candidate: MigrationCandidate, *, shared_dir: str) -
         f"here so you don't reinvent it.\n\n"
         f"Then bring your strongest ideas from your previous run and "
         f"adapt them to this island's frontier."
+    )
+
+
+def _build_resync_prompt(op_names: str) -> str:
+    """Prompt for bystanders restarted by the post-migration resync phase."""
+    return (
+        "An agent migrated between islands, so your process was restarted "
+        f"to refresh launch-injected state ({op_names}) against the new "
+        "island roster. Your session and work are intact — continue exactly "
+        "where you left off."
     )

--- a/coral/agent/migration.py
+++ b/coral/agent/migration.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import logging
 import random
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
@@ -66,6 +66,25 @@ class MigrationCandidate:
     src_island: str
     dst_island: str
     score: float
+
+
+@dataclass(frozen=True)
+class MigrationResyncOp:
+    """One piece of launch-injected per-agent state that must be rebuilt
+    when the island partition changes.
+
+    Bystander resync is a standard post-migration phase: agents on the
+    affected islands are interrupt+restarted, and the restart pipeline
+    itself rebuilds everything ``_setup_and_start_agent`` covers (sandbox
+    spec, permission settings, symlinks). ``prepare`` is the hook for work
+    outside that pipeline — it runs per agent in the quiet window between
+    the interrupt and the restart. The phase is a no-op when no ops apply;
+    see :meth:`coral.agent.manager.AgentManager._migration_resync_ops` for
+    the registry.
+    """
+
+    name: str
+    prepare: Callable[[str], None] | None = None
 
 
 @dataclass(frozen=True)

--- a/coral/config.py
+++ b/coral/config.py
@@ -375,6 +375,13 @@ class MigrationConfig:
     dest_weighting: str = "score"  # score | uniform | round_robin
     max_per_cycle: int = 2
     notify_island: bool = True
+    # Standard post-migration phase: interrupt+resume live bystanders on the
+    # affected islands so launch-injected per-agent state follows the new
+    # partition immediately instead of at their next natural restart (see
+    # AgentManager._migration_resync_ops for the op registry). Sessions are
+    # resumed, so no work is lost. A no-op when no resync ops apply — today
+    # the only op is the agents.sandbox boundary refresh.
+    resync_bystanders: bool = True
 
     def __post_init__(self) -> None:
         if self.every < 1:

--- a/coral/sandbox/srt.py
+++ b/coral/sandbox/srt.py
@@ -473,7 +473,8 @@ class AllowAllProxy:
 
     def _serve(self) -> None:
         listener = self._listener
-        assert listener is not None
+        if listener is None:
+            return
         while not self._stopping.is_set():
             try:
                 conn, _addr = listener.accept()

--- a/coral/sandbox/srt.py
+++ b/coral/sandbox/srt.py
@@ -455,6 +455,13 @@ class AllowAllProxy:
     def stop(self) -> None:
         self._stopping.set()
         if self._listener is not None:
+            # shutdown() before close(): on Linux, close() alone does not wake
+            # a thread blocked in accept(), which keeps the kernel socket in
+            # LISTEN state and still accepting connections.
+            try:
+                self._listener.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
             try:
                 self._listener.close()
             except OSError:
@@ -465,10 +472,11 @@ class AllowAllProxy:
             self._thread = None
 
     def _serve(self) -> None:
-        assert self._listener is not None
+        listener = self._listener
+        assert listener is not None
         while not self._stopping.is_set():
             try:
-                conn, _addr = self._listener.accept()
+                conn, _addr = listener.accept()
             except OSError:
                 break  # listener closed by stop()
             threading.Thread(target=self._handle, args=(conn,), daemon=True).start()

--- a/coral/sandbox/srt.py
+++ b/coral/sandbox/srt.py
@@ -448,9 +448,7 @@ class AllowAllProxy:
         listener.listen(128)
         self._listener = listener
         self.port = listener.getsockname()[1]
-        self._thread = threading.Thread(
-            target=self._serve, name="coral-sandbox-proxy", daemon=True
-        )
+        self._thread = threading.Thread(target=self._serve, name="coral-sandbox-proxy", daemon=True)
         self._thread.start()
         return self.port
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1617,3 +1617,121 @@ def test_maybe_run_migration_cycle_does_not_mix_blocked_deferred_with_fresh(tmp_
 
     assert applied == []
     assert [(c.agent_id, r) for c, r in mgr._deferred_candidates] == [("0-agent-1", "paused")]
+
+
+# ---------------------------------------------------------------------------
+# Bystander resync after migration (islands.migration.resync_bystanders)
+# ---------------------------------------------------------------------------
+
+
+def _resync_manager():
+    """Manager with three islands and one live agent in every role the
+    resync phase distinguishes: the migrant, live mates on the src/dst
+    islands, an outsider, and a dead + a paused mate on src."""
+    from coral.agent.manager import AgentManager
+    from coral.agent.runtime import AgentHandle
+    from coral.config import AgentAssignmentConfig, AgentConfig, CoralConfig
+
+    cfg = CoralConfig(
+        agents=AgentConfig(assignments=[AgentAssignmentConfig(count=6)]),
+        islands=IslandsConfig(count=3),
+    )
+    mgr = AgentManager(cfg)
+
+    class _AliveProc:
+        def poll(self):
+            return None
+
+    def _handle(agent_id: str, *, alive: bool = True) -> AgentHandle:
+        return AgentHandle(
+            agent_id=agent_id,
+            process=_AliveProc() if alive else None,
+            worktree_path=Path("/x"),
+            log_path=Path("/x.log"),
+        )
+
+    mgr._agent_island = {
+        "migrant": "1",  # _apply_migration already moved + restarted it
+        "src-mate": "0",
+        "dst-mate": "1",
+        "outsider": "2",
+        "dead-mate": "0",
+        "paused-mate": "0",
+    }
+    mgr.handles = [
+        _handle("migrant"),
+        _handle("src-mate"),
+        _handle("dst-mate"),
+        _handle("outsider"),
+        _handle("dead-mate", alive=False),
+        _handle("paused-mate"),
+    ]
+    mgr._paused_until = {"paused-mate": 1e18}
+    return mgr
+
+
+def _resync_batch():
+    return [MigrationCandidate(agent_id="migrant", src_island="0", dst_island="1", score=1.0)]
+
+
+def test_resync_bystanders_restarts_affected_live_agents():
+    """With an applicable op (sandbox active), live agents on the src/dst
+    islands restart so launch-injected state follows the new partition;
+    the migrant (already restarted), dead/paused agents, and unaffected
+    islands are left alone."""
+    mgr = _resync_manager()
+    mgr._sandbox = object()  # sandbox provider active -> one resync op
+
+    restarted: list[str] = []
+
+    def _fake_interrupt_and_resume(idx, prompt, prompt_source=None, pre_restart_ops=()):
+        assert prompt_source == "migration:resync"
+        assert "sandbox" in prompt
+        restarted.append(mgr.handles[idx].agent_id)
+        return mgr.handles[idx]
+
+    mgr._interrupt_and_resume = _fake_interrupt_and_resume  # type: ignore[assignment]
+
+    mgr._resync_bystanders_after_migration(_resync_batch())
+    assert restarted == ["src-mate", "dst-mate"]
+
+    # Flag off or empty batch -> no restarts.
+    restarted.clear()
+    mgr.migration_config.resync_bystanders = False
+    mgr._resync_bystanders_after_migration(_resync_batch())
+    mgr.migration_config.resync_bystanders = True
+    mgr._resync_bystanders_after_migration([])
+    assert restarted == []
+
+
+def test_resync_bystanders_noop_without_ops():
+    """No applicable resync ops (no sandbox) -> the phase is a no-op."""
+    mgr = _resync_manager()
+    assert mgr._sandbox is None
+    assert mgr._migration_resync_ops() == []
+
+    mgr._interrupt_and_resume = pytest.fail  # type: ignore[assignment]
+    mgr._resync_bystanders_after_migration(_resync_batch())
+
+
+def test_resync_bystanders_forwards_op_prepare_hooks():
+    """An op's prepare hook rides into _interrupt_and_resume's quiet window
+    (after interrupt, before restart)."""
+    from coral.agent.migration import MigrationResyncOp
+
+    mgr = _resync_manager()
+    prepared: list[str] = []
+    mgr._migration_resync_ops = lambda: [  # type: ignore[assignment]
+        MigrationResyncOp(name="custom", prepare=prepared.append)
+    ]
+
+    def _fake_interrupt_and_resume(idx, prompt, prompt_source=None, pre_restart_ops=()):
+        agent_id = mgr.handles[idx].agent_id
+        for op in pre_restart_ops:
+            op(agent_id)  # what the real helper does in the quiet window
+        return mgr.handles[idx]
+
+    mgr._interrupt_and_resume = _fake_interrupt_and_resume  # type: ignore[assignment]
+
+    mgr._resync_bystanders_after_migration(_resync_batch())
+    assert prepared == ["src-mate", "dst-mate"]


### PR DESCRIPTION
## What

A standard post-migration phase, `islands.migration.resync_bystanders` (default on): after a migration batch lands, interrupt+resume live agents on the src/dst islands so **launch-injected per-agent state** follows the new partition immediately, instead of at their next natural restart.

What needs resyncing is pluggable — a registry of `MigrationResyncOp`s (`AgentManager._migration_resync_ops`). **No applicable ops → the phase is a no-op** (no restarts). Today the only op is the `agents.sandbox` boundary refresh.

## Why

Some per-agent state is injected at process launch and has no hot-reload channel. Sandbox settings (srt) are the motivating case — after a migration:

- the migrant's **old** island-mates still hold a read grant on its worktree → cross-island leak going forward
- its **new** island-mates lack the grant → can't read their new teammate

The migrant itself already restarts with fresh settings inside `_apply_migration`; this closes the gap for bystanders — and gives future launch-injected state (gateway keys, permission settings, ...) a standard place to hook in.

## How

- `MigrationResyncOp(name, prepare)` in `coral/agent/migration.py` — `prepare(agent_id)` is optional, for work the restart pipeline doesn't already cover
- `_interrupt_and_resume` gains a `pre_restart_ops` slot: hooks run in the quiet window after the interrupt, before the restart
- `_apply_migration_batch` tracks what actually applied (a partially-applied batch still changed the partition) and runs the phase
- Resync targets only live, unpaused agents on affected islands, excluding the migrants — the same session-preserving path heartbeats use, so no work is lost
- `MigrationConfig.resync_bystanders: bool = True` as the phase switch

## Testing

Three focused tests: role coverage (migrant / src-mate / dst-mate / outsider / dead / paused + off-switches), no-op without applicable ops, and prepare-hook forwarding into the quiet window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
