### PR TITLE
fix(sandbox): inject SSL_CERT_FILE so rustls CLIs (codex) work under srt

### DIFF
--- a/coral/agent/runtime.py
+++ b/coral/agent/runtime.py
@@ -74,9 +74,11 @@ def apply_sandbox(cmd: list[str], sandbox: AgentSandboxSpec | None) -> list[str]
 def apply_sandbox_env(env: dict[str, str], sandbox: AgentSandboxSpec | None) -> None:
     """Merge the sandbox spec's env into the agent environment, in place.
 
-    Empty for the srt backend (srt injects its proxy vars into the child
-    itself); remote/shim backends carry endpoints and credentials here
-    rather than in the command prefix (argv is visible in ``ps``).
+    For the srt backend this carries the editable-install PYTHONPATH shim
+    and the SSL_CERT_FILE override for rustls clients (srt injects its
+    proxy vars into the child itself); remote/shim backends carry
+    endpoints and credentials here rather than in the command prefix
+    (argv is visible in ``ps``).
     """
     if sandbox is not None and sandbox.env:
         env.update(sandbox.env)

--- a/coral/sandbox/srt.py
+++ b/coral/sandbox/srt.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import select
 import shutil
 import socket
@@ -97,8 +98,9 @@ class SrtSandbox:
 
         Regenerated on every (re)start so restarts pick up the current
         proxy port. srt injects the proxy env vars into its child itself;
-        the spec's own env only carries the editable-install PYTHONPATH
-        shim (see :func:`_cli_pythonpath_shim`), when one is needed.
+        the spec's own env carries the editable-install PYTHONPATH shim
+        (see :func:`_cli_pythonpath_shim`), when one is needed, plus the
+        TLS bundle override for rustls clients (:func:`_tls_cert_env`).
         """
         settings = build_srt_settings(
             self.cfg,
@@ -126,6 +128,7 @@ class SrtSandbox:
             Path(coral.__file__).resolve().parent,
             Path(sys.prefix).resolve(),
         )
+        env.update(_tls_cert_env())
         return AgentSandboxSpec(
             command_prefix=srt_command_prefix(self.cfg.srt_command, settings_path),
             env=env,
@@ -337,6 +340,25 @@ def _cli_pythonpath_shim(run_dir: Path, package_dir: Path, prefix: Path) -> dict
     link.unlink(missing_ok=True)  # repoint if the checkout moved since last start
     link.symlink_to(package_dir)
     return {"PYTHONPATH": str(shim_dir)}
+
+
+def _tls_cert_env() -> dict[str, str]:
+    """Point rustls-based CLIs (codex) at the PEM root-cert bundle.
+
+    On macOS, rustls-native-certs loads roots by querying the system
+    keychain's trust settings through the Security framework, which
+    Seatbelt denies inside the sandbox — every HTTPS request then fails
+    with reqwest's generic "error sending request", while curl (which
+    reads /etc/ssl/cert.pem) works fine. SSL_CERT_FILE short-circuits the
+    keychain lookup to a plain file read the sandbox allows. Respect an
+    existing SSL_CERT_FILE (it propagates via the inherited environment).
+    """
+    if os.environ.get("SSL_CERT_FILE"):
+        return {}
+    for candidate in ("/etc/ssl/cert.pem", "/etc/ssl/certs/ca-certificates.crt"):
+        if Path(candidate).is_file():
+            return {"SSL_CERT_FILE": candidate}
+    return {}
 
 
 def build_srt_settings(

--- a/coral/template/presets/sandbox.yaml
+++ b/coral/template/presets/sandbox.yaml
@@ -14,4 +14,5 @@
 agents:
   sandbox:
     enabled: true
+    provider: srt
     network: open

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -24,6 +24,7 @@ from coral.sandbox.srt import (
     AllowAllProxy,
     SrtSandbox,
     _cli_pythonpath_shim,
+    _tls_cert_env,
     build_srt_settings,
     ensure_sandbox_supported,
     srt_command_prefix,
@@ -303,6 +304,26 @@ def test_cli_pythonpath_shim_noop_for_normal_install(tmp_path):
     assert not (tmp_path / "run" / ".sandbox").exists()
 
 
+def test_tls_cert_env_respects_existing_override(monkeypatch):
+    """A user-set SSL_CERT_FILE propagates via the inherited environment —
+    the spec must not clobber it."""
+    monkeypatch.setenv("SSL_CERT_FILE", "/custom/bundle.pem")
+    assert _tls_cert_env() == {}
+
+
+def test_tls_cert_env_points_at_pem_bundle(monkeypatch):
+    """rustls clients (codex) cannot query the macOS keychain inside the
+    sandbox; the spec points them at the host's PEM bundle instead."""
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    env = _tls_cert_env()
+    if env:  # host has a bundle at a known path (macOS/Linux defaults)
+        assert Path(env["SSL_CERT_FILE"]).is_file()
+    else:  # no known bundle on this host — nothing to point at
+        assert not any(
+            Path(p).is_file() for p in ("/etc/ssl/cert.pem", "/etc/ssl/certs/ca-certificates.crt")
+        )
+
+
 def test_build_settings_open_mode_network(tmp_path):
     settings = build_srt_settings(SandboxConfig(enabled=True), proxy_port=12345, **_paths(tmp_path))
     # Open mode: no domain allowlist, all traffic via the external proxy.
@@ -381,8 +402,10 @@ def test_srt_provider_open_mode_lifecycle(tmp_path):
         assert spec.command_prefix == ["srt", "--settings", str(settings_path), "--"]
         # srt injects proxy env into its child itself; the spec's own env
         # carries at most the editable-install PYTHONPATH shim (present when
-        # this test runs from a dev checkout, absent for normal installs).
-        assert set(spec.env) <= {"PYTHONPATH"}
+        # this test runs from a dev checkout, absent for normal installs)
+        # and the SSL_CERT_FILE override for rustls clients (present when
+        # the host has a PEM bundle at a known path).
+        assert set(spec.env) <= {"PYTHONPATH", "SSL_CERT_FILE"}
     finally:
         provider.stop()
     assert provider._proxy is None


### PR DESCRIPTION
## Problem

With `agents.sandbox.enabled=true` and `agents.runtime: codex`, every model request fails immediately and the agent loops forever:

```
ERROR: Reconnecting... 1/5
...
ERROR: stream disconnected before completion: error sending request for url (xxx)
```

## Root cause

codex is a Rust binary; rustls-native-certs loads root certificates on macOS by querying the system keychain's trust settings through the Security framework, which Seatbelt denies inside the srt sandbox. TLS setup fails before any bytes leave the machine, surfacing as reqwest's generic "error sending request".

Isolated empirically — each step verified inside the same sandbox settings the failing run used:

| Test | Result |
|---|---|
| curl inside sandbox (reads `/etc/ssl/cert.pem`) | ✅ |
| codex through CORAL's `AllowAllProxy`, outside sandbox | ✅ |
| codex through srt's internal proxy, outside sandbox | ✅ |
| codex inside sandbox | ❌ reproduces exactly |
| codex inside sandbox + `SSL_CERT_FILE=/etc/ssl/cert.pem` | ✅ |

So the proxy chain is fine; only in-sandbox cert loading is broken, and only for rustls clients (Node-based CLIs bundle their own CA store).

## Fix

`SrtSandbox.prepare_agent` now injects `SSL_CERT_FILE` into the agent env (`/etc/ssl/cert.pem`, falling back to Linux's `ca-certificates.crt`), short-circuiting the keychain lookup to a plain file read the sandbox allows. A user-set `SSL_CERT_FILE` is left untouched. Applies uniformly to all runtimes; harmless for those that don't read it.

Also spells out `provider: srt` explicitly in the sandbox preset for self-documentation (no behavior change — it's the default).

## Testing

- End-to-end: codex inside the srt sandbox via the real `prepare_agent` path completes a request through the allow-all proxy.
- Two new unit tests for `_tls_cert_env` (respects existing override; points at a real bundle).
- Full suite: 616 passed, 1 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)