### PR TITLE
fix(islands): stop dropping name-based islands from run-wide views

### DIFF
--- a/coral/hub/attempts.py
+++ b/coral/hub/attempts.py
@@ -277,8 +277,10 @@ def get_agent_attempts(
     """
     coral_dir = Path(coral_dir)
     if island_id is None and (coral_dir / "islands").exists():
+        from coral.hub._island import all_view_roots
+
         attempts: list[Attempt] = []
-        for view_root in _all_view_attempt_roots(coral_dir):
+        for view_root in all_view_roots(coral_dir):
             attempts.extend(
                 a
                 for a in read_attempts(coral_dir, island_id=view_root.name)
@@ -286,13 +288,6 @@ def get_agent_attempts(
             )
         return attempts
     return [a for a in read_attempts(coral_dir, island_id=island_id) if a.agent_id == agent_id]
-
-
-def _all_view_attempt_roots(coral_dir: Path) -> list[Path]:
-    """Per-island attempt dirs in multi-island mode (sorted)."""
-    from coral.hub._island import all_view_roots
-
-    return [r for r in all_view_roots(coral_dir) if r.name.isdigit()]
 
 
 def agent_in_grader_queue(

--- a/coral/hub/notes.py
+++ b/coral/hub/notes.py
@@ -41,7 +41,7 @@ from typing import Any
 
 import yaml
 
-from coral.hub._island import island_root
+from coral.hub._island import all_view_roots, island_root
 
 # Sentinel surfaced when a note has no parseable ``creator:`` field. Kept
 # distinct from the empty string so the absence is loud — the dashboard, the
@@ -280,7 +280,7 @@ def list_notes(
         return _list_notes_single(coral_dir, island_id)
 
     entries: list[dict[str, Any]] = []
-    for view_root in _note_view_roots(coral_dir):
+    for view_root in all_view_roots(coral_dir):
         sub = _list_notes_single(coral_dir, island_id=view_root.name, clean=False)
         for entry in sub:
             entry["island_id"] = view_root.name
@@ -334,13 +334,6 @@ def _clean_note_entries(entries: list[dict[str, Any]]) -> None:
         else:
             entry["relative_path"] = entry.get("filename", "")
             entry["category"] = "other"
-
-
-def _note_view_roots(coral_dir: Path) -> list[Path]:
-    """Per-island note roots in multi-island mode."""
-    from coral.hub._island import all_view_roots
-
-    return [r for r in all_view_roots(coral_dir) if r.name.isdigit()]
 
 
 def search_notes(

--- a/coral/web/logs.py
+++ b/coral/web/logs.py
@@ -413,6 +413,7 @@ def list_log_files(coral_dir: Path) -> dict[str, list[dict[str, Any]]]:
     from coral.hub._island import all_view_roots
 
     agents: dict[str, list[dict[str, Any]]] = {}
+    multi_island = (coral_dir / "islands").exists()
     for view_root in all_view_roots(coral_dir):
         logs_dir = view_root / "logs"
         if not logs_dir.exists():
@@ -428,7 +429,7 @@ def list_log_files(coral_dir: Path) -> dict[str, list[dict[str, Any]]]:
                 "size_bytes": stat.st_size,
                 "modified": stat.st_mtime,
             }
-            if view_root.name.isdigit():
+            if multi_island:
                 entry["island_id"] = view_root.name
             agents.setdefault(agent_id, []).append(entry)
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -157,6 +157,33 @@ def test_agent_filter_scans_migrated_agent_current_island():
         assert len(get_agent_attempts(coral_dir, "0-agent-1")) == 1
 
 
+def test_agent_filter_scans_string_named_islands():
+    """island_id=None must scan name-based islands, not only numeric ones.
+
+    Regression: the run-wide scan filtered view roots with
+    ``r.name.isdigit()``, returning nothing for named islands (the
+    ``coral start`` default: ``atlantis``, ``avalon``, ...).
+    """
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d)
+        for island in ("atlantis", "avalon"):
+            (coral_dir / "islands" / island / "attempts").mkdir(parents=True)
+
+        write_attempt(
+            coral_dir, _make_attempt("h1", agent="ahab-from-atlantis"), island_id="atlantis"
+        )
+        write_attempt(
+            coral_dir, _make_attempt("h2", agent="sparrow-from-avalon"), island_id="avalon"
+        )
+
+        assert [a.commit_hash for a in get_agent_attempts(coral_dir, "ahab-from-atlantis")] == [
+            "h1"
+        ]
+        assert [a.commit_hash for a in get_agent_attempts(coral_dir, "sparrow-from-avalon")] == [
+            "h2"
+        ]
+
+
 def test_search():
     with tempfile.TemporaryDirectory() as d:
         write_attempt(d, _make_attempt("a", title="learning rate tuning"))

--- a/tests/test_islands.py
+++ b/tests/test_islands.py
@@ -187,6 +187,31 @@ def test_recent_notes_multi_island_uses_global_date_order():
         assert [entry["island_id"] for entry in recent] == ["1", "0"]
 
 
+def test_list_notes_aggregates_string_named_islands():
+    """island_id=None must aggregate notes from name-based islands.
+
+    Regression: the aggregation path filtered view roots with
+    ``r.name.isdigit()``, so runs using named islands (``atlantis``,
+    ``avalon``, ... — the ``coral start`` default) listed zero notes.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d)
+        for island in ("atlantis", "avalon"):
+            (coral_dir / "islands" / island / "notes").mkdir(parents=True)
+        (coral_dir / "islands" / "atlantis" / "notes" / "a.md").write_text(
+            "---\ncreator: agent-1\ncreated: 2026-05-31\n---\n# A\nbody A\n"
+        )
+        (coral_dir / "islands" / "avalon" / "notes" / "b.md").write_text(
+            "---\ncreator: agent-2\ncreated: 2026-05-31\n---\n# B\nbody B\n"
+        )
+
+        entries = {e["filename"]: e for e in list_notes(coral_dir)}
+
+        assert set(entries) == {"a.md", "b.md"}
+        assert entries["a.md"]["island_id"] == "atlantis"
+        assert entries["b.md"]["island_id"] == "avalon"
+
+
 def test_notes_by_returns_creator_matched_paths():
     with tempfile.TemporaryDirectory() as d:
         coral_dir = Path(d)

--- a/tests/test_web_multi_island.py
+++ b/tests/test_web_multi_island.py
@@ -57,6 +57,21 @@ def test_list_log_files_aggregates_island_logs(tmp_path):
     assert logs["1-agent-1"][0]["island_id"] == "1"
 
 
+def test_list_log_files_tags_island_id_for_string_named_islands(tmp_path):
+    """Name-based islands (the coral start default) must be tagged too."""
+    coral_dir = tmp_path / ".coral"
+    (coral_dir / "public").mkdir(parents=True)
+    for island in ("atlantis", "avalon"):
+        (coral_dir / "islands" / island / "logs").mkdir(parents=True)
+    (coral_dir / "islands" / "atlantis" / "logs" / "ahab-from-atlantis.0.log").write_text("a")
+    (coral_dir / "islands" / "avalon" / "logs" / "sparrow-from-avalon.0.log").write_text("b")
+
+    logs = list_log_files(coral_dir)
+
+    assert logs["ahab-from-atlantis"][0]["island_id"] == "atlantis"
+    assert logs["sparrow-from-avalon"][0]["island_id"] == "avalon"
+
+
 async def test_status_uses_global_eval_count_and_island_logs(tmp_path):
     coral_dir = tmp_path / ".coral"
     _make_multi_island(coral_dir)


### PR DESCRIPTION
## Problem

Run-wide aggregation views filtered island roots with `r.name.isdigit()` — a leftover from when island ids were numeric. `coral start` names islands `atlantis` / `avalon` / ... by default, so on every default multi-island run the filter dropped **all** islands:

- `coral notes` printed `Notes (0): No notes yet.` even with 20+ notes per island on disk (this is what made a working migration look like it never fired — the arrival notes existed but were invisible)
- `get_agent_attempts(island_id=None)` returned nothing run-wide; this also feeds the manager's per-agent attempt lookups
- the web dashboard's `list_log_files` never tagged `island_id` on log entries

Only runs with numeric island ids (`"0"`, `"1"`, ...) behaved correctly — which is also why the existing tests (all using `"0"`/`"1"`) never caught it.

## Fix

- `coral/hub/notes.py`, `coral/hub/attempts.py`: drop the digit-filtering helpers and use `all_view_roots` directly. Both call sites are already guarded by an `islands/` existence check, and `all_view_roots` only returns real `islands/<id>` dirs in multi-island mode, so the second filter had no purpose.
- `coral/web/logs.py`: tag `island_id` whenever the run is multi-island, instead of only for digit-named roots.

No other `.isdigit()` island filtering exists in `coral/` (repo-wide grep).

## Tests

Three regression tests using string island names (`atlantis`/`avalon`):

- `test_list_notes_aggregates_string_named_islands` (tests/test_islands.py)
- `test_agent_filter_scans_string_named_islands` (tests/test_hub.py)
- `test_list_log_files_tags_island_id_for_string_named_islands` (tests/test_web_multi_island.py)

Full suite: 617 passed, 1 skipped. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)