### PR TITLE
release: promote dev to main (sandbox rustls cert fix)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!--
 Thanks for contributing to CORAL! A few notes before you submit:
 
+- Target the `dev` branch — all PRs go to `dev`, not `main` (see CONTRIBUTING.md).
 - See CONTRIBUTING.md for the full workflow.
 - Keep PRs scoped. Unrelated cleanups belong in a separate PR.
 - Make sure `uv run pytest tests/ -v` and `uv run ruff check .` pass locally.
@@ -45,6 +46,7 @@ Examples:
 
 ## Checklist
 
+- [ ] PR targets the `dev` branch (not `main`).
 - [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
 - [ ] `uv run pytest tests/ -v` passes locally.
 - [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ refactored, or generated code, tests, or docs. If you are not sure whether
 your workflow counts, it does — read on.
 
 > **TL;DR**
+> - All PRs target the `dev` branch, never `main` (see CONTRIBUTING.md).
 > - A human author must read every changed line and be able to defend the design end-to-end.
 > - No drive-by mechanical PRs (lone typo fixes, single-line style nits, batch reformat across the repo).
 > - Don't open duplicate PRs against the same issue. Check first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ coral start -c task.yaml agents.sandbox.enabled=true            # Wrap agents in
 coral start -c task.yaml run.session=local                      # No tmux session
 coral resume                                      # Resume latest run (sessions restored)
 coral resume -i "Try greedy approaches"           # Inject an instruction at resume
-coral resume --from <hash> -i "Continue this fork" # Reset an agent to an attempt, then inject instruction
+coral resume --from <hash> -i "Continue this fork" # Reset an agent to an attempt (later attempts are archived = soft-deleted), then inject instruction
 coral stop [--all]                                # Stop one or all active runs
 coral status                                      # Agent health + leaderboard
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,11 @@ grader daemon, heartbeats, and the runtime registry.
 
 ## Branches and commits
 
-- Create a topic branch off `main`. Suggested naming: `feat/<short-desc>`,
+- CORAL uses a two-branch model: **`dev` is the integration branch** where all
+  day-to-day development lands, and `main` tracks releases. Maintainers merge
+  `dev` into `main` as part of the release process — **all PRs must target
+  `dev`**, never `main` directly.
+- Create a topic branch off `dev`. Suggested naming: `feat/<short-desc>`,
   `fix/<short-desc>`, `docs/<short-desc>`, `refactor/<short-desc>`.
 - Keep commits focused. Prefer several small, reviewable commits over one
   large one.
@@ -80,7 +84,8 @@ grader daemon, heartbeats, and the runtime registry.
 
 1. Fork the repo (external contributors) or push your branch (maintainers).
 2. Make sure tests, `ruff check`, and `ruff format` all pass.
-3. Open a PR against `main` with:
+3. Open a PR against `dev` (PRs against `main` will be retargeted or closed)
+   with:
    - a short **summary** of what changed and **why**,
    - a **test plan** (commands you ran, manual checks, screenshots if UI),
    - links to any related issues or discussions.

--- a/coral/_version.py
+++ b/coral/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '0.7.3.dev4+gfb0a612b3.d20260701'
-__version_tuple__ = version_tuple = (0, 7, 3, 'dev4', 'gfb0a612b3.d20260701')
+__version__ = version = '0.7.5.dev4+g343f3e9ea'
+__version_tuple__ = version_tuple = (0, 7, 5, 'dev4', 'g343f3e9ea')
 
 __commit_id__ = commit_id = None

--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -272,7 +272,8 @@ class ClaudeCodeRuntime:
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
                 try:
-                    assert proc.stdout is not None
+                    if proc.stdout is None:
+                        return
                     for line in iter(proc.stdout.readline, b""):
                         decoded = line.decode("utf-8", errors="replace")
                         sys.stdout.write(f"[{agent}] {decoded}")

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -218,7 +218,8 @@ class CodexRuntime:
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
                 try:
-                    assert proc.stdout is not None
+                    if proc.stdout is None:
+                        return
                     for line in iter(proc.stdout.readline, b""):
                         decoded = line.decode("utf-8", errors="replace")
                         sys.stdout.write(f"[{agent}] {decoded}")

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -245,7 +245,8 @@ class CursorAgentRuntime:
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
                 try:
-                    assert proc.stdout is not None
+                    if proc.stdout is None:
+                        return
                     for line in iter(proc.stdout.readline, b""):
                         decoded = line.decode("utf-8", errors="replace")
                         sys.stdout.write(f"[{agent}] {decoded}")

--- a/coral/agent/builtin/kiro.py
+++ b/coral/agent/builtin/kiro.py
@@ -146,7 +146,8 @@ class KiroRuntime:
 
             def _tee_output(proc, log_f, agent):
                 try:
-                    assert proc.stdout is not None
+                    if proc.stdout is None:
+                        return
                     for line in iter(proc.stdout.readline, b""):
                         decoded = line.decode("utf-8", errors="replace")
                         sys.stdout.write(f"[{agent}] {decoded}")

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -202,7 +202,8 @@ class OpenCodeRuntime:
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
                 try:
-                    assert proc.stdout is not None
+                    if proc.stdout is None:
+                        return
                     for line in iter(proc.stdout.readline, b""):
                         decoded = line.decode("utf-8", errors="replace")
                         sys.stdout.write(f"[{agent}] {decoded}")

--- a/coral/agent/builtin/pi_agent.py
+++ b/coral/agent/builtin/pi_agent.py
@@ -213,7 +213,8 @@ class PiAgentRuntime:
 
             def _tee_output(proc: subprocess.Popen, log_f, agent: str) -> None:
                 try:
-                    assert proc.stdout is not None
+                    if proc.stdout is None:
+                        return
                     for line in iter(proc.stdout.readline, b""):
                         decoded = line.decode("utf-8", errors="replace")
                         sys.stdout.write(f"[{agent}] {decoded}")

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -14,6 +14,7 @@ import subprocess
 import threading
 import time
 from collections import deque
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,7 @@ from coral.agent.heartbeat import HeartbeatRunner
 from coral.agent.migration import (
     IslandRoster,
     MigrationCandidate,
+    MigrationResyncOp,
     MigrationRunner,
     choose_roster_balanced_subset,
 )
@@ -789,8 +791,15 @@ class AgentManager:
         idx: int,
         prompt: str,
         prompt_source: str | None = None,
+        pre_restart_ops: Sequence[Callable[[str], None]] = (),
     ) -> AgentHandle:
-        """Interrupt a running agent and resume with a feedback prompt."""
+        """Interrupt a running agent and resume with a feedback prompt.
+
+        ``pre_restart_ops`` run (with the agent id) in the quiet window
+        after the interrupt and before the restart — the slot for surgery
+        that needs the agent's process down, e.g. migration resync ops
+        rewriting launch-injected state.
+        """
         handle = self.handles[idx]
         agent_id = handle.agent_id
 
@@ -799,6 +808,8 @@ class AgentManager:
         # via the owning runtime after interrupt() returns.
         handle.interrupt()
         session_id = self._runtime_for(agent_id).extract_session_id(handle.log_path)
+        for op in pre_restart_ops:
+            op(agent_id)
         self._restart_counts[agent_id] = self._restart_counts.get(agent_id, 0) + 1
 
         if session_id:
@@ -1880,17 +1891,77 @@ class AgentManager:
                 )
             return False
 
+        applied: list[MigrationCandidate] = []
+        ok = True
         for candidate in migrations:
             try:
                 self._apply_migration(candidate, assume_preflight=True)
+                applied.append(candidate)
             except Exception as e:
                 logger.exception(
                     f"Migration {candidate.agent_id} {candidate.src_island}→"
                     f"{candidate.dst_island} failed: {e}"
                 )
-                return False
-        self._deferred_candidates = []
-        return True
+                ok = False
+                break
+        # Even a partially-applied batch changed the partition — resync
+        # bystanders for whatever actually moved.
+        self._resync_bystanders_after_migration(applied)
+        if ok:
+            self._deferred_candidates = []
+        return ok
+
+    def _migration_resync_ops(self) -> list[MigrationResyncOp]:
+        """Registry of resync ops for the standard bystander-resync phase.
+
+        Each op names a piece of launch-injected per-agent state that can
+        only follow an island-partition change through a restart; an op
+        contributes a ``prepare`` hook only for work the restart pipeline
+        (``_setup_and_start_agent``) does not already cover. No applicable
+        ops → the phase is a no-op.
+        """
+        ops: list[MigrationResyncOp] = []
+        if self._sandbox is not None:
+            # Sandbox read boundaries are baked into per-agent settings at
+            # launch; the restart regenerates them via prepare_agent, so no
+            # prepare hook is needed.
+            ops.append(MigrationResyncOp(name="sandbox"))
+        return ops
+
+    def _resync_bystanders_after_migration(self, applied: list[MigrationCandidate]) -> None:
+        """Standard post-migration phase: restart live bystanders on the
+        affected islands so launch-injected per-agent state follows the new
+        partition.
+
+        What needs resyncing is defined by :meth:`_migration_resync_ops` —
+        with no applicable ops (e.g. sandboxing disabled) this is a no-op.
+        Migrants are excluded (:meth:`_apply_migration` already restarted
+        them with fresh state); dead and paused agents pick everything up
+        on their own (re)start path. Sessions are resumed, so no work is
+        lost. Disable via ``islands.migration.resync_bystanders``.
+        """
+        ops = self._migration_resync_ops()
+        if not applied or not ops or not self.migration_config.resync_bystanders:
+            return
+        affected = {c.src_island for c in applied} | {c.dst_island for c in applied}
+        migrated = {c.agent_id for c in applied}
+        op_names = ", ".join(op.name for op in ops)
+        pre_restart_ops = [op.prepare for op in ops if op.prepare is not None]
+        for idx, handle in enumerate(self.handles):
+            agent_id = handle.agent_id
+            if agent_id in migrated or not handle.alive or self._is_paused(agent_id):
+                continue
+            if self._agent_island.get(agent_id) in affected:
+                logger.info(
+                    f"Migration resync ({op_names}): restarting {agent_id} "
+                    f"(island partition changed)"
+                )
+                self.handles[idx] = self._interrupt_and_resume(
+                    idx,
+                    prompt=_build_resync_prompt(op_names),
+                    prompt_source="migration:resync",
+                    pre_restart_ops=pre_restart_ops,
+                )
 
     def _migration_block_reason(self, candidate: MigrationCandidate) -> str | None:
         """Return why ``candidate`` cannot safely migrate right now, if any."""
@@ -2954,4 +3025,14 @@ def _build_migration_prompt(candidate: MigrationCandidate, *, shared_dir: str) -
         f"here so you don't reinvent it.\n\n"
         f"Then bring your strongest ideas from your previous run and "
         f"adapt them to this island's frontier."
+    )
+
+
+def _build_resync_prompt(op_names: str) -> str:
+    """Prompt for bystanders restarted by the post-migration resync phase."""
+    return (
+        "An agent migrated between islands, so your process was restarted "
+        f"to refresh launch-injected state ({op_names}) against the new "
+        "island roster. Your session and work are intact — continue exactly "
+        "where you left off."
     )

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -49,6 +49,7 @@ from coral.config import CoralConfig
 from coral.hub._island import island_root
 from coral.hub.attempts import (
     agent_in_grader_queue,
+    archive_attempts,
     get_leaderboard,
     read_attempts,
     read_eval_count,
@@ -901,6 +902,28 @@ class AgentManager:
             if action.id:
                 applied_actions.add(action.id)
 
+        # Reset matched worktrees before any agent starts, archiving the
+        # attempts on the discarded segments first (soft delete: the run has
+        # explicitly rewound past them, so leaderboard/status/log must stop
+        # showing them). The JSONs and git objects stay on disk.
+        for agent_dir in agent_dirs:
+            action = steering_by_agent.get(agent_dir.name)
+            if action is None:
+                continue
+            discarded = _discarded_commit_hashes(agent_dir, action.hash)
+            _reset_worktree_to_commit(agent_dir, action.hash)
+            if discarded:
+                archived = archive_attempts(
+                    paths.coral_dir,
+                    discarded,
+                    reason=f"discarded by resume --from {action.hash}",
+                )
+                if archived:
+                    logger.info(
+                        f"Archived {len(archived)} attempt(s) discarded by "
+                        f"resume --from {action.hash} ({agent_dir.name})"
+                    )
+
         handles = []
         for agent_dir in agent_dirs:
             agent_id = agent_dir.name
@@ -938,7 +961,6 @@ class AgentManager:
                 prompt = fresh_start_prompt
 
             if steering_action is not None:
-                _reset_worktree_to_commit(agent_dir, steering_action.hash)
                 prompt = _compose_resume_instruction(
                     base_prompt=prompt,
                     action=steering_action,
@@ -2858,6 +2880,19 @@ def _reset_worktree_to_commit(worktree_path: Path, target_hash: str) -> None:
     )
     if result.returncode != 0:
         raise RuntimeError(f"Steering checkout failed for '{target_hash}': {result.stderr}")
+
+
+def _discarded_commit_hashes(worktree_path: Path, target_hash: str) -> set[str]:
+    """Commits that a reset to target_hash drops from this worktree's HEAD."""
+    result = subprocess.run(
+        ["git", "rev-list", f"{target_hash}..HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=worktree_path,
+    )
+    if result.returncode != 0:
+        return set()
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
 
 
 def _worktree_head_descends_from(worktree_path: Path, target_hash: str) -> bool:

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -293,7 +293,8 @@ class AgentManager:
         still recorded in .coral/public/grader_daemon.pid — otherwise two
         daemons would race for the same pending attempts.
         """
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
 
         if self._grader_proc is not None and self._grader_proc.is_alive():
             return
@@ -373,7 +374,8 @@ class AgentManager:
 
     def _start_gateway_if_enabled(self) -> None:
         """Start the LiteLLM gateway if configured."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         gw_cfg = self.config.agents.gateway
         if not gw_cfg.enabled:
             return
@@ -444,7 +446,8 @@ class AgentManager:
         a migration the live ``_agent_island`` map is fresher than the birth
         island recorded on the spec.
         """
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
 
         def island_of(aid: str) -> str | None:
             spec = self.specs_by_id.get(aid)
@@ -464,7 +467,8 @@ class AgentManager:
         """
         if self._sandbox is None:
             return None
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
 
         from coral.sandbox import AgentSandboxContext
 
@@ -487,7 +491,8 @@ class AgentManager:
         agent_ids: list[str],
     ) -> dict[str, str]:
         """Run the warm-start research phase. Returns {agent_id: session_id}."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
 
         if self.verbose:
             print("\n[coral] Warm-start: research phase...\n")
@@ -535,7 +540,8 @@ class AgentManager:
         max_turns: int | None = None,
     ) -> AgentHandle:
         """Set up a single agent and start it."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
 
         runtime = self._runtime_for(agent_id)
         spec = self.specs_by_id.get(agent_id)
@@ -1095,7 +1101,8 @@ class AgentManager:
 
     def _get_seen_attempts(self) -> set[str]:
         """Get the set of attempt filenames currently in any island's attempts dir."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         coral_dir = self.paths.coral_dir
         islands_dir = coral_dir / "islands"
         if islands_dir.exists():
@@ -1112,7 +1119,8 @@ class AgentManager:
 
     def _resolve_attempt_path(self, fname: str) -> Path | None:
         """Look up an attempt JSON file across all islands or public/."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         coral_dir = self.paths.coral_dir
         islands_dir = coral_dir / "islands"
         if islands_dir.exists():
@@ -1193,7 +1201,8 @@ class AgentManager:
 
     def _get_eval_count(self) -> int:
         """Read the current global eval count."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         coral_dir = self.paths.coral_dir
         if (coral_dir / "islands").exists():
             counter_file = coral_dir / "eval_count"
@@ -1217,7 +1226,8 @@ class AgentManager:
 
     def _read_all_run_attempts(self) -> list[Attempt]:
         """Read attempts across the whole run, spanning islands when present."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         coral_dir = self.paths.coral_dir
         if (coral_dir / "islands").exists():
             attempts = []
@@ -1318,7 +1328,8 @@ class AgentManager:
         real_attempt_count = self._get_finalized_real_attempt_count()
         threshold = stop_config.score_threshold
         if threshold is not None:
-            assert self.paths is not None
+            if self.paths is None:
+                raise RuntimeError("run paths are not initialized; start_all() has not run")
             best = get_leaderboard(
                 self.paths.coral_dir,
                 top_n=1,
@@ -1362,7 +1373,8 @@ class AgentManager:
 
     def _auto_stop(self, reason: dict[str, Any]) -> None:
         """Record the auto-stop reason and gracefully stop the run."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         write_auto_stop(self.paths.coral_dir, reason)
         logger.info(
             "Auto-stop triggered: %s (score=%s, real_attempts=%s)",
@@ -1383,7 +1395,8 @@ class AgentManager:
         """Build a HeartbeatRunner by merging local + global heartbeat configs."""
         from coral.agent.heartbeat import HeartbeatAction
 
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         shared_dir = self._runtime_for(agent_id).shared_dir_name
         island_id = self._agent_island.get(agent_id)
 
@@ -1550,7 +1563,8 @@ class AgentManager:
         linger. Returns the ISO-8601 timestamp of the dump on success, or
         None if the dump could not be written.
         """
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         diag_dir = self.paths.coral_dir / "public" / "diagnostics" / agent_id
         try:
             diag_dir.mkdir(parents=True, exist_ok=True)
@@ -1765,7 +1779,8 @@ class AgentManager:
         correct after a resume reshuffles agents across islands via the
         ``.coral_island`` breadcrumb.
         """
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
         results: dict[str, float] = {}
         direction = self.config.grader.direction
         islands_dir = self.paths.coral_dir / "islands"
@@ -1965,7 +1980,8 @@ class AgentManager:
 
     def _migration_block_reason(self, candidate: MigrationCandidate) -> str | None:
         """Return why ``candidate`` cannot safely migrate right now, if any."""
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
 
         agent_id = candidate.agent_id
         if not any(handle.agent_id == agent_id for handle in self.handles):
@@ -2121,7 +2137,8 @@ class AgentManager:
         8. Hand back to ``_setup_and_start_agent`` with the new island and
            an "arrival" prompt summarising the move.
         """
-        assert self.paths is not None
+        if self.paths is None:
+            raise RuntimeError("run paths are not initialized; start_all() has not run")
 
         agent_id = candidate.agent_id
         # (1) Locate handle, bail on missing / paused / pending agents.

--- a/coral/agent/migration.py
+++ b/coral/agent/migration.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import logging
 import random
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
@@ -66,6 +66,25 @@ class MigrationCandidate:
     src_island: str
     dst_island: str
     score: float
+
+
+@dataclass(frozen=True)
+class MigrationResyncOp:
+    """One piece of launch-injected per-agent state that must be rebuilt
+    when the island partition changes.
+
+    Bystander resync is a standard post-migration phase: agents on the
+    affected islands are interrupt+restarted, and the restart pipeline
+    itself rebuilds everything ``_setup_and_start_agent`` covers (sandbox
+    spec, permission settings, symlinks). ``prepare`` is the hook for work
+    outside that pipeline — it runs per agent in the quiet window between
+    the interrupt and the restart. The phase is a no-op when no ops apply;
+    see :meth:`coral.agent.manager.AgentManager._migration_resync_ops` for
+    the registry.
+    """
+
+    name: str
+    prepare: Callable[[str], None] | None = None
 
 
 @dataclass(frozen=True)

--- a/coral/agent/runtime.py
+++ b/coral/agent/runtime.py
@@ -74,9 +74,11 @@ def apply_sandbox(cmd: list[str], sandbox: AgentSandboxSpec | None) -> list[str]
 def apply_sandbox_env(env: dict[str, str], sandbox: AgentSandboxSpec | None) -> None:
     """Merge the sandbox spec's env into the agent environment, in place.
 
-    Empty for the srt backend (srt injects its proxy vars into the child
-    itself); remote/shim backends carry endpoints and credentials here
-    rather than in the command prefix (argv is visible in ``ps``).
+    For the srt backend this carries the editable-install PYTHONPATH shim
+    and the SSL_CERT_FILE override for rustls clients (srt injects its
+    proxy vars into the child itself); remote/shim backends carry
+    endpoints and credentials here rather than in the command prefix
+    (argv is visible in ``ps``).
     """
     if sandbox is not None and sandbox.env:
         env.update(sandbox.env)

--- a/coral/cli/query.py
+++ b/coral/cli/query.py
@@ -153,6 +153,10 @@ def cmd_show(args: argparse.Namespace) -> None:
     from coral.types import get_budget_class
 
     print(f"Budget:  {get_budget_class(data.get('metadata'))}")
+    meta = data.get("metadata") or {}
+    if meta.get("archived") is True:
+        reason = meta.get("archive_reason")
+        print(f"Archived: yes ({reason})" if reason else "Archived: yes")
     print(f"Time:    {data['timestamp']}")
     if data.get("parent_hash"):
         print(f"Parent:  {data['parent_hash']}")

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -513,7 +513,8 @@ def cmd_start(args: argparse.Namespace) -> None:
     for h in handles:
         print(f"  {h.agent_id}: PID {h.process.pid if h.process else '?'} @ {h.worktree_path}")
 
-    assert manager.paths is not None
+    if manager.paths is None:
+        raise RuntimeError("agent manager did not initialize run paths during start_all()")
 
     # Save the starting command for reproducibility
     start_cmd = f"coral start -c {args.config}"

--- a/coral/config.py
+++ b/coral/config.py
@@ -375,6 +375,13 @@ class MigrationConfig:
     dest_weighting: str = "score"  # score | uniform | round_robin
     max_per_cycle: int = 2
     notify_island: bool = True
+    # Standard post-migration phase: interrupt+resume live bystanders on the
+    # affected islands so launch-injected per-agent state follows the new
+    # partition immediately instead of at their next natural restart (see
+    # AgentManager._migration_resync_ops for the op registry). Sessions are
+    # resumed, so no work is lost. A no-op when no resync ops apply — today
+    # the only op is the agents.sandbox boundary refresh.
+    resync_bystanders: bool = True
 
     def __post_init__(self) -> None:
         if self.every < 1:

--- a/coral/gateway/server.py
+++ b/coral/gateway/server.py
@@ -59,7 +59,8 @@ class GatewayManager:
         from coral.gateway.middleware import CoralGatewayMiddleware
 
         proxy_key = f"sk-coral-{agent_id}-{secrets.token_hex(4)}"
-        assert isinstance(self._middleware, CoralGatewayMiddleware)
+        if not isinstance(self._middleware, CoralGatewayMiddleware):
+            raise RuntimeError("gateway middleware is not initialized; call start() first")
         self._middleware.register_agent(agent_id, worktree_path, proxy_key)
         logger.info(f"Registered {agent_id} with gateway (key: {proxy_key[:20]}...)")
         return proxy_key

--- a/coral/grader/daemon.py
+++ b/coral/grader/daemon.py
@@ -553,7 +553,9 @@ def _find_pending(coral_dir: Path) -> list[Attempt]:
                 a = Attempt.from_dict(data)
             except Exception:
                 continue
-            if a.status == "pending" and a.score is None:
+            # Archived attempts are soft-deleted (e.g. discarded by
+            # `coral resume --from`) — never grade them.
+            if a.status == "pending" and a.score is None and not a.archived:
                 pending.append(a)
     pending.sort(key=lambda x: x.timestamp)
     return pending

--- a/coral/hub/__init__.py
+++ b/coral/hub/__init__.py
@@ -1,6 +1,7 @@
 """Hub — shared state management for CORAL agents."""
 
 from coral.hub.attempts import (
+    archive_attempts,
     format_leaderboard,
     get_agent_attempts,
     get_leaderboard,
@@ -13,6 +14,7 @@ from coral.hub.notes import list_notes, read_note
 from coral.hub.skills import get_skill_tree, list_skills, read_skill
 
 __all__ = [
+    "archive_attempts",
     "format_leaderboard",
     "get_agent_attempts",
     "get_leaderboard",

--- a/coral/hub/attempts.py
+++ b/coral/hub/attempts.py
@@ -18,18 +18,13 @@ def _attempts_dir(coral_dir: str | Path, island_id: str | int | None = None) -> 
     return d
 
 
-def write_attempt(
-    coral_dir: str | Path,
-    attempt: Attempt,
-    island_id: str | int | None = None,
-) -> Path:
-    """Write an attempt record to JSON atomically (tmp + rename).
+def _write_attempt_json(path: Path, attempt: Attempt) -> None:
+    """Write an attempt to `path` atomically (tmp + rename).
 
     Readers (monitor loop, grader daemon, `coral wait`) may poll these files
     concurrently with writes. Using tmp + rename guarantees readers see either
     the old complete file or the new complete file, never a partial write.
     """
-    path = _attempts_dir(coral_dir, island_id) / f"{attempt.commit_hash}.json"
     payload = json.dumps(attempt.to_dict(), indent=2)
     # Write to a temp file in the same directory (same filesystem -> atomic rename).
     fd, tmp_path = tempfile.mkstemp(
@@ -50,6 +45,16 @@ def write_attempt(
         except OSError:
             pass
         raise
+
+
+def write_attempt(
+    coral_dir: str | Path,
+    attempt: Attempt,
+    island_id: str | int | None = None,
+) -> Path:
+    """Write an attempt record to JSON atomically (tmp + rename)."""
+    path = _attempts_dir(coral_dir, island_id) / f"{attempt.commit_hash}.json"
+    _write_attempt_json(path, attempt)
     return path
 
 
@@ -90,25 +95,46 @@ def set_user_best(coral_dir: str | Path, commit_hash: str) -> Attempt | None:
                 attempt.metadata.pop("user_best", None)
             else:
                 continue
-            payload = json.dumps(attempt.to_dict(), indent=2)
-            fd, tmp_path = tempfile.mkstemp(
-                prefix=f".{attempt.commit_hash}.",
-                suffix=".json.tmp",
-                dir=path.parent,
-            )
-            try:
-                with os.fdopen(fd, "w") as f:
-                    f.write(payload)
-                    f.flush()
-                    os.fsync(f.fileno())
-                os.replace(tmp_path, path)
-            except Exception:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
-                raise
+            _write_attempt_json(path, attempt)
     return target
+
+
+def archive_attempts(
+    coral_dir: str | Path,
+    commit_hashes: set[str],
+    reason: str | None = None,
+) -> list[str]:
+    """Soft-delete attempts: every listing view stops showing them.
+
+    The JSON stays on disk (and `read_attempt` / `coral show` can still
+    resolve an explicit hash), but `read_attempts` and everything built on
+    it (leaderboard, status, recent, search) skip archived records
+    unconditionally. Scans every view root so multi-island runs archive the
+    record wherever it lives. Returns the commit hashes actually archived.
+    """
+    from coral.hub._island import all_view_roots
+
+    if not commit_hashes:
+        return []
+    archived: list[str] = []
+    for view_root in all_view_roots(coral_dir):
+        attempts_dir = view_root / "attempts"
+        if not attempts_dir.is_dir():
+            continue
+        for commit_hash in sorted(commit_hashes):
+            path = attempts_dir / f"{commit_hash}.json"
+            if not path.exists():
+                continue
+            try:
+                attempt = Attempt.from_dict(json.loads(path.read_text()))
+            except (json.JSONDecodeError, KeyError, OSError):
+                continue
+            attempt.metadata["archived"] = True
+            if reason:
+                attempt.metadata["archive_reason"] = reason
+            _write_attempt_json(path, attempt)
+            archived.append(commit_hash)
+    return archived
 
 
 def _global_eval_count_path(coral_dir: str | Path) -> Path:
@@ -171,7 +197,11 @@ def read_eval_count(coral_dir: str | Path, island_id: str | int | None = None) -
 
 
 def read_attempts(coral_dir: str | Path, island_id: str | int | None = None) -> list[Attempt]:
-    """Read all attempt records."""
+    """Read all attempt records.
+
+    Archived attempts (e.g. discarded by `coral resume --from`) are treated
+    as soft-deleted: they never appear here or in any view built on this.
+    """
     d = _attempts_dir(coral_dir, island_id)
     attempts = []
     for f in sorted(d.glob("*.json")):
@@ -180,7 +210,7 @@ def read_attempts(coral_dir: str | Path, island_id: str | int | None = None) -> 
             attempts.append(Attempt.from_dict(data))
         except (json.JSONDecodeError, KeyError):
             continue
-    return attempts
+    return [a for a in attempts if not a.archived]
 
 
 def _read_all_island_attempts(coral_dir: str | Path) -> list[Attempt]:

--- a/coral/sandbox/srt.py
+++ b/coral/sandbox/srt.py
@@ -448,15 +448,20 @@ class AllowAllProxy:
         listener.listen(128)
         self._listener = listener
         self.port = listener.getsockname()[1]
-        self._thread = threading.Thread(
-            target=self._serve, name="coral-sandbox-proxy", daemon=True
-        )
+        self._thread = threading.Thread(target=self._serve, name="coral-sandbox-proxy", daemon=True)
         self._thread.start()
         return self.port
 
     def stop(self) -> None:
         self._stopping.set()
         if self._listener is not None:
+            # shutdown() before close(): on Linux, close() alone does not wake
+            # a thread blocked in accept(), which keeps the kernel socket in
+            # LISTEN state and still accepting connections.
+            try:
+                self._listener.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
             try:
                 self._listener.close()
             except OSError:
@@ -467,10 +472,12 @@ class AllowAllProxy:
             self._thread = None
 
     def _serve(self) -> None:
-        assert self._listener is not None
+        listener = self._listener
+        if listener is None:
+            return
         while not self._stopping.is_set():
             try:
-                conn, _addr = self._listener.accept()
+                conn, _addr = listener.accept()
             except OSError:
                 break  # listener closed by stop()
             threading.Thread(target=self._handle, args=(conn,), daemon=True).start()

--- a/coral/sandbox/srt.py
+++ b/coral/sandbox/srt.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import select
 import shutil
 import socket
@@ -97,8 +98,9 @@ class SrtSandbox:
 
         Regenerated on every (re)start so restarts pick up the current
         proxy port. srt injects the proxy env vars into its child itself;
-        the spec's own env only carries the editable-install PYTHONPATH
-        shim (see :func:`_cli_pythonpath_shim`), when one is needed.
+        the spec's own env carries the editable-install PYTHONPATH shim
+        (see :func:`_cli_pythonpath_shim`), when one is needed, plus the
+        TLS bundle override for rustls clients (:func:`_tls_cert_env`).
         """
         settings = build_srt_settings(
             self.cfg,
@@ -126,6 +128,7 @@ class SrtSandbox:
             Path(coral.__file__).resolve().parent,
             Path(sys.prefix).resolve(),
         )
+        env.update(_tls_cert_env())
         return AgentSandboxSpec(
             command_prefix=srt_command_prefix(self.cfg.srt_command, settings_path),
             env=env,
@@ -337,6 +340,25 @@ def _cli_pythonpath_shim(run_dir: Path, package_dir: Path, prefix: Path) -> dict
     link.unlink(missing_ok=True)  # repoint if the checkout moved since last start
     link.symlink_to(package_dir)
     return {"PYTHONPATH": str(shim_dir)}
+
+
+def _tls_cert_env() -> dict[str, str]:
+    """Point rustls-based CLIs (codex) at the PEM root-cert bundle.
+
+    On macOS, rustls-native-certs loads roots by querying the system
+    keychain's trust settings through the Security framework, which
+    Seatbelt denies inside the sandbox — every HTTPS request then fails
+    with reqwest's generic "error sending request", while curl (which
+    reads /etc/ssl/cert.pem) works fine. SSL_CERT_FILE short-circuits the
+    keychain lookup to a plain file read the sandbox allows. Respect an
+    existing SSL_CERT_FILE (it propagates via the inherited environment).
+    """
+    if os.environ.get("SSL_CERT_FILE"):
+        return {}
+    for candidate in ("/etc/ssl/cert.pem", "/etc/ssl/certs/ca-certificates.crt"):
+        if Path(candidate).is_file():
+            return {"SSL_CERT_FILE": candidate}
+    return {}
 
 
 def build_srt_settings(

--- a/coral/template/presets/sandbox.yaml
+++ b/coral/template/presets/sandbox.yaml
@@ -14,4 +14,5 @@
 agents:
   sandbox:
     enabled: true
+    provider: srt
     network: open

--- a/coral/types.py
+++ b/coral/types.py
@@ -170,6 +170,11 @@ class Attempt:
         """Budget classification: 'real', 'grader_error', or 'tune'. Defaults to 'real'."""
         return get_budget_class(self.metadata)
 
+    @property
+    def archived(self) -> bool:
+        """True when hidden from listing views (e.g. discarded by `coral resume --from`)."""
+        return self.metadata.get("archived") is True
+
     def to_dict(self) -> dict[str, Any]:
         d = {
             "commit_hash": self.commit_hash,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,13 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP"]
+# S101 bans `assert` outside tests/ — asserts vanish under `python -O`, so
+# main code must use guards or real exceptions instead.
+select = ["E", "F", "I", "N", "W", "UP", "S101"]
 ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/scripts/migrate_legacy_graders.py
+++ b/scripts/migrate_legacy_graders.py
@@ -168,7 +168,8 @@ def main() -> None:
         if not group_tasks:
             continue
         sources = {(t / "eval" / "grader.py").read_bytes() for t in group_tasks}
-        assert len(sources) == 1, f"{group} grader.py files differ; refusing to share"
+        if len(sources) != 1:
+            raise RuntimeError(f"{group} grader.py files differ; refusing to share")
         canonical = EXAMPLES / group / "_grader"
         write_package(
             canonical,

--- a/tests/test_grader_daemon.py
+++ b/tests/test_grader_daemon.py
@@ -772,6 +772,33 @@ def test_find_pending_multi_island_scans_every_island(tmp_path):
     assert hashes == {"aaa000", "bbb111"}
 
 
+def test_find_pending_skips_archived(tmp_path):
+    """Archived (soft-deleted) pending attempts must never be graded."""
+    from coral.grader.daemon import _find_pending
+    from coral.hub.attempts import archive_attempts, write_attempt
+    from coral.types import Attempt
+
+    coral_dir = tmp_path / ".coral"
+
+    def _pending(commit: str) -> Attempt:
+        return Attempt(
+            commit_hash=commit,
+            agent_id="agent-1",
+            title="x",
+            score=None,
+            status="pending",
+            parent_hash=None,
+            timestamp="2026-05-31T10:00:00Z",
+        )
+
+    write_attempt(coral_dir, _pending("aaa000"))
+    write_attempt(coral_dir, _pending("bbb111"))
+    archive_attempts(coral_dir, {"bbb111"}, reason="discarded by resume --from aaa000")
+
+    pending = _find_pending(coral_dir)
+    assert {a.commit_hash for a in pending} == {"aaa000"}
+
+
 def test_grade_one_finalizes_migrated_pending_attempt_in_current_island(tmp_path, monkeypatch):
     """If migration moves a pending attempt mid-grade, finalize into its current island."""
     import coral.grader.daemon as daemon

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -4,11 +4,13 @@ import tempfile
 from pathlib import Path
 
 from coral.hub.attempts import (
+    archive_attempts,
     format_leaderboard,
     format_status_summary,
     get_agent_attempts,
     get_leaderboard,
     per_agent_class_counts,
+    read_attempt,
     read_attempts,
     search_attempts,
     write_attempt,
@@ -88,6 +90,35 @@ def test_attempts_crud():
 
         all_attempts = read_attempts(d)
         assert len(all_attempts) == 2
+
+
+def test_archive_attempts_soft_deletes_from_all_views():
+    with tempfile.TemporaryDirectory() as d:
+        write_attempt(d, _make_attempt("aaa111", score=0.5, title="kept"))
+        write_attempt(d, _make_attempt("bbb222", score=0.9, title="discarded"))
+
+        archived = archive_attempts(d, {"bbb222"}, reason="discarded by resume --from aaa111")
+
+        assert archived == ["bbb222"]
+        assert [a.commit_hash for a in read_attempts(d)] == ["aaa111"]
+        assert [a.commit_hash for a in get_leaderboard(d)] == ["aaa111"]
+        assert [a.commit_hash for a in get_agent_attempts(d, "agent-1")] == ["aaa111"]
+        assert search_attempts(d, "discarded") == []
+        assert "bbb222" not in format_status_summary(d)
+        # The record survives on disk and stays resolvable by explicit hash.
+        kept = read_attempt(d, "bbb222")
+        assert kept is not None
+        assert kept.archived
+        assert kept.metadata["archive_reason"] == "discarded by resume --from aaa111"
+
+
+def test_archive_attempts_ignores_unknown_and_empty():
+    with tempfile.TemporaryDirectory() as d:
+        write_attempt(d, _make_attempt("aaa111"))
+
+        assert archive_attempts(d, set()) == []
+        assert archive_attempts(d, {"nope"}) == []
+        assert [a.commit_hash for a in read_attempts(d)] == ["aaa111"]
 
 
 def test_leaderboard():

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1617,3 +1617,121 @@ def test_maybe_run_migration_cycle_does_not_mix_blocked_deferred_with_fresh(tmp_
 
     assert applied == []
     assert [(c.agent_id, r) for c, r in mgr._deferred_candidates] == [("0-agent-1", "paused")]
+
+
+# ---------------------------------------------------------------------------
+# Bystander resync after migration (islands.migration.resync_bystanders)
+# ---------------------------------------------------------------------------
+
+
+def _resync_manager():
+    """Manager with three islands and one live agent in every role the
+    resync phase distinguishes: the migrant, live mates on the src/dst
+    islands, an outsider, and a dead + a paused mate on src."""
+    from coral.agent.manager import AgentManager
+    from coral.agent.runtime import AgentHandle
+    from coral.config import AgentAssignmentConfig, AgentConfig, CoralConfig
+
+    cfg = CoralConfig(
+        agents=AgentConfig(assignments=[AgentAssignmentConfig(count=6)]),
+        islands=IslandsConfig(count=3),
+    )
+    mgr = AgentManager(cfg)
+
+    class _AliveProc:
+        def poll(self):
+            return None
+
+    def _handle(agent_id: str, *, alive: bool = True) -> AgentHandle:
+        return AgentHandle(
+            agent_id=agent_id,
+            process=_AliveProc() if alive else None,
+            worktree_path=Path("/x"),
+            log_path=Path("/x.log"),
+        )
+
+    mgr._agent_island = {
+        "migrant": "1",  # _apply_migration already moved + restarted it
+        "src-mate": "0",
+        "dst-mate": "1",
+        "outsider": "2",
+        "dead-mate": "0",
+        "paused-mate": "0",
+    }
+    mgr.handles = [
+        _handle("migrant"),
+        _handle("src-mate"),
+        _handle("dst-mate"),
+        _handle("outsider"),
+        _handle("dead-mate", alive=False),
+        _handle("paused-mate"),
+    ]
+    mgr._paused_until = {"paused-mate": 1e18}
+    return mgr
+
+
+def _resync_batch():
+    return [MigrationCandidate(agent_id="migrant", src_island="0", dst_island="1", score=1.0)]
+
+
+def test_resync_bystanders_restarts_affected_live_agents():
+    """With an applicable op (sandbox active), live agents on the src/dst
+    islands restart so launch-injected state follows the new partition;
+    the migrant (already restarted), dead/paused agents, and unaffected
+    islands are left alone."""
+    mgr = _resync_manager()
+    mgr._sandbox = object()  # sandbox provider active -> one resync op
+
+    restarted: list[str] = []
+
+    def _fake_interrupt_and_resume(idx, prompt, prompt_source=None, pre_restart_ops=()):
+        assert prompt_source == "migration:resync"
+        assert "sandbox" in prompt
+        restarted.append(mgr.handles[idx].agent_id)
+        return mgr.handles[idx]
+
+    mgr._interrupt_and_resume = _fake_interrupt_and_resume  # type: ignore[assignment]
+
+    mgr._resync_bystanders_after_migration(_resync_batch())
+    assert restarted == ["src-mate", "dst-mate"]
+
+    # Flag off or empty batch -> no restarts.
+    restarted.clear()
+    mgr.migration_config.resync_bystanders = False
+    mgr._resync_bystanders_after_migration(_resync_batch())
+    mgr.migration_config.resync_bystanders = True
+    mgr._resync_bystanders_after_migration([])
+    assert restarted == []
+
+
+def test_resync_bystanders_noop_without_ops():
+    """No applicable resync ops (no sandbox) -> the phase is a no-op."""
+    mgr = _resync_manager()
+    assert mgr._sandbox is None
+    assert mgr._migration_resync_ops() == []
+
+    mgr._interrupt_and_resume = pytest.fail  # type: ignore[assignment]
+    mgr._resync_bystanders_after_migration(_resync_batch())
+
+
+def test_resync_bystanders_forwards_op_prepare_hooks():
+    """An op's prepare hook rides into _interrupt_and_resume's quiet window
+    (after interrupt, before restart)."""
+    from coral.agent.migration import MigrationResyncOp
+
+    mgr = _resync_manager()
+    prepared: list[str] = []
+    mgr._migration_resync_ops = lambda: [  # type: ignore[assignment]
+        MigrationResyncOp(name="custom", prepare=prepared.append)
+    ]
+
+    def _fake_interrupt_and_resume(idx, prompt, prompt_source=None, pre_restart_ops=()):
+        agent_id = mgr.handles[idx].agent_id
+        for op in pre_restart_ops:
+            op(agent_id)  # what the real helper does in the quiet window
+        return mgr.handles[idx]
+
+    mgr._interrupt_and_resume = _fake_interrupt_and_resume  # type: ignore[assignment]
+
+    mgr._resync_bystanders_after_migration(_resync_batch())
+    assert prepared == ["src-mate", "dst-mate"]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -24,6 +24,7 @@ from coral.sandbox.srt import (
     AllowAllProxy,
     SrtSandbox,
     _cli_pythonpath_shim,
+    _tls_cert_env,
     build_srt_settings,
     ensure_sandbox_supported,
     srt_command_prefix,
@@ -303,6 +304,26 @@ def test_cli_pythonpath_shim_noop_for_normal_install(tmp_path):
     assert not (tmp_path / "run" / ".sandbox").exists()
 
 
+def test_tls_cert_env_respects_existing_override(monkeypatch):
+    """A user-set SSL_CERT_FILE propagates via the inherited environment —
+    the spec must not clobber it."""
+    monkeypatch.setenv("SSL_CERT_FILE", "/custom/bundle.pem")
+    assert _tls_cert_env() == {}
+
+
+def test_tls_cert_env_points_at_pem_bundle(monkeypatch):
+    """rustls clients (codex) cannot query the macOS keychain inside the
+    sandbox; the spec points them at the host's PEM bundle instead."""
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    env = _tls_cert_env()
+    if env:  # host has a bundle at a known path (macOS/Linux defaults)
+        assert Path(env["SSL_CERT_FILE"]).is_file()
+    else:  # no known bundle on this host — nothing to point at
+        assert not any(
+            Path(p).is_file() for p in ("/etc/ssl/cert.pem", "/etc/ssl/certs/ca-certificates.crt")
+        )
+
+
 def test_build_settings_open_mode_network(tmp_path):
     settings = build_srt_settings(SandboxConfig(enabled=True), proxy_port=12345, **_paths(tmp_path))
     # Open mode: no domain allowlist, all traffic via the external proxy.
@@ -381,8 +402,10 @@ def test_srt_provider_open_mode_lifecycle(tmp_path):
         assert spec.command_prefix == ["srt", "--settings", str(settings_path), "--"]
         # srt injects proxy env into its child itself; the spec's own env
         # carries at most the editable-install PYTHONPATH shim (present when
-        # this test runs from a dev checkout, absent for normal installs).
-        assert set(spec.env) <= {"PYTHONPATH"}
+        # this test runs from a dev checkout, absent for normal installs)
+        # and the SSL_CERT_FILE override for rustls clients (present when
+        # the host has a PEM bundle at a known path).
+        assert set(spec.env) <= {"PYTHONPATH", "SSL_CERT_FILE"}
     finally:
         provider.stop()
     assert provider._proxy is None

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 from coral.agent.manager import AgentManager
 from coral.config import CoralConfig
-from coral.hub.attempts import read_attempt, write_attempt
+from coral.hub.attempts import read_attempt, read_attempts, write_attempt
 from coral.hub.steering import (
     ContinueFromAction,
     MarkBestAction,
@@ -361,6 +361,59 @@ def test_resume_from_resets_real_worktree_head(tmp_path: Path, monkeypatch) -> N
     assert _git(agent_dir, "rev-parse", "HEAD") == target_hash
     assert (agent_dir / "solution.txt").read_text() == "target\n"
     assert prompts and f"## Continue from Attempt {target_hash}" in prompts[0]
+
+
+def test_resume_from_archives_attempts_after_target(tmp_path: Path, monkeypatch) -> None:
+    """Attempts on the discarded segment are soft-deleted from every view."""
+    coral_dir = tmp_path / ".coral"
+    agents_dir = tmp_path / "agents"
+    repo_dir = tmp_path / "repo"
+    agent_dir = agents_dir / "agent-1"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / ".coral_agent_id").write_text("agent-1")
+    repo_dir.mkdir()
+
+    _git(agent_dir, "init")
+    _git(agent_dir, "config", "user.email", "test@example.com")
+    _git(agent_dir, "config", "user.name", "Test User")
+    target_hash = _commit_file(agent_dir, "solution.txt", "target\n", "target attempt")
+    mid_hash = _commit_file(agent_dir, "solution.txt", "mid\n", "mid attempt")
+    latest_hash = _commit_file(agent_dir, "solution.txt", "latest\n", "latest attempt")
+
+    write_attempt(coral_dir, _attempt(target_hash, score=0.5))
+    write_attempt(coral_dir, _attempt(mid_hash, score=0.6))
+    write_attempt(coral_dir, _attempt(latest_hash, score=0.7))
+
+    paths = ProjectPaths(
+        results_dir=tmp_path,
+        task_dir=tmp_path,
+        run_dir=tmp_path,
+        coral_dir=coral_dir,
+        agents_dir=agents_dir,
+        repo_dir=repo_dir,
+    )
+    cfg = CoralConfig.from_dict(
+        {
+            "task": {"name": "t", "description": "d"},
+            "agents": {"count": 1, "runtime": "claude-code"},
+        }
+    )
+    manager = AgentManager(cfg)
+    _stub_manager_for_resume(manager, monkeypatch, {"agent-1": agent_dir})
+
+    manager.resume_all(paths, resume_from=target_hash)
+
+    # Only the target survives in listing views; the discarded segment is gone.
+    visible = {a.commit_hash for a in read_attempts(coral_dir)}
+    assert visible == {target_hash}
+    # The records themselves stay on disk, flagged archived with a reason.
+    for discarded_hash in (mid_hash, latest_hash):
+        record = read_attempt(coral_dir, discarded_hash)
+        assert record is not None
+        assert record.archived
+        assert record.metadata["archive_reason"] == f"discarded by resume --from {target_hash}"
+    target_record = read_attempt(coral_dir, target_hash)
+    assert target_record is not None and not target_record.archived
 
 
 def test_resume_from_resets_all_descendant_agent_worktrees(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Motivation

Promote `dev` to `main`. Content-wise this release carries one change: the srt sandbox fix that unblocks rustls-based CLIs (codex) on macOS (#167). The other commits in the range (#161, #162, #164, #165, CI staging) already landed on `main` via the previous promote (#166) — the tree diff is the sandbox fix only.

## Changes

- **fix(sandbox)**: inject `SSL_CERT_FILE` into the sandboxed agent env (#167). On macOS, rustls-native-certs loads roots by querying the system keychain through the Security framework, which Seatbelt denies inside the sandbox — every codex HTTPS request failed with "error sending request" and agents restart-looped. Pointing rustls at the PEM bundle (`/etc/ssl/cert.pem`, Linux fallback `ca-certificates.crt`) turns the lookup into a plain file read the sandbox allows; a user-set `SSL_CERT_FILE` is respected.
- **preset**: `sandbox.yaml` spells out `provider: srt` explicitly (no behavior change).

Tree diff vs main: 4 files, +55/−7 (`coral/sandbox/srt.py`, `coral/agent/runtime.py`, `coral/template/presets/sandbox.yaml`, `tests/test_sandbox.py`).

## Test plan

- End-to-end: codex inside the srt sandbox via the real `prepare_agent` path completes model requests through the allow-all proxy (the exact previously-failing kernel_builder setup).
- `uv run pytest tests/ -q`: 616 passed, 1 skipped; ruff check + format clean.

## Affected areas

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [x] `coral/template/` (CORAL.md, bundled skills/agents)
- [x] Other: `coral/sandbox/`

## Checklist

- [x] Title follows Conventional Commits (`release:`).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Tests updated in #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)