### PR TITLE
docs(contributing): all PRs target the dev branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!--
 Thanks for contributing to CORAL! A few notes before you submit:
 
+- Target the `dev` branch — all PRs go to `dev`, not `main` (see CONTRIBUTING.md).
 - See CONTRIBUTING.md for the full workflow.
 - Keep PRs scoped. Unrelated cleanups belong in a separate PR.
 - Make sure `uv run pytest tests/ -v` and `uv run ruff check .` pass locally.
@@ -45,6 +46,7 @@ Examples:
 
 ## Checklist
 
+- [ ] PR targets the `dev` branch (not `main`).
 - [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
 - [ ] `uv run pytest tests/ -v` passes locally.
 - [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ refactored, or generated code, tests, or docs. If you are not sure whether
 your workflow counts, it does — read on.
 
 > **TL;DR**
+> - All PRs target the `dev` branch, never `main` (see CONTRIBUTING.md).
 > - A human author must read every changed line and be able to defend the design end-to-end.
 > - No drive-by mechanical PRs (lone typo fixes, single-line style nits, batch reformat across the repo).
 > - Don't open duplicate PRs against the same issue. Check first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,11 @@ grader daemon, heartbeats, and the runtime registry.
 
 ## Branches and commits
 
-- Create a topic branch off `main`. Suggested naming: `feat/<short-desc>`,
+- CORAL uses a two-branch model: **`dev` is the integration branch** where all
+  day-to-day development lands, and `main` tracks releases. Maintainers merge
+  `dev` into `main` as part of the release process — **all PRs must target
+  `dev`**, never `main` directly.
+- Create a topic branch off `dev`. Suggested naming: `feat/<short-desc>`,
   `fix/<short-desc>`, `docs/<short-desc>`, `refactor/<short-desc>`.
 - Keep commits focused. Prefer several small, reviewable commits over one
   large one.
@@ -80,7 +84,8 @@ grader daemon, heartbeats, and the runtime registry.
 
 1. Fork the repo (external contributors) or push your branch (maintainers).
 2. Make sure tests, `ruff check`, and `ruff format` all pass.
-3. Open a PR against `main` with:
+3. Open a PR against `dev` (PRs against `main` will be retargeted or closed)
+   with:
    - a short **summary** of what changed and **why**,
    - a **test plan** (commands you ran, manual checks, screenshots if UI),
    - links to any related issues or discussions.


### PR DESCRIPTION
## Motivation

CI now runs on `dev` as the staging/integration branch (3e4d402), but the contributing docs still tell contributors to branch off and open PRs against `main`. This aligns the docs with the actual workflow: **all PRs go to `dev`**, and `main` tracks releases.

## Changes

- **CONTRIBUTING.md** — document the two-branch model (`dev` = integration, `main` = releases); topic branches now branch off `dev`; PRs open against `dev` (PRs against `main` will be retargeted or closed).
- **.github/PULL_REQUEST_TEMPLATE.md** — add a top-of-template reminder to target `dev`, plus a checklist item.
- **AGENTS.md** — add the target-branch rule to the TL;DR so AI-assisted contributors see it too.

## Test plan

Docs-only change — proofread the rendered markdown; no code or tests affected.

## Affected areas

- [x] Other: contribution docs (CONTRIBUTING.md, PR template, AGENTS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)