### PR TITLE
feat(resume): archive attempts discarded by resume --from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ coral start -c task.yaml run.stop.max_real_attempts=30          # Stop after 30 
 coral start -c task.yaml run.session=local                      # No tmux session
 coral resume                                      # Resume latest run (sessions restored)
 coral resume -i "Try greedy approaches"           # Inject an instruction at resume
-coral resume --from <hash> -i "Continue this fork" # Reset an agent to an attempt, then inject instruction
+coral resume --from <hash> -i "Continue this fork" # Reset an agent to an attempt (later attempts are archived = soft-deleted), then inject instruction
 coral stop [--all]                                # Stop one or all active runs
 coral status                                      # Agent health + leaderboard
 

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -49,6 +49,7 @@ from coral.config import CoralConfig
 from coral.hub._island import island_root
 from coral.hub.attempts import (
     agent_in_grader_queue,
+    archive_attempts,
     get_leaderboard,
     read_attempts,
     read_eval_count,
@@ -812,6 +813,28 @@ class AgentManager:
             if action.id:
                 applied_actions.add(action.id)
 
+        # Reset matched worktrees before any agent starts, archiving the
+        # attempts on the discarded segments first (soft delete: the run has
+        # explicitly rewound past them, so leaderboard/status/log must stop
+        # showing them). The JSONs and git objects stay on disk.
+        for agent_dir in agent_dirs:
+            action = steering_by_agent.get(agent_dir.name)
+            if action is None:
+                continue
+            discarded = _discarded_commit_hashes(agent_dir, action.hash)
+            _reset_worktree_to_commit(agent_dir, action.hash)
+            if discarded:
+                archived = archive_attempts(
+                    paths.coral_dir,
+                    discarded,
+                    reason=f"discarded by resume --from {action.hash}",
+                )
+                if archived:
+                    logger.info(
+                        f"Archived {len(archived)} attempt(s) discarded by "
+                        f"resume --from {action.hash} ({agent_dir.name})"
+                    )
+
         handles = []
         for agent_dir in agent_dirs:
             agent_id = agent_dir.name
@@ -849,7 +872,6 @@ class AgentManager:
                 prompt = fresh_start_prompt
 
             if steering_action is not None:
-                _reset_worktree_to_commit(agent_dir, steering_action.hash)
                 prompt = _compose_resume_instruction(
                     base_prompt=prompt,
                     action=steering_action,
@@ -2762,6 +2784,19 @@ def _reset_worktree_to_commit(worktree_path: Path, target_hash: str) -> None:
     )
     if result.returncode != 0:
         raise RuntimeError(f"Steering checkout failed for '{target_hash}': {result.stderr}")
+
+
+def _discarded_commit_hashes(worktree_path: Path, target_hash: str) -> set[str]:
+    """Commits that a reset to target_hash drops from this worktree's HEAD."""
+    result = subprocess.run(
+        ["git", "rev-list", f"{target_hash}..HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=worktree_path,
+    )
+    if result.returncode != 0:
+        return set()
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
 
 
 def _worktree_head_descends_from(worktree_path: Path, target_hash: str) -> bool:

--- a/coral/cli/query.py
+++ b/coral/cli/query.py
@@ -153,6 +153,10 @@ def cmd_show(args: argparse.Namespace) -> None:
     from coral.types import get_budget_class
 
     print(f"Budget:  {get_budget_class(data.get('metadata'))}")
+    meta = data.get("metadata") or {}
+    if meta.get("archived") is True:
+        reason = meta.get("archive_reason")
+        print(f"Archived: yes ({reason})" if reason else "Archived: yes")
     print(f"Time:    {data['timestamp']}")
     if data.get("parent_hash"):
         print(f"Parent:  {data['parent_hash']}")

--- a/coral/grader/daemon.py
+++ b/coral/grader/daemon.py
@@ -553,7 +553,9 @@ def _find_pending(coral_dir: Path) -> list[Attempt]:
                 a = Attempt.from_dict(data)
             except Exception:
                 continue
-            if a.status == "pending" and a.score is None:
+            # Archived attempts are soft-deleted (e.g. discarded by
+            # `coral resume --from`) — never grade them.
+            if a.status == "pending" and a.score is None and not a.archived:
                 pending.append(a)
     pending.sort(key=lambda x: x.timestamp)
     return pending

--- a/coral/hub/__init__.py
+++ b/coral/hub/__init__.py
@@ -1,6 +1,7 @@
 """Hub — shared state management for CORAL agents."""
 
 from coral.hub.attempts import (
+    archive_attempts,
     format_leaderboard,
     get_agent_attempts,
     get_leaderboard,
@@ -13,6 +14,7 @@ from coral.hub.notes import list_notes, read_note
 from coral.hub.skills import get_skill_tree, list_skills, read_skill
 
 __all__ = [
+    "archive_attempts",
     "format_leaderboard",
     "get_agent_attempts",
     "get_leaderboard",

--- a/coral/hub/attempts.py
+++ b/coral/hub/attempts.py
@@ -18,18 +18,13 @@ def _attempts_dir(coral_dir: str | Path, island_id: str | int | None = None) -> 
     return d
 
 
-def write_attempt(
-    coral_dir: str | Path,
-    attempt: Attempt,
-    island_id: str | int | None = None,
-) -> Path:
-    """Write an attempt record to JSON atomically (tmp + rename).
+def _write_attempt_json(path: Path, attempt: Attempt) -> None:
+    """Write an attempt to `path` atomically (tmp + rename).
 
     Readers (monitor loop, grader daemon, `coral wait`) may poll these files
     concurrently with writes. Using tmp + rename guarantees readers see either
     the old complete file or the new complete file, never a partial write.
     """
-    path = _attempts_dir(coral_dir, island_id) / f"{attempt.commit_hash}.json"
     payload = json.dumps(attempt.to_dict(), indent=2)
     # Write to a temp file in the same directory (same filesystem -> atomic rename).
     fd, tmp_path = tempfile.mkstemp(
@@ -50,6 +45,16 @@ def write_attempt(
         except OSError:
             pass
         raise
+
+
+def write_attempt(
+    coral_dir: str | Path,
+    attempt: Attempt,
+    island_id: str | int | None = None,
+) -> Path:
+    """Write an attempt record to JSON atomically (tmp + rename)."""
+    path = _attempts_dir(coral_dir, island_id) / f"{attempt.commit_hash}.json"
+    _write_attempt_json(path, attempt)
     return path
 
 
@@ -90,25 +95,46 @@ def set_user_best(coral_dir: str | Path, commit_hash: str) -> Attempt | None:
                 attempt.metadata.pop("user_best", None)
             else:
                 continue
-            payload = json.dumps(attempt.to_dict(), indent=2)
-            fd, tmp_path = tempfile.mkstemp(
-                prefix=f".{attempt.commit_hash}.",
-                suffix=".json.tmp",
-                dir=path.parent,
-            )
-            try:
-                with os.fdopen(fd, "w") as f:
-                    f.write(payload)
-                    f.flush()
-                    os.fsync(f.fileno())
-                os.replace(tmp_path, path)
-            except Exception:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
-                raise
+            _write_attempt_json(path, attempt)
     return target
+
+
+def archive_attempts(
+    coral_dir: str | Path,
+    commit_hashes: set[str],
+    reason: str | None = None,
+) -> list[str]:
+    """Soft-delete attempts: every listing view stops showing them.
+
+    The JSON stays on disk (and `read_attempt` / `coral show` can still
+    resolve an explicit hash), but `read_attempts` and everything built on
+    it (leaderboard, status, recent, search) skip archived records
+    unconditionally. Scans every view root so multi-island runs archive the
+    record wherever it lives. Returns the commit hashes actually archived.
+    """
+    from coral.hub._island import all_view_roots
+
+    if not commit_hashes:
+        return []
+    archived: list[str] = []
+    for view_root in all_view_roots(coral_dir):
+        attempts_dir = view_root / "attempts"
+        if not attempts_dir.is_dir():
+            continue
+        for commit_hash in sorted(commit_hashes):
+            path = attempts_dir / f"{commit_hash}.json"
+            if not path.exists():
+                continue
+            try:
+                attempt = Attempt.from_dict(json.loads(path.read_text()))
+            except (json.JSONDecodeError, KeyError, OSError):
+                continue
+            attempt.metadata["archived"] = True
+            if reason:
+                attempt.metadata["archive_reason"] = reason
+            _write_attempt_json(path, attempt)
+            archived.append(commit_hash)
+    return archived
 
 
 def _global_eval_count_path(coral_dir: str | Path) -> Path:
@@ -171,7 +197,11 @@ def read_eval_count(coral_dir: str | Path, island_id: str | int | None = None) -
 
 
 def read_attempts(coral_dir: str | Path, island_id: str | int | None = None) -> list[Attempt]:
-    """Read all attempt records."""
+    """Read all attempt records.
+
+    Archived attempts (e.g. discarded by `coral resume --from`) are treated
+    as soft-deleted: they never appear here or in any view built on this.
+    """
     d = _attempts_dir(coral_dir, island_id)
     attempts = []
     for f in sorted(d.glob("*.json")):
@@ -180,7 +210,7 @@ def read_attempts(coral_dir: str | Path, island_id: str | int | None = None) -> 
             attempts.append(Attempt.from_dict(data))
         except (json.JSONDecodeError, KeyError):
             continue
-    return attempts
+    return [a for a in attempts if not a.archived]
 
 
 def _read_all_island_attempts(coral_dir: str | Path) -> list[Attempt]:

--- a/coral/types.py
+++ b/coral/types.py
@@ -170,6 +170,11 @@ class Attempt:
         """Budget classification: 'real', 'grader_error', or 'tune'. Defaults to 'real'."""
         return get_budget_class(self.metadata)
 
+    @property
+    def archived(self) -> bool:
+        """True when hidden from listing views (e.g. discarded by `coral resume --from`)."""
+        return self.metadata.get("archived") is True
+
     def to_dict(self) -> dict[str, Any]:
         d = {
             "commit_hash": self.commit_hash,

--- a/tests/test_grader_daemon.py
+++ b/tests/test_grader_daemon.py
@@ -772,6 +772,33 @@ def test_find_pending_multi_island_scans_every_island(tmp_path):
     assert hashes == {"aaa000", "bbb111"}
 
 
+def test_find_pending_skips_archived(tmp_path):
+    """Archived (soft-deleted) pending attempts must never be graded."""
+    from coral.grader.daemon import _find_pending
+    from coral.hub.attempts import archive_attempts, write_attempt
+    from coral.types import Attempt
+
+    coral_dir = tmp_path / ".coral"
+
+    def _pending(commit: str) -> Attempt:
+        return Attempt(
+            commit_hash=commit,
+            agent_id="agent-1",
+            title="x",
+            score=None,
+            status="pending",
+            parent_hash=None,
+            timestamp="2026-05-31T10:00:00Z",
+        )
+
+    write_attempt(coral_dir, _pending("aaa000"))
+    write_attempt(coral_dir, _pending("bbb111"))
+    archive_attempts(coral_dir, {"bbb111"}, reason="discarded by resume --from aaa000")
+
+    pending = _find_pending(coral_dir)
+    assert {a.commit_hash for a in pending} == {"aaa000"}
+
+
 def test_grade_one_finalizes_migrated_pending_attempt_in_current_island(tmp_path, monkeypatch):
     """If migration moves a pending attempt mid-grade, finalize into its current island."""
     import coral.grader.daemon as daemon

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -4,11 +4,13 @@ import tempfile
 from pathlib import Path
 
 from coral.hub.attempts import (
+    archive_attempts,
     format_leaderboard,
     format_status_summary,
     get_agent_attempts,
     get_leaderboard,
     per_agent_class_counts,
+    read_attempt,
     read_attempts,
     search_attempts,
     write_attempt,
@@ -88,6 +90,35 @@ def test_attempts_crud():
 
         all_attempts = read_attempts(d)
         assert len(all_attempts) == 2
+
+
+def test_archive_attempts_soft_deletes_from_all_views():
+    with tempfile.TemporaryDirectory() as d:
+        write_attempt(d, _make_attempt("aaa111", score=0.5, title="kept"))
+        write_attempt(d, _make_attempt("bbb222", score=0.9, title="discarded"))
+
+        archived = archive_attempts(d, {"bbb222"}, reason="discarded by resume --from aaa111")
+
+        assert archived == ["bbb222"]
+        assert [a.commit_hash for a in read_attempts(d)] == ["aaa111"]
+        assert [a.commit_hash for a in get_leaderboard(d)] == ["aaa111"]
+        assert [a.commit_hash for a in get_agent_attempts(d, "agent-1")] == ["aaa111"]
+        assert search_attempts(d, "discarded") == []
+        assert "bbb222" not in format_status_summary(d)
+        # The record survives on disk and stays resolvable by explicit hash.
+        kept = read_attempt(d, "bbb222")
+        assert kept is not None
+        assert kept.archived
+        assert kept.metadata["archive_reason"] == "discarded by resume --from aaa111"
+
+
+def test_archive_attempts_ignores_unknown_and_empty():
+    with tempfile.TemporaryDirectory() as d:
+        write_attempt(d, _make_attempt("aaa111"))
+
+        assert archive_attempts(d, set()) == []
+        assert archive_attempts(d, {"nope"}) == []
+        assert [a.commit_hash for a in read_attempts(d)] == ["aaa111"]
 
 
 def test_leaderboard():

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 from coral.agent.manager import AgentManager
 from coral.config import CoralConfig
-from coral.hub.attempts import read_attempt, write_attempt
+from coral.hub.attempts import read_attempt, read_attempts, write_attempt
 from coral.hub.steering import (
     ContinueFromAction,
     MarkBestAction,
@@ -361,6 +361,59 @@ def test_resume_from_resets_real_worktree_head(tmp_path: Path, monkeypatch) -> N
     assert _git(agent_dir, "rev-parse", "HEAD") == target_hash
     assert (agent_dir / "solution.txt").read_text() == "target\n"
     assert prompts and f"## Continue from Attempt {target_hash}" in prompts[0]
+
+
+def test_resume_from_archives_attempts_after_target(tmp_path: Path, monkeypatch) -> None:
+    """Attempts on the discarded segment are soft-deleted from every view."""
+    coral_dir = tmp_path / ".coral"
+    agents_dir = tmp_path / "agents"
+    repo_dir = tmp_path / "repo"
+    agent_dir = agents_dir / "agent-1"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / ".coral_agent_id").write_text("agent-1")
+    repo_dir.mkdir()
+
+    _git(agent_dir, "init")
+    _git(agent_dir, "config", "user.email", "test@example.com")
+    _git(agent_dir, "config", "user.name", "Test User")
+    target_hash = _commit_file(agent_dir, "solution.txt", "target\n", "target attempt")
+    mid_hash = _commit_file(agent_dir, "solution.txt", "mid\n", "mid attempt")
+    latest_hash = _commit_file(agent_dir, "solution.txt", "latest\n", "latest attempt")
+
+    write_attempt(coral_dir, _attempt(target_hash, score=0.5))
+    write_attempt(coral_dir, _attempt(mid_hash, score=0.6))
+    write_attempt(coral_dir, _attempt(latest_hash, score=0.7))
+
+    paths = ProjectPaths(
+        results_dir=tmp_path,
+        task_dir=tmp_path,
+        run_dir=tmp_path,
+        coral_dir=coral_dir,
+        agents_dir=agents_dir,
+        repo_dir=repo_dir,
+    )
+    cfg = CoralConfig.from_dict(
+        {
+            "task": {"name": "t", "description": "d"},
+            "agents": {"count": 1, "runtime": "claude-code"},
+        }
+    )
+    manager = AgentManager(cfg)
+    _stub_manager_for_resume(manager, monkeypatch, {"agent-1": agent_dir})
+
+    manager.resume_all(paths, resume_from=target_hash)
+
+    # Only the target survives in listing views; the discarded segment is gone.
+    visible = {a.commit_hash for a in read_attempts(coral_dir)}
+    assert visible == {target_hash}
+    # The records themselves stay on disk, flagged archived with a reason.
+    for discarded_hash in (mid_hash, latest_hash):
+        record = read_attempt(coral_dir, discarded_hash)
+        assert record is not None
+        assert record.archived
+        assert record.metadata["archive_reason"] == f"discarded by resume --from {target_hash}"
+    target_record = read_attempt(coral_dir, target_hash)
+    assert target_record is not None and not target_record.archived
 
 
 def test_resume_from_resets_all_descendant_agent_worktrees(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

`coral resume --from <hash>` resets matched agent worktrees to the target attempt, but the attempts on the discarded segment stayed fully visible — `coral log`, `coral status`, the leaderboard, and every agent kept seeing (and building on) work the run had explicitly rewound past.

This PR archives them: a **soft delete** flagged in `metadata.archived`, applied before any resumed agent starts.

- **Hub** (`coral/hub/attempts.py`): new `archive_attempts()` marks records archived (+ `archive_reason`) with the same atomic tmp+rename write, scanning every view root so multi-island runs archive the record wherever it lives. `read_attempts` filters archived records unconditionally, so leaderboard / status / recent / search / per-agent counts / plateau detection / web UI all hide them through the one chokepoint. The duplicated in-place rewrite in `set_user_best` is factored into `_write_attempt_json`.
- **Manager** (`coral/agent/manager.py`): `resume_all` collects `git rev-list <from>..HEAD` per matched agent, resets the worktree, and archives the discarded hashes — all before any agent is spawned, so agents wake up to a clean leaderboard.
- **Daemon** (`coral/grader/daemon.py`): `_find_pending` skips archived pendings, so a discarded queued eval is never graded. Finalization already re-reads current attempt metadata before write-back, so an archive landing mid-grade survives.
- **CLI** (`coral/cli/query.py`): `coral show <hash>` still resolves an explicit hash and prints `Archived: yes (<reason>)`.

The attempt JSONs and git objects stay on disk — nothing is hard-deleted, and `coral checkout <hash>` / `coral show <hash>` still work for forensic use.

## Testing

- New tests: hub archive semantics (hidden from all listing views, resolvable by hash, unknown/empty hash no-ops), real-git-worktree `resume --from` archiving the discarded segment with reason, daemon `_find_pending` skipping archived pendings.
- `uv run pytest tests/` — 569 passed; the 2 failures in `test_start_session_mode.py` also fail on unmodified `main` in this environment (tmux-dependent) and are unrelated.
- `uv run ruff check .` and `ruff format --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)