### PR TITLE
example(kernel_builder): default to a sandboxed codex agent

### DIFF
--- a/examples/kernel_builder/task.yaml
+++ b/examples/kernel_builder/task.yaml
@@ -57,6 +57,17 @@ workspace:
   results_dir: "./results"
   repo_path: "./examples/kernel_builder/seed"
 
+islands:
+  count: 1
+
+agents:
+  count: 1
+  runtime: codex
+  sandbox:
+    enabled: true
+    provider: srt
+    network: open
+
 run:
   session: local
   docker_image: ""


### PR DESCRIPTION
## Motivation

The kernel_builder example carried no `agents:` section, so every run needed ad-hoc dotlist overrides to reproduce the configuration it's actually exercised with. Now that rustls cert loading works inside the srt sandbox (#167), the sandbox + codex combination is viable end-to-end and worth pinning as a working reference.

## Changes

Adds explicit `islands` / `agents` / `run` settings to `examples/kernel_builder/task.yaml`: one codex agent wrapped in the srt sandbox (`network: open`), single island, local (no-tmux) session. Config-only — no seed or grader changes.

## Test plan

- `coral validate examples/kernel_builder` — grader venv builds, seed scores 11,910 cycles (12.40x speedup).
- Smoke run of this exact config (codex inside the srt sandbox through the allow-all proxy) completes model requests end-to-end — this is the setup used to diagnose and verify #167.
- `uv run pytest tests/ -q` on the base branch state: 616 passed, 1 skipped; `ruff check .` clean (no Python changes here).

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [x] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change. (config-only example change; no behavior change in `coral/`)
- [ ] Updated docs for any user-visible or contract change. (n/a)
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path. (n/a)
- [x] **Modified `examples/<task>/`**: `coral validate examples/kernel_builder` succeeds. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)