### PR TITLE
feat(sandbox): pluggable per-agent sandboxing with srt provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Key concepts:
 | `coral/types.py` | Core types: `Task`, `Score`, `ScoreBundle`, `Attempt` |
 | `coral/config.py` | OmegaConf-backed YAML configuration (`CoralConfig`, `GraderConfig`, `AgentConfig`, `GatewayConfig`, `WarmStartConfig`, `HeartbeatActionConfig`, ...) |
 | `coral/agent/` | Agent lifecycle: `manager.py` (multi-agent supervisor), `runtime.py` (abstract), `state.py`, `heartbeat.py`, `exit_classifier.py`, `warmstart.py`, `process.py`, `registry.py` |
+| `coral/sandbox/` | Pluggable agent sandboxing (`agents.sandbox`): `protocol.py` (`SandboxProvider` + spec/context types), `registry.py` (name or `module:Class` entrypoint resolution), `srt.py` (built-in srt provider: OS-level FS/network enforcement + allow-all proxy) |
 | `coral/agent/builtin/` | Concrete runtimes: `claude_code`, `codex`, `cursor_agent`, `kiro`, `opencode` |
 | `coral/grader/` | Grader stack: `protocol.py`, `base.py`, `task_grader.py`, `loader.py`, `subprocess_grader.py`, `daemon.py` (long-running grader), `builtin/function_grader.py` |
 | `coral/hub/` | Shared state: `attempts.py`, `notes.py`, `skills.py`, `checkpoint.py` (git-tracked snapshots of `.coral/public/`), `heartbeat.py`, `prompts/` (built-in heartbeat prompts) |
@@ -110,6 +111,7 @@ coral start -c task.yaml                          # Launch agents (auto-tmux)
 coral start -c task.yaml agents.count=4 agents.model=opus       # Dotlist overrides
 coral start -c task.yaml run.verbose=true run.ui=true           # Verbose + dashboard
 coral start -c task.yaml run.stop.max_real_attempts=30          # Stop after 30 finalized real attempts
+coral start -c task.yaml agents.sandbox.enabled=true            # Wrap agents in srt OS-level sandbox (or `preset: sandbox`)
 coral start -c task.yaml run.session=local                      # No tmux session
 coral resume                                      # Resume latest run (sessions restored)
 coral resume -i "Try greedy approaches"           # Inject an instruction at resume

--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -15,7 +15,14 @@ from coral.agent.exit_classifier import (
     claude_code_log_has_session_error,
 )
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
+from coral.agent.runtime import (
+    AgentHandle,
+    apply_run_as_user,
+    apply_sandbox,
+    apply_sandbox_env,
+    write_coral_log_entry,
+)
+from coral.sandbox.protocol import AgentSandboxSpec
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -55,6 +62,30 @@ def _extract_claude_code_session_id(log_path: Path) -> str | None:
     except Exception as e:
         logger.debug(f"Failed to extract session_id from {log_path}: {e}")
     return None
+
+
+def _permission_args(
+    sandbox: AgentSandboxSpec | None, run_as_user: dict[str, Any] | None
+) -> list[str]:
+    """Permission flags for the `claude` CLI, keyed on OS-level containment.
+
+    Under OS-level containment — an srt sandbox spec, or user isolation
+    (which the Docker session forces) — the kernel already enforces every
+    boundary the permission system politely requests, so skip permission
+    checks entirely: `auto` mode would only add friction (a fringe tool not
+    in the allow-list gets denied with no human to approve it).
+
+    Otherwise grant autonomy via `auto`, which MUST be set on the CLI: in
+    headless `-p` mode Claude Code silently downgrades a project-level
+    `permissions.defaultMode: "auto"` (from .claude/settings.local.json or
+    settings.json) back to `default`, because a repo-checked-in settings
+    file isn't trusted to escalate to auto — only the user's own
+    ~/.claude/settings.json or this flag can. The allow/deny rules in
+    settings.local.json still apply on top.
+    """
+    if sandbox is not None or run_as_user is not None:
+        return ["--dangerously-skip-permissions"]
+    return ["--permission-mode", "auto"]
 
 
 class ClaudeCodeRuntime:
@@ -113,6 +144,7 @@ class ClaudeCodeRuntime:
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
         run_as_user: dict[str, Any] | None = None,
+        sandbox: AgentSandboxSpec | None = None,
     ) -> AgentHandle:
         """Start a Claude Code agent in the given worktree."""
         agent_id_file = worktree_path / ".coral_agent_id"
@@ -139,17 +171,7 @@ class ClaudeCodeRuntime:
             prompt,
             "--model",
             model,
-            # Grant the agent autonomy. `auto` MUST be set on the CLI: in
-            # headless `-p` mode Claude Code silently downgrades a project-level
-            # `permissions.defaultMode: "auto"` (from .claude/settings.local.json
-            # or settings.json) back to `default`, because a repo-checked-in
-            # settings file isn't trusted to escalate to auto — only the user's
-            # own ~/.claude/settings.json or this flag can. Without it agents run
-            # in `default` mode and any tool not in the settings allow-list
-            # (e.g. MCP tools) is denied with no human to approve it. The
-            # allow/deny rules in settings.local.json still apply on top.
-            "--permission-mode",
-            "auto",
+            *_permission_args(sandbox, run_as_user),
         ]
         # 0 = no cap — let the underlying `claude` CLI run until it exits
         # naturally. The manager still restarts on any exit, preserving context
@@ -174,6 +196,8 @@ class ClaudeCodeRuntime:
         if resume_session_id:
             cmd.extend(["--resume", resume_session_id])
 
+        cmd = apply_sandbox(cmd, sandbox)
+
         logger.info(f"Starting agent {agent_id} in {worktree_path}")
         logger.info(f"Command: {' '.join(cmd)}")
 
@@ -194,6 +218,14 @@ class ClaudeCodeRuntime:
             logger.info(f"Agent {agent_id}: routing via gateway at {gateway_url}")
         if gateway_api_key:
             agent_env["ANTHROPIC_API_KEY"] = gateway_api_key
+
+        apply_sandbox_env(agent_env, sandbox)
+
+        # Claude Code refuses --dangerously-skip-permissions as root unless
+        # IS_SANDBOX=1. We only pass that flag under OS-level containment
+        # (see _permission_args), where the claim is true by construction.
+        if sandbox is not None or run_as_user is not None:
+            agent_env["IS_SANDBOX"] = "1"
 
         # OS-user isolation: drop the agent subprocess to the unprivileged user
         # (no-op when run_as_user is None). Adjusts HOME so Claude Code finds its

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -12,7 +12,14 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
+from coral.agent.runtime import (
+    AgentHandle,
+    apply_run_as_user,
+    apply_sandbox,
+    apply_sandbox_env,
+    write_coral_log_entry,
+)
+from coral.sandbox.protocol import AgentSandboxSpec
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -95,6 +102,7 @@ class CodexRuntime:
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
         run_as_user: dict[str, Any] | None = None,
+        sandbox: AgentSandboxSpec | None = None,
     ) -> AgentHandle:
         """Start a Codex agent in the given worktree.
 
@@ -147,6 +155,8 @@ class CodexRuntime:
                 "--json",
             ]
 
+        cmd = apply_sandbox(cmd, sandbox)
+
         logger.info(f"Starting Codex agent {agent_id} in {worktree_path}")
         logger.info(f"Command: {' '.join(cmd)}")
 
@@ -166,6 +176,8 @@ class CodexRuntime:
             logger.info(f"Codex agent {agent_id}: routing via gateway at {gateway_url}")
         if gateway_api_key:
             agent_env["OPENAI_API_KEY"] = gateway_api_key
+
+        apply_sandbox_env(agent_env, sandbox)
 
         # OS-user isolation: drop the agent subprocess to the unprivileged user
         # (no-op when run_as_user is None). Adjusts HOME so codex finds its creds

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -24,7 +24,14 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
+from coral.agent.runtime import (
+    AgentHandle,
+    apply_run_as_user,
+    apply_sandbox,
+    apply_sandbox_env,
+    write_coral_log_entry,
+)
+from coral.sandbox.protocol import AgentSandboxSpec
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -133,6 +140,7 @@ class CursorAgentRuntime:
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
         run_as_user: dict[str, Any] | None = None,
+        sandbox: AgentSandboxSpec | None = None,
     ) -> AgentHandle:
         agent_id_file = worktree_path / ".coral_agent_id"
         agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
@@ -185,6 +193,8 @@ class CursorAgentRuntime:
         # reference impl (cursor-cli-runner.ts L106-L129).
         cmd.append(prompt)
 
+        cmd = apply_sandbox(cmd, sandbox)
+
         logger.info(f"Starting Cursor agent {agent_id} in {worktree_path}")
         logger.info(f"Command: {' '.join(cmd)}")
 
@@ -194,6 +204,8 @@ class CursorAgentRuntime:
         agent_env["VIRTUAL_ENV"] = worktree_venv
         venv_bin = str(worktree_path / ".venv" / "bin")
         agent_env["PATH"] = venv_bin + ":" + agent_env.get("PATH", "")
+
+        apply_sandbox_env(agent_env, sandbox)
 
         # OS-user isolation: drop the agent subprocess to the unprivileged
         # user (no-op when run_as_user is None). Sets HOME so the CLI finds

--- a/coral/agent/builtin/kiro.py
+++ b/coral/agent/builtin/kiro.py
@@ -11,7 +11,14 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
+from coral.agent.runtime import (
+    AgentHandle,
+    apply_run_as_user,
+    apply_sandbox,
+    apply_sandbox_env,
+    write_coral_log_entry,
+)
+from coral.sandbox.protocol import AgentSandboxSpec
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -66,6 +73,7 @@ class KiroRuntime:
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
         run_as_user: dict[str, Any] | None = None,
+        sandbox: AgentSandboxSpec | None = None,
     ) -> AgentHandle:
         agent_id_file = worktree_path / ".coral_agent_id"
         agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
@@ -91,10 +99,14 @@ class KiroRuntime:
         if model and model != "default":
             cmd.extend(["--model", model])
 
+        cmd = apply_sandbox(cmd, sandbox)
+
         logger.info(f"Starting Kiro agent {agent_id} in {worktree_path}")
         logger.info(f"Command: {' '.join(cmd)}")
 
         agent_env = _clean_env()
+
+        apply_sandbox_env(agent_env, sandbox)
 
         # OS-user isolation: drop the agent subprocess to the unprivileged
         # user (no-op when run_as_user is None). Sets HOME so the CLI finds

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -12,7 +12,14 @@ from typing import Any
 
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
-from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
+from coral.agent.runtime import (
+    AgentHandle,
+    apply_run_as_user,
+    apply_sandbox,
+    apply_sandbox_env,
+    write_coral_log_entry,
+)
+from coral.sandbox.protocol import AgentSandboxSpec
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -92,6 +99,7 @@ class OpenCodeRuntime:
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
         run_as_user: dict[str, Any] | None = None,
+        sandbox: AgentSandboxSpec | None = None,
     ) -> AgentHandle:
         """Start an OpenCode agent in the given worktree."""
         agent_id_file = worktree_path / ".coral_agent_id"
@@ -131,6 +139,8 @@ class OpenCodeRuntime:
         # Prompt goes last as positional arg
         cmd.append(prompt)
 
+        cmd = apply_sandbox(cmd, sandbox)
+
         logger.info(f"Starting OpenCode agent {agent_id} in {worktree_path}")
         logger.info(f"Command: {' '.join(cmd)}")
 
@@ -150,6 +160,8 @@ class OpenCodeRuntime:
             logger.info(f"OpenCode agent {agent_id}: routing via gateway at {gateway_url}")
         if gateway_api_key:
             agent_env["OPENAI_API_KEY"] = gateway_api_key
+
+        apply_sandbox_env(agent_env, sandbox)
 
         # OS-user isolation: drop the agent subprocess to the unprivileged
         # user (no-op when run_as_user is None). Sets HOME so the CLI finds

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -157,6 +157,9 @@ class AgentManager:
         self._pending_restart_after_pause: set[str] = set()
         self._gateway: Any | None = None
         self._gateway_keys: dict[str, str] = {}  # agent_id -> proxy key
+        # Sandbox provider (agents.sandbox.provider, e.g. srt). Instantiated
+        # in _start_sandbox_if_enabled; lives and dies with the manager.
+        self._sandbox: Any | None = None
         self._grader_proc: multiprocessing.Process | None = None
         self._grader_stop_event: Any | None = None  # multiprocessing.Event
         # Island migration. Only meaningful with >=2 islands and migration
@@ -214,6 +217,10 @@ class AgentManager:
         # 1b. Start gateway if configured
         self._start_gateway_if_enabled()
 
+        # 1b2. Start the sandbox provider if configured (must be up before
+        # agents spawn — their launch specs embed its live state).
+        self._start_sandbox_if_enabled()
+
         # 1c. Start grader daemon. Agents' `coral eval` writes pending attempts;
         #     the daemon picks them up, grades inside an isolated worktree,
         #     and writes the score back. Must be running before agents start.
@@ -266,8 +273,10 @@ class AgentManager:
         self.handles = handles
         self._running = True
 
-        # 5. Write PID file
+        # 5. Write PID file + initial agent state (so `coral status` shows
+        # per-agent facts like the sandbox provider from the first tick).
         self._write_pid_file()
+        self._persist_agent_state()
 
         # 6. Register atexit handler as safety net for unexpected exits
         atexit.register(self._atexit_cleanup)
@@ -397,6 +406,77 @@ class AgentManager:
         gateway.start()
         self._gateway = gateway
         logger.info(f"Gateway running at {gateway.url}")
+
+    def _start_sandbox_if_enabled(self) -> None:
+        """Resolve, validate, and start the configured sandbox provider.
+
+        Idempotent. The provider owns its run-level resources (the srt
+        backend starts its allow-all proxy here; other backends might open
+        an API session or warm a VM pool).
+        """
+        sb = self.config.agents.sandbox
+        if not sb.enabled or self._sandbox is not None:
+            return
+
+        from coral.sandbox import get_sandbox_provider
+
+        provider = get_sandbox_provider(sb)
+        provider.validate(self.config.agents)
+        provider.start()
+        self._sandbox = provider
+        logger.info(f"Sandbox provider {sb.provider!r} active")
+        if self.verbose:
+            print(f"[coral] Sandbox provider {sb.provider!r} active")
+
+    def _stop_sandbox(self) -> None:
+        if self._sandbox is not None:
+            self._sandbox.stop()
+            self._sandbox = None
+
+    def _island_worktrees(self, agent_id: str) -> list[Path]:
+        """Worktrees of this agent's island-mates (own included).
+
+        Computed from the manager's roster rather than on-disk breadcrumbs:
+        at initial start later agents' worktrees don't exist yet, and after
+        a migration the live ``_agent_island`` map is fresher than the birth
+        island recorded on the spec.
+        """
+        assert self.paths is not None
+
+        def island_of(aid: str) -> str | None:
+            spec = self.specs_by_id.get(aid)
+            return self._agent_island.get(aid) or (spec.island_id if spec else None)
+
+        own = island_of(agent_id)
+        return [
+            self.paths.agents_dir / s.agent_id for s in self.specs if island_of(s.agent_id) == own
+        ]
+
+    def _sandbox_spec_for(self, agent_id: str, worktree_path: Path, shared_dir_name: str):
+        """Build the agent's sandbox launch spec (None when disabled).
+
+        Called on every (re)start so specs always reflect live provider
+        state (e.g. the srt backend's current proxy port) and the current
+        island partition (migration restarts the migrant through here).
+        """
+        if self._sandbox is None:
+            return None
+        assert self.paths is not None
+
+        from coral.sandbox import AgentSandboxContext
+
+        spec = self._sandbox.prepare_agent(
+            AgentSandboxContext(
+                agent_id=agent_id,
+                worktree_path=worktree_path,
+                coral_dir=self.paths.coral_dir,
+                repo_dir=self.paths.repo_dir,
+                shared_dir_name=shared_dir_name,
+                sibling_worktrees=self._island_worktrees(agent_id),
+            )
+        )
+        logger.info(f"  {agent_id}: sandboxed via {self.config.agents.sandbox.provider!r}")
+        return spec
 
     def _run_warmstart_research(
         self,
@@ -599,6 +679,10 @@ class AgentManager:
         # that user. Manager/grader stay root. No-op when isolate_user is unset.
         run_as_user = self._apply_user_isolation(worktree_path, island_id, shared_dir_name)
 
+        # Sandbox: ask the provider for this agent's launch spec (command
+        # prefix + env). None when agents.sandbox is disabled.
+        sandbox_spec = self._sandbox_spec_for(agent_id, worktree_path, shared_dir_name)
+
         # Start agent
         if island_id is not None:
             log_dir = self.paths.coral_dir / "islands" / str(island_id) / "logs"
@@ -621,6 +705,7 @@ class AgentManager:
             gateway_url=gateway_url,
             gateway_api_key=gateway_api_key,
             run_as_user=run_as_user,
+            sandbox=sandbox_spec,
         )
         # Record fresh process start time for the exit-classifier uptime check.
         self._started_at[agent_id] = time.time()
@@ -747,6 +832,10 @@ class AgentManager:
         # Start gateway if configured
         self._start_gateway_if_enabled()
 
+        # Start the sandbox provider if configured (resumed agents get
+        # fresh launch specs reflecting its new state).
+        self._start_sandbox_if_enabled()
+
         # Start grader daemon (must be up before resumed agents submit evals).
         self._start_grader_daemon()
 
@@ -869,6 +958,7 @@ class AgentManager:
         self.handles = handles
         self._running = True
         self._write_pid_file()
+        self._persist_agent_state()
         atexit.register(self._atexit_cleanup)
         return handles
 
@@ -942,10 +1032,13 @@ class AgentManager:
         if self._gateway:
             self._gateway.stop()
             self._gateway = None
+        # Stop the sandbox provider last — nothing else depends on it.
+        self._stop_sandbox()
         logger.info("All agents stopped.")
 
     def status(self) -> list[dict[str, Any]]:
         """Get status of all agents."""
+        sandbox = self.config.agents.sandbox.provider if self._sandbox is not None else None
         statuses = []
         for handle in self.handles:
             statuses.append(
@@ -957,6 +1050,7 @@ class AgentManager:
                     "log": str(handle.log_path),
                     "session_id": handle.session_id,
                     "restarts": self._restart_counts.get(handle.agent_id, 0),
+                    "sandbox": sandbox,
                 }
             )
         return statuses
@@ -1511,6 +1605,7 @@ class AgentManager:
         """Persist current paused/active state to public/agent_state.json."""
         if self.paths is None:
             return
+        sandbox = self.config.agents.sandbox.provider if self._sandbox is not None else None
         document = AgentStateDocument()
         for handle in self.handles:
             agent_id = handle.agent_id
@@ -1521,6 +1616,7 @@ class AgentManager:
                 paused_until=until,
                 pause_count=self._pause_count.get(agent_id, 0),
                 last_fault_at=self._last_fault_at.get(agent_id),
+                sandbox=sandbox,
             )
         try:
             write_agent_state(self.paths.coral_dir, document)

--- a/coral/agent/runtime.py
+++ b/coral/agent/runtime.py
@@ -12,6 +12,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO, Any, Protocol, runtime_checkable
 
+from coral.sandbox.protocol import AgentSandboxSpec
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,6 +38,7 @@ class AgentRuntime(Protocol):
         gateway_url: str | None = None,
         gateway_api_key: str | None = None,
         run_as_user: dict[str, Any] | None = None,
+        sandbox: AgentSandboxSpec | None = None,
     ) -> AgentHandle: ...
 
     def extract_session_id(self, log_path: Path) -> str | None: ...
@@ -53,6 +56,30 @@ class AgentRuntime(Protocol):
         config/skill discovery: `.claude`, `.codex`, `.opencode`, etc.
         """
         ...
+
+
+def apply_sandbox(cmd: list[str], sandbox: AgentSandboxSpec | None) -> list[str]:
+    """Wrap a runtime command in its sandbox (no-op when sandbox is None).
+
+    ``sandbox`` comes from the run's :class:`coral.sandbox.SandboxProvider`
+    (e.g. ``["srt", "--settings", <path>, "--"]`` for the srt backend). The
+    sandbox applies to the whole process tree, so everything the runtime
+    spawns (shell tools, ``coral eval``) inherits it.
+    """
+    if sandbox is None or not sandbox.command_prefix:
+        return cmd
+    return [*sandbox.command_prefix, *cmd]
+
+
+def apply_sandbox_env(env: dict[str, str], sandbox: AgentSandboxSpec | None) -> None:
+    """Merge the sandbox spec's env into the agent environment, in place.
+
+    Empty for the srt backend (srt injects its proxy vars into the child
+    itself); remote/shim backends carry endpoints and credentials here
+    rather than in the command prefix (argv is visible in ``ps``).
+    """
+    if sandbox is not None and sandbox.env:
+        env.update(sandbox.env)
 
 
 def apply_run_as_user(env: dict[str, str], run_as_user: dict[str, Any] | None) -> dict[str, Any]:

--- a/coral/agent/state.py
+++ b/coral/agent/state.py
@@ -44,12 +44,15 @@ class AgentRuntimeState:
     `state` is one of "active", "paused".
     `paused_until` is the wall-clock epoch second the pause expires; it is None
     when the agent is not currently paused.
+    `sandbox` is the sandbox provider name the agent runs under
+    (`agents.sandbox.provider`, e.g. "srt"); None when unsandboxed.
     """
 
     state: str = "active"
     paused_until: float | None = None
     pause_count: int = 0
     last_fault_at: str | None = None  # ISO-8601 UTC timestamp of most recent fault dump
+    sandbox: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -61,6 +64,7 @@ class AgentRuntimeState:
             paused_until=data.get("paused_until"),
             pause_count=int(data.get("pause_count", 0)),
             last_fault_at=data.get("last_fault_at"),
+            sandbox=data.get("sandbox"),
         )
 
 

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -979,6 +979,8 @@ def cmd_status(args: argparse.Namespace) -> None:
                 status_str = "stopped"
 
             extras = []
+            if runtime_state and runtime_state.sandbox:
+                extras.append(f"sandbox: {runtime_state.sandbox}")
             if runtime_state and runtime_state.pause_count > 0:
                 extras.append(f"pauses: {runtime_state.pause_count}")
             if runtime_state and runtime_state.last_fault_at:

--- a/coral/config.py
+++ b/coral/config.py
@@ -113,6 +113,73 @@ class WarmStartConfig:
 
 
 @dataclass
+class SandboxConfig:
+    """OS-level agent sandboxing via a pluggable provider (default: ``srt``).
+
+    When enabled, every agent subprocess is wrapped by the configured
+    sandbox provider (see ``coral.sandbox``), which enforces filesystem and
+    network boundaries — uniformly across all runtimes, unlike the
+    per-runtime permission settings, which are advisory. With the built-in
+    ``srt`` provider (Anthropic's sandbox-runtime — Seatbelt on macOS,
+    bubblewrap on Linux), reads are confined to this run: the agent sees
+    its own worktree, the run repo, shared ``.coral/`` state (minus
+    ``private/``), the surfaced grader source, and the toolchain's home
+    dotdirs — not other runs, sibling agents' worktrees, or host secrets
+    (``~/.ssh``, ``~/.aws``, ...). Writes are allow-listed to the same
+    slice plus /tmp.
+
+    Composes with tmux/local sessions; mutually exclusive with
+    ``agents.isolate_user`` (and thus ``run.session=docker``) — both solve
+    the same isolation problem.
+
+    ``provider``: built-in name (``srt``) or a custom
+    ``module.path:ClassName`` entrypoint implementing
+    :class:`coral.sandbox.SandboxProvider` — the hook for hosted backends
+    like e2b or modal.
+
+    ``network``:
+    - ``"open"`` (default): full network access via an allow-all proxy the
+      manager runs in-process. srt refuses a wildcard allowlist; an external
+      proxy owning the filtering policy is its sanctioned escape hatch.
+      Traffic is proxy-mediated, so raw UDP/ICMP and proxy-ignorant clients
+      won't work.
+    - ``"allowlist"``: srt's own filtering proxies restrict traffic to
+      ``allowed_domains`` (srt syntax, e.g. "github.com", "*.npmjs.org").
+
+    The srt provider requires the sandbox-runtime npm package
+    (npm install -g @anthropic-ai/sandbox-runtime), invoked via
+    ``srt_command`` (default ``npx --no-install srt``); Linux additionally
+    needs bubblewrap, socat, and ripgrep.
+    """
+
+    enabled: bool = False
+    provider: str = "srt"  # built-in name or "module.path:ClassName" entrypoint
+    network: str = "open"  # "open" or "allowlist"
+    # How to invoke srt. The npx default also finds npm -g installs whose
+    # global bin dir is not on PATH; --no-install stops npx from fetching
+    # the unrelated "srt" registry package when sandbox-runtime is missing.
+    # Override with e.g. ["srt"] or ["/usr/local/bin/srt"].
+    srt_command: list[str] = field(default_factory=lambda: ["npx", "--no-install", "srt"])
+    allowed_domains: list[str] = field(default_factory=list)  # allowlist mode only
+    deny_read: list[str] = field(default_factory=list)  # extra paths hidden from agents
+    allow_read: list[str] = field(default_factory=list)  # extra readable paths (e.g. ~/.aws)
+    allow_write: list[str] = field(default_factory=list)  # extra writable paths
+    # Escape hatch: deep-merged last into the generated srt settings JSON
+    # (e.g. {"enableWeakerNestedSandbox": true} inside containers).
+    extra_settings: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.provider:
+            raise ValueError("agents.sandbox.provider must be a non-empty string")
+        if self.network not in ("open", "allowlist"):
+            raise ValueError(
+                f"agents.sandbox.network must be 'open' or 'allowlist', got {self.network!r}"
+            )
+        if not self.srt_command:
+            raise ValueError("agents.sandbox.srt_command must be a non-empty command list")
+
+
+@dataclass
 class AgentAssignmentConfig:
     """Per-assignment override of runtime/model for mix-and-match multi-agent runs.
 
@@ -155,6 +222,9 @@ class AgentConfig:
     # session this value is forced to the image's ``agent`` user regardless of
     # what is set here.
     isolate_user: str = ""
+    # OS-level sandboxing via sandbox-runtime (`srt`) — the lightweight,
+    # host-native alternative to isolate_user/Docker. See SandboxConfig.
+    sandbox: SandboxConfig = field(default_factory=SandboxConfig)
     # Mix-and-match: when non-empty, each entry spawns its own runtime/model
     # combo. ``agents.count`` is ignored (total = sum of assignment counts).
     # Empty fields on an assignment inherit the agents.* defaults below.
@@ -200,6 +270,15 @@ class AgentConfig:
     min_clean_runtime_seconds: int = 60
 
     def __post_init__(self) -> None:
+        # Direct construction (tests, SubprocessGrader-style round-trips) may
+        # leave nested sandbox config as a plain dict; coerce like RunConfig.stop.
+        if isinstance(self.sandbox, dict):
+            self.sandbox = SandboxConfig(**self.sandbox)
+        if self.sandbox.enabled and self.isolate_user:
+            raise ValueError(
+                "agents.sandbox and agents.isolate_user are mutually exclusive — "
+                "both isolate agents from .coral/private/; use one or the other."
+            )
         # Reject negative values for the new reliability knobs;
         # 0 is treated as "disabled" for the same fields where it makes sense.
         for field_name in (

--- a/coral/sandbox/__init__.py
+++ b/coral/sandbox/__init__.py
@@ -1,0 +1,11 @@
+"""Pluggable agent sandboxing (``agents.sandbox``)."""
+
+from coral.sandbox.protocol import AgentSandboxContext, AgentSandboxSpec, SandboxProvider
+from coral.sandbox.registry import get_sandbox_provider
+
+__all__ = [
+    "AgentSandboxContext",
+    "AgentSandboxSpec",
+    "SandboxProvider",
+    "get_sandbox_provider",
+]

--- a/coral/sandbox/protocol.py
+++ b/coral/sandbox/protocol.py
@@ -1,0 +1,95 @@
+"""Sandbox provider protocol — pluggable isolation backends for agents.
+
+A sandbox provider is the containment counterpart of an agent runtime: the
+runtime decides *what* command runs an agent, the provider decides *how
+contained* that command is. Providers are resolved by name from
+``agents.sandbox.provider`` (see :mod:`coral.sandbox.registry`) — ``srt``
+is the built-in default; hosted backends (e2b, modal, ...) plug in as
+custom entrypoints without touching runtimes or the manager.
+
+The contract is deliberately narrow: :meth:`SandboxProvider.prepare_agent`
+returns an :class:`AgentSandboxSpec` whose ``command_prefix`` wraps the
+runtime command and whose ``env`` is merged into the agent's environment.
+The wrapped command MUST still behave like a local process — stream stdio,
+propagate exit codes and signals, and see the worktree path — because the
+manager supervises it through the same ``AgentHandle`` machinery as an
+unsandboxed agent. A local enforcer (srt, bwrap, docker run) satisfies
+this directly; a remote backend satisfies it with a shim command that
+syncs the worktree and tunnels execution.
+
+Lifecycle: ``validate`` (fail fast on missing deps / config conflicts,
+before any run state is created) → ``start`` (run-level resources: a
+network proxy, a VM pool, an API session) → ``prepare_agent`` per agent
+(re-invoked on every restart/resume, so specs may embed live state like a
+proxy port) → ``stop`` (teardown with the run).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from coral.config import AgentConfig
+
+
+@dataclass
+class AgentSandboxContext:
+    """Everything a provider may need to build one agent's containment."""
+
+    agent_id: str
+    worktree_path: Path
+    coral_dir: Path
+    repo_dir: Path
+    # The runtime's native shared-state dir name (".claude", ".codex", ...) —
+    # providers use it to grant the runtime CLI's own home state.
+    shared_dir_name: str
+    # Worktrees of this agent's collaborators (island-mates in multi-island
+    # runs), own worktree included. Supplied from the manager's roster, which
+    # is authoritative even when the paths don't exist on disk yet (initial
+    # start spawns agents one by one) or a breadcrumb is mid-rewrite
+    # (migration). Empty means "provider decides" (e.g. srt falls back to
+    # on-disk breadcrumbs).
+    sibling_worktrees: list[Path] = field(default_factory=list)
+
+
+@dataclass
+class AgentSandboxSpec:
+    """How to launch one agent inside the sandbox.
+
+    ``command_prefix`` is prepended to the runtime command (see
+    :func:`coral.agent.runtime.apply_sandbox`); ``env`` is merged into the
+    agent subprocess environment (secrets belong here, not in the prefix —
+    argv is visible in ``ps``).
+    """
+
+    command_prefix: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@runtime_checkable
+class SandboxProvider(Protocol):
+    """Protocol all sandbox backends implement.
+
+    Constructed with the run's ``SandboxConfig`` (see the registry); must be
+    safe to construct even when the backend's dependencies are absent —
+    dependency checks belong in ``validate``.
+    """
+
+    def validate(self, agents: AgentConfig) -> None:
+        """Raise RuntimeError (with an actionable message) if this backend
+        cannot work here — missing binaries, conflicting agent config."""
+        ...
+
+    def start(self) -> None:
+        """Bring up run-level resources. Idempotent."""
+        ...
+
+    def stop(self) -> None:
+        """Tear down whatever ``start`` created. Safe to call when idle."""
+        ...
+
+    def prepare_agent(self, ctx: AgentSandboxContext) -> AgentSandboxSpec:
+        """Build the launch spec for one agent. Called on every (re)start."""
+        ...

--- a/coral/sandbox/registry.py
+++ b/coral/sandbox/registry.py
@@ -1,0 +1,41 @@
+"""Resolve ``agents.sandbox.provider`` names to provider instances.
+
+Mirrors :mod:`coral.agent.registry`: built-in names map to bundled
+implementations, and a ``module.path:ClassName`` entrypoint plugs in an
+out-of-tree backend (e.g. an e2b or modal provider) without code changes
+here. Imports are lazy so listing/validation never drags in backend deps.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from coral.config import SandboxConfig
+    from coral.sandbox.protocol import SandboxProvider
+
+_BUILTIN: dict[str, str] = {
+    "srt": "coral.sandbox.srt:SrtSandbox",
+}
+
+
+def get_sandbox_provider(cfg: SandboxConfig) -> SandboxProvider:
+    """Instantiate the provider named by ``cfg.provider``."""
+    name = cfg.provider
+    entrypoint = _BUILTIN.get(name)
+    if entrypoint is None and ":" in name:
+        entrypoint = name
+    if entrypoint is None:
+        available = ", ".join(sorted(_BUILTIN))
+        raise ValueError(
+            f"Unknown sandbox provider {name!r}. Built-in providers: {available}. "
+            f"For a custom backend, use a 'module.path:ClassName' entrypoint."
+        )
+
+    module_path, _, class_name = entrypoint.partition(":")
+    try:
+        cls = getattr(importlib.import_module(module_path), class_name)
+    except (ImportError, AttributeError) as e:
+        raise ValueError(f"Cannot load sandbox provider {entrypoint!r}: {e}") from e
+    return cls(cfg)

--- a/coral/sandbox/srt.py
+++ b/coral/sandbox/srt.py
@@ -1,0 +1,585 @@
+"""Built-in sandbox provider: Anthropic's sandbox-runtime (``srt``).
+
+Everywhere else, CORAL *asks* agents to stay out of ``.coral/private/``
+(runtime permission settings, CORAL.md instructions). This provider wraps
+each agent subprocess in ``srt``
+(https://github.com/anthropic-experimental/sandbox-runtime), which enforces
+the same boundaries at the OS level — Seatbelt on macOS, bubblewrap on
+Linux — for every runtime uniformly:
+
+- Reads are confined to this run: the agent sees the agent worktrees (its
+  own and its siblings' — same-island only in multi-island runs, see
+  :func:`_worktree_reads`), the run repo, shared ``.coral/`` state (minus
+  ``private/``), the surfaced grader source, the CORAL installation itself
+  (so agent-side ``coral`` commands resolve to the same code the manager
+  runs), and the toolchain's home dotdirs. Other runs and host secrets
+  (``~/.ssh``, ``~/.aws``, ...) are unreadable.
+- Writes are allow-listed to the same slice plus /tmp.
+
+Network comes in two modes (``agents.sandbox.network``):
+
+- ``"open"`` — full network access. srt's config schema deliberately
+  refuses a wildcard domain allowlist; its sanctioned escape hatch is
+  ``network.httpProxyPort``, an external proxy that owns filtering policy.
+  :class:`AllowAllProxy` is that proxy with the policy "allow everything".
+  Traffic is still proxy-mediated (srt removes direct network access
+  structurally), so raw UDP/ICMP and proxy-ignorant clients won't work.
+- ``"allowlist"`` — srt runs its own filtering proxies against
+  ``agents.sandbox.allowed_domains``.
+
+The per-agent settings JSON lives under ``.coral/private/sandbox/`` — srt
+reads it host-side before the sandbox exists, and the sandbox itself then
+prevents the agent from tampering with its own policy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import select
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from coral.sandbox.protocol import AgentSandboxContext, AgentSandboxSpec
+
+if TYPE_CHECKING:
+    from coral.config import AgentConfig, SandboxConfig
+
+logger = logging.getLogger(__name__)
+
+# srt overrides TMPDIR to this path inside the sandbox (unless
+# CLAUDE_CODE_TMPDIR is set); it must exist or every mktemp fails.
+_SRT_TMPDIR = Path("/tmp/claude")
+
+_INSTALL_HINT = "npm install -g @anthropic-ai/sandbox-runtime"
+
+_LINUX_DEPS = {
+    "bwrap": "bubblewrap",
+    "socat": "socat",
+    "rg": "ripgrep",
+}
+
+
+class SrtSandbox:
+    """srt-backed :class:`coral.sandbox.protocol.SandboxProvider`."""
+
+    def __init__(self, cfg: SandboxConfig) -> None:
+        self.cfg = cfg
+        self._proxy: AllowAllProxy | None = None
+
+    def validate(self, agents: AgentConfig) -> None:
+        ensure_sandbox_supported(agents)
+
+    def start(self) -> None:
+        """Start the allow-all proxy backing ``network="open"``. Idempotent.
+
+        Allowlist mode needs no run-level resources — srt runs its own
+        filtering proxies per agent.
+        """
+        if self.cfg.network == "open" and self._proxy is None:
+            self._proxy = AllowAllProxy()
+            port = self._proxy.start()
+            logger.info(f"Sandbox network proxy (allow-all) on 127.0.0.1:{port}")
+
+    def stop(self) -> None:
+        if self._proxy is not None:
+            self._proxy.stop()
+            self._proxy = None
+            logger.info("Sandbox network proxy stopped")
+
+    def prepare_agent(self, ctx: AgentSandboxContext) -> AgentSandboxSpec:
+        """Write the per-agent srt settings file and return the launch spec.
+
+        Regenerated on every (re)start so restarts pick up the current
+        proxy port. srt injects the proxy env vars into its child itself;
+        the spec's own env only carries the editable-install PYTHONPATH
+        shim (see :func:`_cli_pythonpath_shim`), when one is needed.
+        """
+        settings = build_srt_settings(
+            self.cfg,
+            worktree_path=ctx.worktree_path,
+            coral_dir=ctx.coral_dir,
+            repo_dir=ctx.repo_dir,
+            shared_dir_name=ctx.shared_dir_name,
+            proxy_port=self._proxy.port if self._proxy else None,
+            sibling_worktrees=ctx.sibling_worktrees,
+        )
+        settings_dir = ctx.coral_dir / "private" / "sandbox"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        settings_path = settings_dir / f"{ctx.agent_id}.json"
+        settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+
+        try:
+            _SRT_TMPDIR.mkdir(exist_ok=True)
+        except OSError:
+            pass  # srt/tools will surface a clearer error if /tmp is unusable
+
+        import coral
+
+        env = _cli_pythonpath_shim(
+            ctx.coral_dir.parent,
+            Path(coral.__file__).resolve().parent,
+            Path(sys.prefix).resolve(),
+        )
+        return AgentSandboxSpec(
+            command_prefix=srt_command_prefix(self.cfg.srt_command, settings_path),
+            env=env,
+        )
+
+
+def ensure_sandbox_supported(agents: AgentConfig) -> None:
+    """Fail fast with actionable errors when srt sandboxing cannot work here.
+
+    Raises RuntimeError on: unresolvable srt command, missing Linux sandbox
+    dependencies, or combination with OS-user isolation (``srt`` must read
+    the settings file under ``.coral/private/``, which user isolation locks
+    to root — the two mechanisms solve the same problem; pick one).
+    """
+    if agents.isolate_user:
+        raise RuntimeError(
+            "agents.sandbox cannot be combined with agents.isolate_user "
+            "(set implicitly by run.session=docker). Both isolate the agent "
+            "from .coral/private/ — use one or the other."
+        )
+    # Probe the actual invocation rather than PATH-checking a binary name:
+    # the npx default resolves npm -g installs whose bin dir is not on PATH,
+    # and --no-install makes the probe fail cleanly (instead of npx fetching
+    # the unrelated "srt" registry package) when sandbox-runtime is absent.
+    srt_command = agents.sandbox.srt_command
+    try:
+        probe = subprocess.run(
+            [*srt_command, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        raise RuntimeError(
+            f"agents.sandbox.enabled=true but `{' '.join(srt_command)}` failed to run ({e}). "
+            f"Install sandbox-runtime with: {_INSTALL_HINT}"
+        ) from e
+    if probe.returncode != 0:
+        detail = (probe.stderr or probe.stdout).strip().splitlines()
+        raise RuntimeError(
+            f"agents.sandbox.enabled=true but `{' '.join(srt_command)} --version` failed"
+            + (f" ({detail[-1]})" if detail else "")
+            + f". Install sandbox-runtime with: {_INSTALL_HINT}"
+        )
+    if sys.platform.startswith("linux"):
+        missing = [pkg for binary, pkg in _LINUX_DEPS.items() if shutil.which(binary) is None]
+        if missing:
+            raise RuntimeError(
+                "agents.sandbox.enabled=true but srt's Linux dependencies are "
+                f"missing: {', '.join(missing)}. Install them with your package "
+                f"manager (e.g. apt-get install {' '.join(missing)})."
+            )
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``override`` into ``base`` (override wins)."""
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _runtime_home_paths(shared_dir_name: str) -> list[str]:
+    """Home paths a sandboxed agent needs, used for both reads and writes.
+
+    Reads are confined to the run dir, so everything under ``$HOME`` the
+    agent toolchain legitimately needs must be allowed back explicitly:
+    the runtime CLI's own state dir (sessions/credentials — Claude Code
+    cannot run without reading ``~/.claude.json``), and the tool caches the
+    stack lives off (uv/coral under ``~/.local`` + ``~/.cache``, node under
+    ``~/.nvm`` or npm's cache). Deliberately narrow: broad creds dirs like
+    ``~/.ssh``, ``~/.aws``, ``~/.config`` (gh/gcloud tokens) stay denied.
+    srt's mandatory protections still deny writes to ``.gitconfig``, shell
+    rc files, etc. within these grants.
+    """
+    home = Path.home()
+    paths = [
+        str(home / ".cache"),  # uv, pip, and friends
+        str(home / ".local"),  # uv tools (incl. coral), uv-managed pythons
+        str(home / ".npm"),
+        str(home / ".nvm"),  # node itself, when nvm-managed
+        str(home / ".gitconfig"),  # git aborts on an unreadable existing config
+        str(home / shared_dir_name),  # runtime state: ~/.claude, ~/.codex, ...
+    ]
+    if shared_dir_name == ".claude":
+        paths += [str(home / ".claude.json"), str(home / ".claude.json.backup")]
+    elif shared_dir_name == ".opencode":
+        paths += [str(home / ".config" / "opencode"), str(home / ".opencode")]
+    return paths
+
+
+def _worktree_island(worktree: Path) -> str | None:
+    """Read a worktree's island membership from its .coral_island breadcrumb."""
+    try:
+        return (worktree / ".coral_island").read_text().strip() or None
+    except OSError:
+        return None
+
+
+def _worktree_reads(
+    worktree_path: Path, coral_dir: Path, sibling_worktrees: list[Path]
+) -> list[str]:
+    """Agent worktrees this agent may read.
+
+    Reading (not writing) siblings' trees is part of the shared-knowledge
+    design, so single-island runs grant the whole ``agents/`` dir — which
+    also covers agents spawned later. Multi-island runs stop at the island
+    boundary: islands evolve independently and exchange work only through
+    migration, so a cross-island read would defeat the diversity the
+    partition exists to create. The island-mate roster comes from the
+    manager (``ctx.sibling_worktrees`` — correct even before those
+    worktrees exist on disk; srt rules are plain path patterns); without
+    one, membership falls back to each worktree's ``.coral_island``
+    breadcrumb. Either way the grant is rebuilt at every agent (re)start —
+    migration updates the roster before restarting the migrant, and
+    bystanders pick up the new boundary at their own next restart.
+    """
+    agents_dir = worktree_path.parent
+    if not (coral_dir / "islands").exists():
+        return [str(agents_dir.resolve())]
+    reads = {str(worktree_path.resolve())}
+    if sibling_worktrees:
+        reads.update(str(p.resolve()) for p in sibling_worktrees)
+    else:
+        own = _worktree_island(worktree_path)
+        for sibling in agents_dir.iterdir() if own is not None else ():
+            if sibling.is_dir() and _worktree_island(sibling) == own:
+                reads.add(str(sibling.resolve()))
+    return sorted(reads)
+
+
+def _run_dir_reads(
+    worktree_path: Path, coral_dir: Path, repo_dir: Path, sibling_worktrees: list[Path]
+) -> list[str]:
+    """Run-dir paths this agent may read.
+
+    Enumerated per-child instead of granting the run dir wholesale because
+    srt's read rules are allow-beats-deny: an ``allowRead`` on any ancestor
+    of ``.coral/private/`` would resurrect it. Other runs are simply never
+    allowed back.
+    """
+    reads = [
+        *_worktree_reads(worktree_path, coral_dir, sibling_worktrees),
+        str(repo_dir.resolve()),  # run repo (worktree git ops read its .git)
+        str((coral_dir / "public").resolve()),
+        str((coral_dir / "islands").resolve()),  # multi-island shared state
+        str((coral_dir / ".git").resolve()),  # checkpoint history (coral notes --history)
+        str((coral_dir / "config.yaml").resolve()),
+        str((coral_dir / "config_dir").resolve()),  # breadcrumb read by hooks
+        # PYTHONPATH shim for editable installs (_cli_pythonpath_shim). Not
+        # under allowWrite, so agents cannot repoint the symlink.
+        str((coral_dir.parent / ".sandbox").resolve()),
+    ]
+    # The grader source is surfaced to agents as <shared_dir>/grader — a
+    # symlink whose target (the task's grader/ package) lives outside the
+    # run dir. Allow exactly that target; the task dir's other siblings
+    # (e.g. the hidden taskdata/ that grader.private copies) stay denied.
+    from coral.workspace.worktree import grader_source_dir
+
+    grader_source = grader_source_dir(coral_dir)
+    if grader_source is not None:
+        reads.append(str(grader_source.resolve()))
+    return reads
+
+
+def _coral_install_reads() -> list[str]:
+    """Paths of the CORAL installation driving this run.
+
+    Agents invoke the bare ``coral`` CLI, which must resolve to the same
+    installation the manager runs — otherwise the shell's PATH search
+    silently falls through to whatever older ``coral`` is readable (e.g. a
+    stale ``uv tool install``), and its hooks write attempts where this
+    run's daemon never looks. A dev checkout's venv and editable source
+    live under ``$HOME`` (denied wholesale), so allow back exactly the
+    interpreter prefix (venv: entry script, deps) and the ``coral`` package
+    dir (editable installs keep it outside the prefix). Never the checkout
+    root: an ``allowRead`` there would resurrect sibling runs' ``.coral/
+    private/`` via allow-beats-deny.
+    """
+    import coral
+
+    return [
+        str(Path(sys.prefix).resolve()),
+        str(Path(coral.__file__).resolve().parent),
+    ]
+
+
+def _cli_pythonpath_shim(run_dir: Path, package_dir: Path, prefix: Path) -> dict[str, str]:
+    """Make an editable-installed ``coral`` importable inside the sandbox.
+
+    An editable install's ``.pth`` puts the *checkout root* on ``sys.path``,
+    and Python's import machinery must ``listdir()`` every path entry — but
+    the root can never be allowed back (sibling runs' ``.coral/private/``
+    live under it, and srt reads are allow-beats-deny). Same trick as the
+    surfaced grader source: expose the package through a shim directory
+    inside the run dir holding a single symlink, and put that on
+    ``PYTHONPATH``. Seatbelt evaluates the resolved target, which
+    :func:`_coral_install_reads` already allows. Non-editable installs
+    (package inside the interpreter prefix) need nothing.
+    """
+    if package_dir.is_relative_to(prefix):
+        return {}
+    shim_dir = run_dir / ".sandbox" / "pythonpath"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    link = shim_dir / package_dir.name
+    link.unlink(missing_ok=True)  # repoint if the checkout moved since last start
+    link.symlink_to(package_dir)
+    return {"PYTHONPATH": str(shim_dir)}
+
+
+def build_srt_settings(
+    cfg: SandboxConfig,
+    *,
+    worktree_path: Path,
+    coral_dir: Path,
+    repo_dir: Path,
+    shared_dir_name: str,
+    proxy_port: int | None,
+    sibling_worktrees: list[Path] | None = None,
+) -> dict[str, Any]:
+    """Build the srt settings JSON for one agent.
+
+    Reads are confined to this run: the user's home is denied wholesale and
+    only the agent's own slice of the run dir (worktree, repo, shared
+    ``.coral`` state minus ``private/``, the surfaced grader source) plus
+    the toolchain's home dotdirs are allowed back. System paths (/usr,
+    /opt, ...) stay readable so binaries and libraries work. Writes are
+    allow-listed to the same slice.
+    """
+    private_dir = str((coral_dir / "private").resolve())
+    home_paths = _runtime_home_paths(shared_dir_name)
+
+    settings: dict[str, Any] = {
+        "network": {
+            "allowedDomains": list(cfg.allowed_domains),
+            "deniedDomains": [],
+            # Agents routinely bind localhost ports (dev servers, test suites).
+            "allowLocalBinding": True,
+        },
+        "filesystem": {
+            # private_dir is listed even though home already covers the
+            # default layout — runs placed outside $HOME (workspace.run_dir)
+            # must still hide it.
+            "denyRead": [str(Path.home()), private_dir, *cfg.deny_read],
+            "allowRead": [
+                *_run_dir_reads(worktree_path, coral_dir, repo_dir, sibling_worktrees or []),
+                *_coral_install_reads(),
+                *home_paths,
+                *cfg.allow_read,
+            ],
+            "allowWrite": [
+                str(worktree_path.resolve()),
+                # Notes, attempts, eval logs, and the checkpoint repo all live
+                # under .coral/ and are written from agent-side `coral` commands.
+                str(coral_dir.resolve()),
+                # Worktree commits (coral eval) write objects/refs into the
+                # run repo's .git; srt's built-in protections still deny
+                # .git/hooks and .git/config within it.
+                str((repo_dir / ".git").resolve()),
+                *home_paths,
+                "/tmp",
+                "/private/tmp",  # macOS: /tmp resolves here
+                *cfg.allow_write,
+            ],
+            "denyWrite": [private_dir],
+        },
+        # Runtime CLIs allocate ptys for their shell tools (macOS-only knob).
+        "allowPty": True,
+    }
+
+    if cfg.network == "open":
+        if proxy_port is None:
+            raise ValueError("sandbox.network='open' requires a running allow-all proxy")
+        settings["network"]["httpProxyPort"] = proxy_port
+    else:
+        # The srt CLI registers no ask-callback, so unmatched hosts are denied
+        # regardless; strictAllowlist documents that this list is policy.
+        settings["network"]["strictAllowlist"] = True
+
+    return _deep_merge(settings, cfg.extra_settings)
+
+
+def srt_command_prefix(srt_command: list[str], settings_path: Path) -> list[str]:
+    """Command prefix that wraps a runtime command in the srt sandbox.
+
+    The trailing ``--`` makes srt's CLI treat the entire runtime command as
+    positional arguments, so runtime flags (``-p``, ``-c``, ``--model``) can
+    never collide with srt's own options.
+    """
+    return [*srt_command, "--settings", str(settings_path), "--"]
+
+
+class AllowAllProxy:
+    """Minimal allow-all HTTP forward proxy backing ``sandbox.network: open``.
+
+    Handles CONNECT tunnels (all HTTPS/TLS traffic — git, pip, npm, model
+    APIs) and single-request absolute-URI plain HTTP. Runs entirely in
+    daemon threads inside the manager process: nothing extra to supervise,
+    and it dies with the run.
+    """
+
+    _HEAD_LIMIT = 64 * 1024
+    _CONNECT_TIMEOUT = 30.0
+
+    def __init__(self, host: str = "127.0.0.1") -> None:
+        self._host = host
+        self._listener: socket.socket | None = None
+        self._thread: threading.Thread | None = None
+        self._stopping = threading.Event()
+        self.port: int | None = None
+
+    def start(self) -> int:
+        """Bind an ephemeral port and start accepting. Returns the port."""
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind((self._host, 0))
+        listener.listen(128)
+        self._listener = listener
+        self.port = listener.getsockname()[1]
+        self._thread = threading.Thread(
+            target=self._serve, name="coral-sandbox-proxy", daemon=True
+        )
+        self._thread.start()
+        return self.port
+
+    def stop(self) -> None:
+        self._stopping.set()
+        if self._listener is not None:
+            try:
+                self._listener.close()
+            except OSError:
+                pass
+            self._listener = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+    def _serve(self) -> None:
+        assert self._listener is not None
+        while not self._stopping.is_set():
+            try:
+                conn, _addr = self._listener.accept()
+            except OSError:
+                break  # listener closed by stop()
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn: socket.socket) -> None:
+        try:
+            head = self._read_head(conn)
+            if head is None:
+                return
+            request_line, rest = head.split(b"\r\n", 1)
+            parts = request_line.decode("latin-1", "replace").split(" ")
+            if len(parts) != 3:
+                conn.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+                return
+            method, target, version = parts
+            if method.upper() == "CONNECT":
+                self._tunnel(conn, target)
+            else:
+                self._forward_http(conn, method, target, version, rest)
+        except OSError:
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    def _read_head(self, conn: socket.socket) -> bytes | None:
+        """Read up to and including the request-head terminator."""
+        conn.settimeout(self._CONNECT_TIMEOUT)
+        head = b""
+        while b"\r\n\r\n" not in head:
+            if len(head) > self._HEAD_LIMIT:
+                return None
+            chunk = conn.recv(8192)
+            if not chunk:
+                return None
+            head += chunk
+        return head
+
+    @staticmethod
+    def _split_host_port(authority: str, default_port: int) -> tuple[str, int]:
+        if authority.startswith("["):  # [ipv6]:port
+            host, _, rest = authority[1:].partition("]")
+            port = int(rest[1:]) if rest.startswith(":") else default_port
+            return host, port
+        host, sep, port_s = authority.rpartition(":")
+        if sep and port_s.isdigit():
+            return host, int(port_s)
+        return authority, default_port
+
+    def _dial(self, authority: str, default_port: int) -> socket.socket:
+        host, port = self._split_host_port(authority, default_port)
+        return socket.create_connection((host, port), timeout=self._CONNECT_TIMEOUT)
+
+    def _tunnel(self, conn: socket.socket, target: str) -> None:
+        """CONNECT: open a raw tunnel and relay bytes both ways."""
+        try:
+            upstream = self._dial(target, 443)
+        except OSError:
+            conn.sendall(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+            return
+        with upstream:
+            conn.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            self._relay(conn, upstream)
+
+    def _forward_http(
+        self, conn: socket.socket, method: str, target: str, version: str, rest: bytes
+    ) -> None:
+        """Absolute-URI plain HTTP: rewrite to origin-form and relay.
+
+        Transparent single-request forwarding (each keep-alive request on
+        this connection must target the same host, which real clients do).
+        Plain HTTP through a proxy is rare — HTTPS goes via CONNECT above.
+        """
+        if "://" not in target:
+            conn.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            return
+        authority_and_path = target.split("://", 1)[1]
+        authority, slash, path = authority_and_path.partition("/")
+        try:
+            upstream = self._dial(authority, 80)
+        except OSError:
+            conn.sendall(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+            return
+        with upstream:
+            origin_line = f"{method} {slash + path or '/'} {version}".encode("latin-1")
+            upstream.sendall(origin_line + b"\r\n" + rest)
+            self._relay(conn, upstream)
+
+    @staticmethod
+    def _relay(a: socket.socket, b: socket.socket) -> None:
+        """Shuttle bytes between two sockets until either side closes."""
+        a.settimeout(None)
+        b.settimeout(None)
+        sockets = [a, b]
+        peer = {a: b, b: a}
+        while True:
+            readable, _, errored = select.select(sockets, [], sockets, 300)
+            if errored or not readable:
+                return
+            for sock in readable:
+                try:
+                    data = sock.recv(65536)
+                except OSError:
+                    return
+                if not data:
+                    return
+                try:
+                    peer[sock].sendall(data)
+                except OSError:
+                    return

--- a/coral/template/presets/sandbox.yaml
+++ b/coral/template/presets/sandbox.yaml
@@ -1,0 +1,17 @@
+# Wrap every agent in Anthropic's sandbox-runtime (`srt`) for OS-level
+# enforcement of CORAL's isolation boundaries: reads are confined to the
+# agent's slice of this run (own worktree, run repo, shared .coral/ state
+# minus private/, grader source) plus toolchain dotdirs — other runs,
+# sibling worktrees, and host secrets (~/.ssh, ~/.aws) are unreadable.
+# Writes are allow-listed to the same slice. Network traffic flows through
+# an allow-all proxy (full network access, proxy-mediated).
+#
+# Requires: npm install -g @anthropic-ai/sandbox-runtime
+# Linux additionally: bubblewrap, socat, ripgrep
+#
+# Usage in task.yaml:   preset: sandbox
+# Or ad hoc:            coral start -c task.yaml agents.sandbox.enabled=true
+agents:
+  sandbox:
+    enabled: true
+    network: open

--- a/coral/template/skills/create-notes/scripts/lint.py
+++ b/coral/template/skills/create-notes/scripts/lint.py
@@ -242,7 +242,7 @@ def _lint_note(
 
     confidence = meta.get("confidence")
     if confidence is not None:
-        if isinstance(confidence, (int, float)) and not isinstance(confidence, bool):
+        if isinstance(confidence, int | float) and not isinstance(confidence, bool):
             warnings.append(
                 f"`confidence: {confidence}` is a number — the schema is now "
                 f"{sorted(CONFIDENCE_VOCAB)}; map low (<0.4) / medium / high (>0.7)"

--- a/coral/web/api.py
+++ b/coral/web/api.py
@@ -302,7 +302,7 @@ async def get_logs(request: Request) -> JSONResponse:
         agg_usage: dict[str, int] = {}
         for m in all_session_metas:
             for k, v in m.get("usage", {}).items():
-                if isinstance(v, (int, float)):
+                if isinstance(v, int | float):
                     agg_usage[k] = agg_usage.get(k, 0) + int(v)
         agent_meta = {
             "total_cost_usd": total_cost,

--- a/coral/workspace/repo.py
+++ b/coral/workspace/repo.py
@@ -29,6 +29,22 @@ def _clean_env() -> dict[str, str]:
     return env
 
 
+def _pin_hooks_path(dest: Path) -> None:
+    """Point the run repo's core.hooksPath at its own (empty) hooks dir.
+
+    A user-level core.hooksPath (e.g. ~/.git-hooks with a pre-commit) would
+    otherwise fire personal hooks on every mechanical agent commit — and
+    under the srt sandbox those hook files are unreadable, so every
+    `coral eval` commit would fail. The local setting overrides the global
+    one; the absolute path matters because worktrees resolve a relative
+    hooksPath against their own toplevel.
+    """
+    subprocess.run(
+        ["git", "-C", str(dest), "config", "core.hooksPath", str(dest / ".git" / "hooks")],
+        capture_output=True,
+    )
+
+
 def clone_or_init_repo(source: Path, dest: Path) -> Path:
     """Clone source repo to dest, or init a new one if source doesn't exist.
 
@@ -45,6 +61,7 @@ def clone_or_init_repo(source: Path, dest: Path) -> Path:
         if result.returncode != 0:
             raise RuntimeError(f"git clone failed: {result.stderr}")
         logger.debug(f"Clone: {result.stdout.strip()}")
+        _pin_hooks_path(dest)
         return dest
 
     if source.name.endswith(".git"):
@@ -57,6 +74,7 @@ def clone_or_init_repo(source: Path, dest: Path) -> Path:
         )
         if result.returncode != 0:
             raise RuntimeError(f"git clone failed: {result.stderr}")
+        _pin_hooks_path(dest)
         return dest
 
     # No git repo at source — init a fresh one at dest
@@ -86,6 +104,7 @@ def clone_or_init_repo(source: Path, dest: Path) -> Path:
         ["git", "-C", str(dest), "config", "user.name", "CORAL"],
         capture_output=True,
     )
+    _pin_hooks_path(dest)
     subprocess.run(
         ["git", "-C", str(dest), "add", "-A"],
         capture_output=True,

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,571 @@
+"""Tests for pluggable agent sandboxing (coral/sandbox/)."""
+
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import subprocess
+import sys
+import threading
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from coral.config import AgentConfig, CoralConfig, SandboxConfig
+from coral.sandbox import (
+    AgentSandboxContext,
+    AgentSandboxSpec,
+    SandboxProvider,
+    get_sandbox_provider,
+)
+from coral.sandbox.srt import (
+    AllowAllProxy,
+    SrtSandbox,
+    _cli_pythonpath_shim,
+    build_srt_settings,
+    ensure_sandbox_supported,
+    srt_command_prefix,
+)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_config_defaults():
+    cfg = SandboxConfig()
+    assert cfg.enabled is False
+    assert cfg.provider == "srt"
+    assert cfg.network == "open"
+    assert cfg.allowed_domains == []
+    assert cfg.srt_command == ["npx", "--no-install", "srt"]
+
+
+def test_sandbox_config_rejects_bad_network():
+    with pytest.raises(ValueError, match="'open' or 'allowlist'"):
+        SandboxConfig(network="unrestricted")
+
+
+def test_sandbox_config_rejects_empty_provider():
+    with pytest.raises(ValueError, match="provider"):
+        SandboxConfig(provider="")
+
+
+def test_sandbox_and_isolate_user_are_mutually_exclusive():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        AgentConfig(isolate_user="agent", sandbox=SandboxConfig(enabled=True))
+
+
+def test_agent_config_coerces_sandbox_dict():
+    cfg = AgentConfig(sandbox={"enabled": True, "network": "allowlist"})
+    assert isinstance(cfg.sandbox, SandboxConfig)
+    assert cfg.sandbox.enabled is True
+    assert cfg.sandbox.network == "allowlist"
+
+
+def test_sandbox_config_parses_from_task_yaml_dict():
+    cfg = CoralConfig.from_dict(
+        {
+            "task": {"name": "t", "description": "d"},
+            "agents": {
+                "sandbox": {
+                    "enabled": True,
+                    "network": "allowlist",
+                    "allowed_domains": ["github.com", "*.npmjs.org"],
+                }
+            },
+        }
+    )
+    assert cfg.agents.sandbox.enabled is True
+    assert cfg.agents.sandbox.allowed_domains == ["github.com", "*.npmjs.org"]
+
+
+def test_sandbox_preset_enables_sandbox():
+    cfg = CoralConfig.from_dict({"task": {"name": "t", "description": "d"}, "preset": "sandbox"})
+    assert cfg.agents.sandbox.enabled is True
+    assert cfg.agents.sandbox.network == "open"
+
+
+# ---------------------------------------------------------------------------
+# Registry / protocol
+# ---------------------------------------------------------------------------
+
+
+class DummyProvider:
+    """Minimal out-of-tree provider used to exercise the entrypoint path."""
+
+    def __init__(self, cfg: SandboxConfig) -> None:
+        self.cfg = cfg
+
+    def validate(self, agents: AgentConfig) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def prepare_agent(self, ctx: AgentSandboxContext) -> AgentSandboxSpec:
+        return AgentSandboxSpec(command_prefix=["dummy-exec", "--"], env={"DUMMY": "1"})
+
+
+def test_registry_resolves_builtin_srt():
+    provider = get_sandbox_provider(SandboxConfig(enabled=True))
+    assert isinstance(provider, SrtSandbox)
+    assert isinstance(provider, SandboxProvider)
+
+
+def test_registry_resolves_custom_entrypoint():
+    cfg = SandboxConfig(enabled=True, provider="tests.test_sandbox:DummyProvider")
+    provider = get_sandbox_provider(cfg)
+    assert isinstance(provider, DummyProvider)
+    assert isinstance(provider, SandboxProvider)
+    assert provider.cfg is cfg
+
+
+def test_registry_rejects_unknown_provider():
+    with pytest.raises(ValueError, match="Unknown sandbox provider"):
+        get_sandbox_provider(SandboxConfig(enabled=True, provider="e2b"))
+
+
+def test_registry_rejects_unloadable_entrypoint():
+    with pytest.raises(ValueError, match="Cannot load"):
+        get_sandbox_provider(SandboxConfig(enabled=True, provider="no.such.module:Nope"))
+
+
+# ---------------------------------------------------------------------------
+# srt settings generation
+# ---------------------------------------------------------------------------
+
+
+def _paths(tmp_path: Path) -> dict[str, Path | str]:
+    worktree = tmp_path / "agents" / "agent-1"
+    coral_dir = tmp_path / ".coral"
+    repo_dir = tmp_path / "repo"
+    for p in (worktree, coral_dir / "private", coral_dir / "public", repo_dir / ".git"):
+        p.mkdir(parents=True)
+    return {
+        "worktree_path": worktree,
+        "coral_dir": coral_dir,
+        "repo_dir": repo_dir,
+        "shared_dir_name": ".claude",
+    }
+
+
+def test_build_settings_reads_confined_to_run(tmp_path):
+    paths = _paths(tmp_path)
+    settings = build_srt_settings(SandboxConfig(enabled=True), proxy_port=12345, **paths)
+
+    fs = settings["filesystem"]
+    private = str((tmp_path / ".coral" / "private").resolve())
+    # Home is denied wholesale; the run slice + toolchain dotdirs come back.
+    assert str(Path.home()) in fs["denyRead"]
+    assert private in fs["denyRead"]
+    allow_read = fs["allowRead"]
+    # The agents/ parent grants every worktree — reading siblings' trees is
+    # part of the shared-knowledge design; writes stay own-worktree-only.
+    assert str((tmp_path / "agents").resolve()) in allow_read
+    assert str((tmp_path / "repo").resolve()) in allow_read
+    assert str((tmp_path / ".coral" / "public").resolve()) in allow_read
+    assert str(Path.home() / ".claude") in allow_read
+    assert str(Path.home() / ".claude.json") in allow_read
+    # Nothing allowed back may be an ancestor of private/ — srt read rules
+    # are allow-beats-deny, so an ancestor grant would resurrect it.
+    for path in allow_read:
+        assert not private.startswith(path + "/") and path != private
+
+
+def test_build_settings_writes(tmp_path):
+    paths = _paths(tmp_path)
+    settings = build_srt_settings(SandboxConfig(enabled=True), proxy_port=12345, **paths)
+
+    fs = settings["filesystem"]
+    private = str((tmp_path / ".coral" / "private").resolve())
+    assert private in fs["denyWrite"]
+    assert str((tmp_path / "agents" / "agent-1").resolve()) in fs["allowWrite"]
+    assert str((tmp_path / ".coral").resolve()) in fs["allowWrite"]
+    assert str((tmp_path / "repo" / ".git").resolve()) in fs["allowWrite"]
+    # Home is NOT writable wholesale — only the toolchain dotdirs.
+    assert str(Path.home()) not in fs["allowWrite"]
+    assert str(Path.home() / ".claude") in fs["allowWrite"]
+
+
+def test_build_settings_grader_source_readable(tmp_path):
+    paths = _paths(tmp_path)
+    # Simulate a task dir with a grader package, referenced by the
+    # .coral/config_dir breadcrumb (how grader_source_dir resolves it).
+    task_dir = tmp_path / "task"
+    (task_dir / "grader").mkdir(parents=True)
+    (task_dir / "taskdata").mkdir()  # hidden-data sibling must stay denied
+    (paths["coral_dir"] / "config_dir").write_text(str(task_dir))
+
+    settings = build_srt_settings(SandboxConfig(enabled=True), proxy_port=1, **paths)
+    allow_read = settings["filesystem"]["allowRead"]
+    assert str((task_dir / "grader").resolve()) in allow_read
+    assert str((task_dir / "taskdata").resolve()) not in allow_read
+
+
+def test_build_settings_coral_install_readable(tmp_path):
+    """Agents must resolve `coral` to the manager's own installation.
+
+    Without these grants a dev checkout's venv is unreadable in the sandbox
+    and the shell's PATH search silently falls through to whatever stale
+    `coral` is readable (e.g. an old uv tool install), whose hooks write
+    attempts where this run's daemon never looks.
+    """
+    import coral as coral_pkg
+
+    settings = build_srt_settings(SandboxConfig(enabled=True), proxy_port=1, **_paths(tmp_path))
+    allow_read = settings["filesystem"]["allowRead"]
+    assert str(Path(sys.prefix).resolve()) in allow_read
+    assert str(Path(coral_pkg.__file__).resolve().parent) in allow_read
+
+
+def test_build_settings_multi_island_roster(tmp_path):
+    """The manager's island-mate roster drives worktree reads — including
+    worktrees that don't exist on disk yet (initial start spawns agents one
+    by one, so later island-mates are pre-granted by path)."""
+    paths = _paths(tmp_path)
+    (tmp_path / ".coral" / "islands").mkdir()
+    own = tmp_path / "agents" / "agent-1"
+    unborn_mate = tmp_path / "agents" / "agent-2"  # deliberately not created
+    foreigner = tmp_path / "agents" / "agent-3"
+    foreigner.mkdir()
+
+    allow_read = build_srt_settings(
+        SandboxConfig(enabled=True),
+        proxy_port=1,
+        sibling_worktrees=[own, unborn_mate],
+        **paths,
+    )["filesystem"]["allowRead"]
+    assert str(own.resolve()) in allow_read
+    assert str(unborn_mate.resolve()) in allow_read
+    assert str(foreigner.resolve()) not in allow_read
+    assert str((tmp_path / "agents").resolve()) not in allow_read
+
+
+def test_build_settings_multi_island_breadcrumb_fallback(tmp_path):
+    """Without a roster (direct API use), island membership falls back to
+    each worktree's .coral_island breadcrumb — reads stop at the island
+    boundary; islands exchange work only through migration."""
+    paths = _paths(tmp_path)
+    (tmp_path / ".coral" / "islands").mkdir()
+    own = tmp_path / "agents" / "agent-1"
+    (own / ".coral_island").write_text("avalon\n")
+    islandmate = tmp_path / "agents" / "agent-2"
+    islandmate.mkdir()
+    (islandmate / ".coral_island").write_text("avalon\n")
+    foreigner = tmp_path / "agents" / "agent-3"
+    foreigner.mkdir()
+    (foreigner / ".coral_island").write_text("atlantis\n")
+
+    allow_read = build_srt_settings(SandboxConfig(enabled=True), proxy_port=1, **paths)[
+        "filesystem"
+    ]["allowRead"]
+    assert str(own.resolve()) in allow_read
+    assert str(islandmate.resolve()) in allow_read
+    assert str(foreigner.resolve()) not in allow_read
+    assert str((tmp_path / "agents").resolve()) not in allow_read
+
+
+def test_cli_pythonpath_shim_editable_install(tmp_path):
+    """Editable installs get a symlink shim on PYTHONPATH — the .pth path
+    entry (the checkout root) can never be allowed back in the sandbox."""
+    run_dir = tmp_path / "run"
+    prefix = tmp_path / "venv"
+    prefix.mkdir()
+    pkg = tmp_path / "checkout" / "coral"
+    pkg.mkdir(parents=True)
+
+    env = _cli_pythonpath_shim(run_dir, pkg, prefix)
+    shim = run_dir / ".sandbox" / "pythonpath"
+    assert env == {"PYTHONPATH": str(shim)}
+    assert (shim / "coral").readlink() == pkg
+
+    # Re-preparing repoints the symlink when the checkout moved.
+    pkg2 = tmp_path / "checkout2" / "coral"
+    pkg2.mkdir(parents=True)
+    _cli_pythonpath_shim(run_dir, pkg2, prefix)
+    assert (shim / "coral").readlink() == pkg2
+
+
+def test_cli_pythonpath_shim_noop_for_normal_install(tmp_path):
+    """A coral installed inside the interpreter prefix needs no shim —
+    sys.prefix is already in allowRead."""
+    prefix = tmp_path / "venv"
+    pkg = prefix / "lib" / "site-packages" / "coral"
+    pkg.mkdir(parents=True)
+
+    assert _cli_pythonpath_shim(tmp_path / "run", pkg, prefix) == {}
+    assert not (tmp_path / "run" / ".sandbox").exists()
+
+
+def test_build_settings_open_mode_network(tmp_path):
+    settings = build_srt_settings(SandboxConfig(enabled=True), proxy_port=12345, **_paths(tmp_path))
+    # Open mode: no domain allowlist, all traffic via the external proxy.
+    assert settings["network"]["allowedDomains"] == []
+    assert settings["network"]["httpProxyPort"] == 12345
+    assert "strictAllowlist" not in settings["network"]
+
+
+def test_build_settings_open_mode_requires_proxy(tmp_path):
+    with pytest.raises(ValueError, match="allow-all proxy"):
+        build_srt_settings(SandboxConfig(enabled=True), proxy_port=None, **_paths(tmp_path))
+
+
+def test_build_settings_allowlist_mode(tmp_path):
+    cfg = SandboxConfig(enabled=True, network="allowlist", allowed_domains=["github.com"])
+    settings = build_srt_settings(cfg, proxy_port=None, **_paths(tmp_path))
+    assert settings["network"]["allowedDomains"] == ["github.com"]
+    assert settings["network"]["strictAllowlist"] is True
+    assert "httpProxyPort" not in settings["network"]
+
+
+def test_build_settings_extra_paths_and_deep_merge(tmp_path):
+    cfg = SandboxConfig(
+        enabled=True,
+        deny_read=["/opt/secrets"],
+        allow_read=["/opt/datasets"],
+        allow_write=["/scratch"],
+        extra_settings={
+            "enableWeakerNestedSandbox": True,
+            "network": {"allowLocalBinding": False},
+        },
+    )
+    settings = build_srt_settings(cfg, proxy_port=1, **_paths(tmp_path))
+    assert "/opt/secrets" in settings["filesystem"]["denyRead"]
+    assert "/opt/datasets" in settings["filesystem"]["allowRead"]
+    assert "/scratch" in settings["filesystem"]["allowWrite"]
+    # extra_settings deep-merges: sibling network keys survive, override wins.
+    assert settings["enableWeakerNestedSandbox"] is True
+    assert settings["network"]["allowLocalBinding"] is False
+    assert settings["network"]["httpProxyPort"] == 1
+
+
+def test_srt_command_prefix_ends_with_separator():
+    # The trailing "--" is load-bearing: without it, runtime flags like -c
+    # or -p would be parsed as srt's own options.
+    prefix = srt_command_prefix(["npx", "--no-install", "srt"], Path("/x.json"))
+    assert prefix == ["npx", "--no-install", "srt", "--settings", "/x.json", "--"]
+
+
+# ---------------------------------------------------------------------------
+# SrtSandbox provider lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _ctx(paths: dict[str, Path | str]) -> AgentSandboxContext:
+    return AgentSandboxContext(
+        agent_id="agent-1",
+        worktree_path=paths["worktree_path"],
+        coral_dir=paths["coral_dir"],
+        repo_dir=paths["repo_dir"],
+        shared_dir_name=paths["shared_dir_name"],
+    )
+
+
+def test_srt_provider_open_mode_lifecycle(tmp_path):
+    paths = _paths(tmp_path)
+    provider = SrtSandbox(SandboxConfig(enabled=True, srt_command=["srt"]))
+    provider.start()
+    try:
+        assert provider._proxy is not None
+        port = provider._proxy.port
+        spec = provider.prepare_agent(_ctx(paths))
+        settings_path = paths["coral_dir"] / "private" / "sandbox" / "agent-1.json"
+        assert settings_path.exists()
+        assert json.loads(settings_path.read_text())["network"]["httpProxyPort"] == port
+        assert spec.command_prefix == ["srt", "--settings", str(settings_path), "--"]
+        # srt injects proxy env into its child itself; the spec's own env
+        # carries at most the editable-install PYTHONPATH shim (present when
+        # this test runs from a dev checkout, absent for normal installs).
+        assert set(spec.env) <= {"PYTHONPATH"}
+    finally:
+        provider.stop()
+    assert provider._proxy is None
+
+
+def test_srt_provider_allowlist_mode_needs_no_proxy(tmp_path):
+    paths = _paths(tmp_path)
+    provider = SrtSandbox(
+        SandboxConfig(enabled=True, network="allowlist", allowed_domains=["github.com"])
+    )
+    provider.start()
+    assert provider._proxy is None
+    spec = provider.prepare_agent(_ctx(paths))
+    settings_path = paths["coral_dir"] / "private" / "sandbox" / "agent-1.json"
+    assert "httpProxyPort" not in json.loads(settings_path.read_text())["network"]
+    assert spec.command_prefix[:3] == ["npx", "--no-install", "srt"]
+    provider.stop()
+
+
+# ---------------------------------------------------------------------------
+# Claude Code permission mode under containment
+# ---------------------------------------------------------------------------
+
+
+def test_claude_permission_args_bypass_under_containment():
+    from coral.agent.builtin.claude_code import _permission_args
+
+    spec = AgentSandboxSpec(command_prefix=["srt", "--"])
+    user = {"uid": 1000, "gid": 1000, "home": "/home/agent"}
+    assert _permission_args(spec, None) == ["--dangerously-skip-permissions"]
+    assert _permission_args(None, user) == ["--dangerously-skip-permissions"]
+    assert _permission_args(spec, user) == ["--dangerously-skip-permissions"]
+    # Unconfined agents keep the advisory permission system in auto mode.
+    assert _permission_args(None, None) == ["--permission-mode", "auto"]
+
+
+# ---------------------------------------------------------------------------
+# Agent state marking
+# ---------------------------------------------------------------------------
+
+
+def test_agent_state_records_sandbox_provider():
+    from coral.agent.state import AgentRuntimeState
+
+    state = AgentRuntimeState(sandbox="srt")
+    assert AgentRuntimeState.from_dict(state.to_dict()).sandbox == "srt"
+    # Documents written before the field existed read back as unsandboxed.
+    assert AgentRuntimeState.from_dict({"state": "active"}).sandbox is None
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+def _mock_srt_probe(monkeypatch, returncode: int = 0, stderr: str = ""):
+    """Replace the `srt --version` probe subprocess with a canned result."""
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, returncode, stdout="1.0.0", stderr=stderr)
+
+    monkeypatch.setattr("coral.sandbox.srt.subprocess.run", fake_run)
+
+
+def test_preflight_unresolvable_srt_command(monkeypatch):
+    _mock_srt_probe(monkeypatch, returncode=1, stderr="npm error could not determine executable")
+    with pytest.raises(RuntimeError, match="sandbox-runtime"):
+        ensure_sandbox_supported(AgentConfig(sandbox=SandboxConfig(enabled=True)))
+
+
+def test_preflight_missing_npx(monkeypatch):
+    def raise_missing(cmd, **kwargs):
+        raise FileNotFoundError("npx")
+
+    monkeypatch.setattr("coral.sandbox.srt.subprocess.run", raise_missing)
+    with pytest.raises(RuntimeError, match="sandbox-runtime"):
+        ensure_sandbox_supported(AgentConfig(sandbox=SandboxConfig(enabled=True)))
+
+
+def test_preflight_rejects_isolate_user(monkeypatch):
+    _mock_srt_probe(monkeypatch)
+    agents = AgentConfig(sandbox=SandboxConfig(enabled=True))
+    agents.isolate_user = "agent"  # set post-construction, like the Docker session does
+    with pytest.raises(RuntimeError, match="isolate_user"):
+        ensure_sandbox_supported(agents)
+
+
+def test_preflight_passes_with_srt(monkeypatch):
+    _mock_srt_probe(monkeypatch)
+    monkeypatch.setattr("coral.sandbox.srt.sys.platform", "darwin")
+    ensure_sandbox_supported(AgentConfig(sandbox=SandboxConfig(enabled=True)))
+
+
+def test_preflight_missing_linux_deps(monkeypatch):
+    _mock_srt_probe(monkeypatch)
+    monkeypatch.setattr("coral.sandbox.srt.shutil.which", lambda binary: None)
+    monkeypatch.setattr("coral.sandbox.srt.sys.platform", "linux")
+    with pytest.raises(RuntimeError, match="bubblewrap"):
+        ensure_sandbox_supported(AgentConfig(sandbox=SandboxConfig(enabled=True)))
+
+
+# ---------------------------------------------------------------------------
+# Allow-all proxy
+# ---------------------------------------------------------------------------
+
+
+class _OkHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        body = b"ok"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # silence test output
+        pass
+
+
+@pytest.fixture
+def local_http_server():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _OkHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server.server_address
+    server.shutdown()
+
+
+@pytest.fixture
+def proxy():
+    p = AllowAllProxy()
+    p.start()
+    yield p
+    p.stop()
+
+
+def test_proxy_plain_http_forwarding(proxy, local_http_server):
+    host, port = local_http_server
+    opener = urllib.request.build_opener(
+        urllib.request.ProxyHandler({"http": f"http://127.0.0.1:{proxy.port}"})
+    )
+    with opener.open(f"http://{host}:{port}/", timeout=10) as resp:
+        assert resp.status == 200
+        assert resp.read() == b"ok"
+
+
+def test_proxy_connect_tunnel(proxy, local_http_server):
+    host, port = local_http_server
+    with socket.create_connection(("127.0.0.1", proxy.port), timeout=10) as conn:
+        conn.sendall(f"CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n".encode())
+        response = conn.recv(4096)
+        assert response.startswith(b"HTTP/1.1 200")
+        # Speak plain HTTP through the tunnel to prove bytes relay both ways.
+        conn.sendall(f"GET / HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n".encode())
+        data = b""
+        while True:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        assert b"200" in data and data.endswith(b"ok")
+
+
+def test_proxy_connect_unreachable_target_returns_502(proxy):
+    # Grab a port with no listener.
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    dead_port = probe.getsockname()[1]
+    probe.close()
+
+    with socket.create_connection(("127.0.0.1", proxy.port), timeout=10) as conn:
+        conn.sendall(f"CONNECT 127.0.0.1:{dead_port} HTTP/1.1\r\n\r\n".encode())
+        assert conn.recv(4096).startswith(b"HTTP/1.1 502")
+
+
+def test_proxy_bad_request_line(proxy):
+    with socket.create_connection(("127.0.0.1", proxy.port), timeout=10) as conn:
+        conn.sendall(b"NONSENSE\r\n\r\n")
+        assert conn.recv(4096).startswith(b"HTTP/1.1 400")
+
+
+def test_proxy_stop_closes_listener():
+    p = AllowAllProxy()
+    port = p.start()
+    p.stop()
+    with pytest.raises(OSError):
+        socket.create_connection(("127.0.0.1", port), timeout=1)


### PR DESCRIPTION
## What

`agents.sandbox`: pluggable OS-level per-agent sandboxing, with a built-in `srt` provider (Anthropic sandbox-runtime — Seatbelt on macOS, bubblewrap on Linux). Wraps each agent subprocess uniformly across all runtimes; composes with tmux/local sessions; mutually exclusive with `agents.isolate_user` / docker.

```bash
coral start -c task.yaml agents.sandbox.enabled=true   # or preset: sandbox
```

## Design

- **Protocol** (`coral/sandbox/protocol.py`): `SandboxProvider` — validate / start / stop / `prepare_agent(ctx) → AgentSandboxSpec(command_prefix, env)`. Custom backends (e2b, modal, ...) plug in via `agents.sandbox.provider = "module:Class"` without touching runtimes or the manager.
- **Read confinement** (`coral/sandbox/srt.py`): home is denied wholesale; allowed back are exactly — own + island-mate worktrees (from the manager's roster, correct before worktrees exist on disk), the run repo, `.coral` minus `private/`, the surfaced grader source, the CORAL installation itself, and the runtime's home dotdirs. Enumerated per-child because srt reads are allow-beats-deny: any ancestor grant would resurrect `.coral/private/`.
- **Network**: `open` (default) routes everything through an in-process allow-all proxy via srt's `httpProxyPort` seam (srt refuses wildcard allowlists by design); `allowlist` uses srt's own filtering against `allowed_domains`.
- **Editable installs**: agent-side `coral` must resolve to the manager's own installation; a run-local PYTHONPATH symlink shim keeps editable checkouts importable (the `.pth` checkout root can never be allowed back).
- **Permissions**: `claude_code` runs `--dangerously-skip-permissions` under OS containment (`IS_SANDBOX=1`), `--permission-mode auto` otherwise.
- `coral status` marks each agent with its sandbox provider; run repos pin `core.hooksPath` so personal git hooks never fire on mechanical agent commits.

## Validation

- 80+ unit tests (`tests/test_sandbox.py`): config, registry, settings generation (incl. the no-allowRead-ancestor-of-private invariant), permission args, preflight, provider lifecycle, live proxy round-trips.
- Live-validated end-to-end on a multi-island kernel-builder run: agents evaluated and scored inside the sandbox, blocked cleanly on every out-of-run probe, network via the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
