### PR TITLE
feat(template): evidence-based knowledge governance — scan-usage skill + meta-skill admission standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Key concepts:
 | `coral/hub/` | Shared state: `attempts.py`, `notes.py`, `skills.py`, `checkpoint.py` (git-tracked snapshots of `.coral/public/`), `heartbeat.py`, `prompts/` (built-in heartbeat prompts) |
 | `coral/hooks/` | `post_commit.py` — implements `submit_eval` (called by `coral eval`) |
 | `coral/workspace/` | Run layout: `project.py` (run dir setup), `worktree.py` (per-agent git worktrees + symlinks), `repo.py` (clone/init), `grader_env.py` (`.coral/private/grader_venv/`) |
-| `coral/template/` | `coral_md.py` + `coral.md.template` / `coral_single.md.template`; bundled `agents/` (deep-researcher, librarian) and `skills/` (deep-research, organize-files, skill-creator) seeded into every run |
+| `coral/template/` | `coral_md.py` + `coral.md.template` / `coral_single.md.template`; bundled `agents/` (deep-researcher, librarian) and `skills/` (deep-research, organize-files, skill-creator, scan-usage) seeded into every run |
 | `coral/gateway/` | Optional LiteLLM gateway (`server.py`, `middleware.py`, `config.py`) for intercepting agent model traffic |
 | `coral/web/` | Starlette web dashboard (`app.py`, `api.py`, `events.py`, `logs.py`, `static/`) |
 | `coral/cli/` | CLI package: `start.py`, `query.py`, `eval.py`, `heartbeat.py`, `agents.py` (user-level bindings), `ui.py`, `author.py`, `validation.py`, `_helpers.py` |

--- a/coral/_version.py
+++ b/coral/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '0.7.5.dev4+g343f3e9ea'
-__version_tuple__ = version_tuple = (0, 7, 5, 'dev4', 'g343f3e9ea')
+__version__ = version = '0.7.5.dev8+ga8b126d12.d20260710'
+__version_tuple__ = version_tuple = (0, 7, 5, 'dev8', 'ga8b126d12.d20260710')
 
 __commit_id__ = commit_id = None

--- a/coral/_version.py
+++ b/coral/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '0.7.5.dev8+ga8b126d12.d20260710'
-__version_tuple__ = version_tuple = (0, 7, 5, 'dev8', 'ga8b126d12.d20260710')
+__version__ = version = '0.7.5.dev4+g343f3e9ea'
+__version_tuple__ = version_tuple = (0, 7, 5, 'dev4', 'g343f3e9ea')
 
 __commit_id__ = commit_id = None

--- a/coral/template/agents/librarian.md
+++ b/coral/template/agents/librarian.md
@@ -11,6 +11,7 @@ tools:
 skills:
   organize-files: true
   skill-creator: true
+  scan-usage: true
 ---
 
 You are the **knowledge librarian**. Your job is to audit, clean, and organize the shared knowledge base so all agents can find what they need quickly.
@@ -34,7 +35,29 @@ bash .claude/skills/organize-files/scripts/audit.sh 2>/dev/null || echo "audit s
 ls .claude/skills/
 ```
 
-### 2. Deduplicate Notes
+### 2. Gather Usage Evidence
+
+Before touching anything, measure what agents *actually read* — don't guess
+from file names or age:
+
+```bash
+python .claude/skills/scan-usage/scripts/scan_usage.py 2>/dev/null || echo "scan-usage script not found, skip evidence pass"
+```
+
+This scans every agent's session log and reports per-note reads, per-skill
+uses, and a never-read / never-used inventory. Use it to drive the steps
+below:
+
+- **Heavily-read notes** are load-bearing: merge duplicates *into* them,
+  keep their paths stable, and prioritize improving them.
+- **Never-read notes** are archive candidates — but respect an **evidence
+  floor**: only archive when the run has real activity behind it (many
+  evals happened since the note was created) and the count is still zero.
+  When in doubt, leave it alone; premature retirement destroys knowledge.
+- **Never-used skills** usually have a description that doesn't trigger —
+  rewrite the SKILL.md frontmatter description before considering removal.
+
+### 3. Deduplicate Notes
 
 Find and merge near-duplicate notes:
 
@@ -46,7 +69,7 @@ python .claude/skills/organize-files/scripts/find_duplicates.py .claude/notes --
 - Preserve contradictory findings — flag them in `_open-questions.md`
 - Archive originals to `notes/_archive/`
 
-### 3. Reorganize
+### 4. Reorganize
 
 Follow the `organize-files` skill workflow (`.claude/skills/organize-files/SKILL.md`):
 
@@ -59,7 +82,7 @@ Follow the `organize-files` skill workflow (`.claude/skills/organize-files/SKILL
 - `notes/_synthesis/` — owned by consolidate
 - `notes/_connections.md` — owned by consolidate
 
-### 4. Regenerate Index
+### 5. Regenerate Index
 
 ```bash
 python .claude/skills/organize-files/scripts/generate_index.py .claude/notes 2>/dev/null
@@ -67,23 +90,29 @@ python .claude/skills/organize-files/scripts/generate_index.py .claude/notes 2>/
 
 Ensure `notes/index.md` reflects the current structure. If the script is not available, regenerate manually.
 
-### 5. Extract Skills
+### 6. Extract Skills
 
 Look for reusable patterns buried in notes that should be skills:
 
 - Techniques that produced top scores repeatedly
 - Scripts or workflows described in notes but not yet packaged
 - Debugging approaches that multiple agents have used
+- Notes the usage scan shows are read by many distinct agents — repeated
+  cross-agent reads mean the content is a workflow, not a finding
 
 Package them in `.claude/skills/<name>/SKILL.md` with the standard skill format.
 
-### 6. Log Changes
+### 7. Log Changes
 
-Append a summary to `notes/_organization-log.md` describing what you reorganized and why.
+Append a summary to `notes/_organization-log.md` describing what you
+reorganized and why. Include the usage evidence behind each archive/merge
+decision (e.g. "archived foo.md: 0 reads across 42 agent sessions").
 
 ## Guidelines
 
 - Don't reorganize for its own sake — only when discovery is genuinely hard
+- Retire with evidence, never on a hunch — archive (reversible), don't
+  delete, and only when the usage scan shows sustained zero reads
 - Prefer updating existing skills over creating new ones
 - When merging notes, preserve specific numbers and scores
 - Return a concise summary: files moved, merged, skills created, index updated

--- a/coral/template/agents/librarian.md
+++ b/coral/template/agents/librarian.md
@@ -100,7 +100,14 @@ Look for reusable patterns buried in notes that should be skills:
 - Notes the usage scan shows are read by many distinct agents — repeated
   cross-agent reads mean the content is a workflow, not a finding
 
-Package them in `.claude/skills/<name>/SKILL.md` with the standard skill format.
+Before packaging, apply the admission gate in
+`.claude/skills/skill-creator/references/meta-skill.md` (recurrence +
+outcome evidence, beyond base-model competence, no 70%+ overlap with an
+existing skill, generalizes past the current task-state). Rejecting a
+candidate is a good outcome — every skill description permanently occupies
+every agent's context.
+
+Package the ones that pass in `.claude/skills/<name>/SKILL.md` with the standard skill format.
 
 ### 7. Log Changes
 

--- a/coral/template/skills/create-notes/SKILL.md
+++ b/coral/template/skills/create-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-notes
-description: "Write a note to {shared_dir}/notes/ that future agents can actually act on. Use after every coral eval, when a heartbeat (reflect / consolidate / pivot) asks for a note, or when you discover a grader / build / runtime issue that future agents will hit. Covers 4 note variants (experiment / infra / focus / synthesis), the required frontmatter with the team-level `creator:` filter, the structured-trace schema (`type` / `claim` / `status` / `confidence` / `based_on` / `evidence` / `supersedes` / `refutes` / `touched`) that populates the dashboard knowledge graph, the self-audit checklist (backfilled predictions, abandoned paths, sourced magic numbers, cross-links), the bundled `scripts/{stamp,lint,unattributed}.py` helpers, and the shell-escaping gotchas that silently strip markdown content. Trigger this skill whenever you are about to Write a file under notes/ — even if the prompt didn't say 'write a note'."
+description: "Write a note to {shared_dir}/notes/ that future agents can actually act on. Use after every coral eval, when a heartbeat (reflect / consolidate / pivot) asks for a note, or when you discover a grader / build / runtime issue that future agents will hit. Covers the before-you-write admission check (update-vs-new placement, note-vs-skill routing, discoverability), 4 note variants (experiment / infra / focus / synthesis), the required frontmatter with the team-level `creator:` filter, the structured-trace schema (`type` / `claim` / `status` / `confidence` / `based_on` / `evidence` / `supersedes` / `refutes` / `touched`) that populates the dashboard knowledge graph, the self-audit checklist (backfilled predictions, abandoned paths, sourced magic numbers, cross-links), the bundled `scripts/{stamp,lint,unattributed}.py` helpers, and the shell-escaping gotchas that silently strip markdown content. Trigger this skill whenever you are about to Write a file under notes/ — even if the prompt didn't say 'write a note'."
 ---
 
 # Create Notes
@@ -12,6 +12,40 @@ A good note answers three questions a future agent will actually ask:
 3. **What should I do — or not do — given this?** (ordered next steps + things you tried that failed)
 
 A bad note is a wall of headings with empty bodies, or a final-design pitch with no record of the alternatives you rejected. The bad pattern shows up enough that this skill exists to prevent it.
+
+## Before You Write — Admission and Placement
+
+Notes are the team's default, cheap knowledge medium — the bar for writing
+one is low (unlike skills, a note doesn't occupy every agent's context).
+The bar that matters is *placement*: the expensive failure mode is not a
+bad note, it's the tenth near-duplicate that fragments what the team knows
+and leaves every future reader unsure which copy is authoritative.
+
+Run this check before creating any new file:
+
+1. **Does this claim already have a home?** Search first — scan
+   `notes/index.md` and run `coral notes --search <keyword>` (or grep).
+   If an existing note covers the same claim or topic:
+   - New evidence on the same claim → **update that note** (append
+     evidence, adjust `status:` / `confidence:`), don't fork it.
+   - Your result contradicts it → a new note with `refutes:` pointing at
+     it, or an `_open-questions.md` entry — never a silent parallel note.
+   - A synthesis being replaced → new file with `supersedes:` (lineage
+     stays in the graph).
+
+   Per-eval experiment notes (Variant A) are the exception: append-only by
+   design, one per eval — dedup happens later at synthesis.
+2. **Is this actually a skill?** If what you're writing is a *repeatable
+   procedure* — steps and commands another agent will re-run, not a
+   finding — route it through skill-creator and its admission gate
+   (`{shared_dir}/skills/skill-creator/references/meta-skill.md`). The
+   skill-vs-note table there decides in one glance.
+3. **Will anyone find it?** Write the title and `claim:` in the vocabulary
+   a *different* agent would search for, not your private shorthand; add
+   the `index.md` entry; link the notes you built on. The librarian
+   periodically scans agent logs for what actually gets read (scan-usage
+   skill) — notes nobody reads get archived. Discovery is designed, not
+   hoped for.
 
 ## When to Use
 

--- a/coral/template/skills/scan-usage/SKILL.md
+++ b/coral/template/skills/scan-usage/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: scan-usage
+description: "Measure which shared notes and skills agents actually read by scanning agent session logs. Use before archiving, merging, or retiring knowledge — curation decisions should be based on usage evidence, not guesses."
+---
+
+# Scan Usage
+
+Answer "is anyone actually reading this?" with evidence from agent session
+logs, instead of asking agents to self-report or guessing from file age.
+
+## When to Use
+
+- Before archiving or deleting a note — check nobody depends on it
+- Before retiring or rewriting a skill — check whether it is ever invoked
+- Deciding which notes to consolidate first (heavily-read ones pay off most)
+- Checking whether a skill you built is being discovered by other agents
+- During a librarian audit, to rank the knowledge base by real consumption
+
+## Usage
+
+```bash
+# Full report: per-skill uses, per-note reads/writes, never-read inventory
+python .claude/skills/scan-usage/scripts/scan_usage.py
+
+# Machine-readable, for filtering with jq or python
+python .claude/skills/scan-usage/scripts/scan_usage.py --json
+
+# One agent's reading habits
+python .claude/skills/scan-usage/scripts/scan_usage.py --agent agent-2
+```
+
+The script reads `.claude/logs/*.log` (every agent's session log, NDJSON)
+and counts agent-initiated tool calls touching `notes/` and `skills/`:
+
+| Signal | Counted as |
+|---|---|
+| `Read` of `notes/<path>.md` | note read |
+| `cat` / `sed` / `grep` a specific note file in Bash | note read |
+| `Write` / `Edit` of a note | note write (authorship, not consumption) |
+| `Glob` / `Grep` patterns under `notes/` | browse (discovery only) |
+| `Skill` tool invocation | skill use |
+| Reading or running anything under `skills/<name>/` | skill use |
+| `coral skills --read <name>` | skill use |
+
+It then diffs against what exists on disk and lists **never-read notes**
+and **never-used skills**. It never modifies files.
+
+## Interpreting the Numbers
+
+- **High reads + many distinct readers** — load-bearing knowledge. Keep it
+  authoritative: merge duplicates *into* it, keep its path stable, improve
+  it rather than fragmenting.
+- **Writes but zero reads by others** — the author is talking to themselves.
+  Candidate for merging into a hub note, or its title/index entry needs to
+  be more discoverable.
+- **Never read / never used** — retirement candidate, but apply an
+  **evidence floor**: low counts early in a run mean "not yet", not
+  "useless". Only archive when the run has accumulated enough activity
+  (many evals since the file was created) and the count is still zero.
+  Archive (move to `notes/_archive/`), don't delete — archiving is
+  reversible via checkpoint history, premature deletion is how useful
+  knowledge gets destroyed.
+- **A skill with uses concentrated in its author** — the description in its
+  SKILL.md frontmatter probably doesn't trigger for anyone else; rewrite it.
+
+## Known Blind Spots
+
+- **Subagent activity is invisible.** Tool calls made inside spawned
+  subagents (deep-researcher, librarian) only appear in logs as progress
+  events without file paths, so their reads are not counted. Reads from the
+  main agent loop dominate in practice.
+- `coral notes --read N` is index-based; those reads are counted in
+  aggregate but can't be attributed to a specific note (reported separately).
+- Logs only cover this run (and this island, in multi-island mode). A note
+  seeded from a warm start may look unread here yet have earned its place
+  in a previous run.

--- a/coral/template/skills/scan-usage/scripts/scan_usage.py
+++ b/coral/template/skills/scan-usage/scripts/scan_usage.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""scan_usage.py — Measure which shared notes and skills agents actually read.
+
+Scans agent session logs (NDJSON) for agent-initiated tool calls that touch
+the shared notes/ and skills/ directories, then cross-references the files
+that exist on disk. This gives the librarian *outcome evidence* — which
+knowledge is actually consumed — instead of relying on agents to self-report.
+
+Usage:
+    python scan_usage.py [LOGS_DIR] [--notes-dir DIR] [--skills-dir DIR]
+                         [--agent ID] [--top N] [--json]
+
+Defaults assume it runs inside an agent worktree: logs at .claude/logs,
+notes at .claude/notes, skills at .claude/skills (any shared_dir name works —
+.codex/.opencode/... paths in logs are matched too).
+
+What counts:
+  - note READ: Read tool on notes/<path>.md, or a Bash command that names a
+    specific note file (cat/sed/grep/head/...).
+  - note WRITE: Write/Edit/NotebookEdit on notes/<path>.md.
+  - note BROWSE: Glob/Grep patterns under notes/ (discovery, not consumption).
+  - skill USE: Skill tool invocation, Read of any file inside skills/<name>/,
+    or a Bash command referencing skills/<name>/ (e.g. running its scripts),
+    or `coral skills --read <name>`.
+
+Only assistant-initiated tool calls are counted — tool *results* (directory
+listings, note contents echoing other paths) are ignored, so `ls notes/`
+does not mark every note as read.
+
+This script NEVER modifies any files. Self-contained — no coral imports.
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# <dot-dir>/notes/<relpath with extension>  e.g. .claude/notes/experiments/foo.md
+# also matches .coral/public/notes/... and .coral/islands/3/notes/...
+_NOTE_RE = re.compile(
+    r"(?:\.[A-Za-z][\w.-]*|public|islands/\d+)/notes/((?:[\w.+-]+/)*[\w.+-]+\.\w+)"
+)
+_SKILL_RE = re.compile(r"(?:\.[A-Za-z][\w.-]*|public|islands/\d+)/skills/([\w-]+)")
+_CORAL_SKILLS_READ_RE = re.compile(r"coral\s+skills\s+--read[\s=]+([\w-]+)")
+# `... > notes/x.md`, `... >> notes/x.md`, `... | tee notes/x.md` are writes;
+# trailing [\w./-]* absorbs an absolute-path prefix before the matched dot-dir
+_SHELL_REDIRECT_RE = re.compile(r"(?:>>?|\btee(?:\s+-a)?)\s*['\"]?[\w./-]*$")
+
+_READ_TOOLS = {"Read"}
+_WRITE_TOOLS = {"Write", "Edit", "NotebookEdit"}
+_BROWSE_TOOLS = {"Glob", "Grep"}
+
+
+def _agent_id_from_log(path: Path) -> str:
+    """agent-1.3.log -> agent-1 (logs are named <agent_id>.<index>.log)."""
+    parts = path.stem.rsplit(".", 1)
+    return parts[0] if len(parts) == 2 and parts[1].isdigit() else path.stem
+
+
+def _iter_tool_uses(path: Path):
+    """Yield (tool_name, input_dict) for agent-initiated tool calls in a log.
+
+    Supports Claude Code stream-json (assistant messages with tool_use
+    blocks). Other runtimes' JSONL is handled tolerantly: any event carrying
+    a top-level or item-level "command" string (Codex-style command
+    execution) is yielded as a Bash call. Unknown lines are skipped.
+    """
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict):
+                continue
+
+            msg_type = obj.get("type", "")
+            if msg_type == "assistant":
+                content = obj.get("message", {}).get("content", [])
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            yield block.get("name", ""), block.get("input") or {}
+            elif msg_type in ("user", "result", "system", "coral"):
+                # Tool results / metadata — never count paths echoed in output.
+                continue
+            else:
+                # Non-Claude-Code runtimes: pick up command-execution events.
+                cmd = obj.get("command")
+                if cmd is None and isinstance(obj.get("item"), dict):
+                    cmd = obj["item"].get("command")
+                if isinstance(cmd, list):
+                    cmd = " ".join(str(c) for c in cmd)
+                if isinstance(cmd, str) and cmd:
+                    yield "Bash", {"command": cmd}
+
+
+def _new_stats() -> dict:
+    return {
+        "reads": 0,
+        "writes": 0,
+        "browses": 0,
+        "readers": defaultdict(int),
+        "writers": defaultdict(int),
+    }
+
+
+def scan_logs(logs_dir: Path, only_agent: str | None = None) -> tuple[dict, dict, int]:
+    """Return (note_stats, skill_stats, unresolved_note_reads).
+
+    note_stats:  {relpath: {reads, writes, browses, readers{agent: n}, writers{agent: n}}}
+    skill_stats: {name:    {uses, users{agent: n}}}
+    unresolved_note_reads counts `coral notes --read N` calls (index-based,
+    can't be mapped back to a filename after the fact).
+    """
+    notes: dict[str, dict] = defaultdict(_new_stats)
+    skills: dict[str, dict] = defaultdict(lambda: {"uses": 0, "users": defaultdict(int)})
+    unresolved = 0
+
+    for log_file in sorted(logs_dir.glob("*.log")):
+        agent = _agent_id_from_log(log_file)
+        if only_agent and agent != only_agent:
+            continue
+        for tool, tool_input in _iter_tool_uses(log_file):
+            if not isinstance(tool_input, dict):
+                continue
+
+            if tool == "Skill":
+                name = tool_input.get("skill") or tool_input.get("name") or ""
+                # Strip plugin namespacing like "coral:deep-research".
+                name = str(name).rsplit(":", 1)[-1]
+                if name:
+                    skills[name]["uses"] += 1
+                    skills[name]["users"][agent] += 1
+                continue
+
+            if tool in _READ_TOOLS or tool in _WRITE_TOOLS:
+                text = str(tool_input.get("file_path") or tool_input.get("path") or "")
+                kind = "read" if tool in _READ_TOOLS else "write"
+            elif tool in _BROWSE_TOOLS:
+                text = f"{tool_input.get('path') or ''} {tool_input.get('pattern') or ''}"
+                kind = "browse"
+            elif tool == "Bash":
+                text = str(tool_input.get("command") or "")
+                kind = "read"  # naming a specific file in a command ≈ consuming it
+                if re.search(r"coral\s+notes\s+--read\b", text):
+                    unresolved += 1
+                for m in _CORAL_SKILLS_READ_RE.finditer(text):
+                    skills[m.group(1)]["uses"] += 1
+                    skills[m.group(1)]["users"][agent] += 1
+            else:
+                continue
+
+            for m in _NOTE_RE.finditer(text):
+                rel = m.group(1)
+                stats = notes[rel]
+                hit_kind = kind
+                if tool == "Bash" and _SHELL_REDIRECT_RE.search(text[: m.start()]):
+                    hit_kind = "write"
+                if hit_kind == "read":
+                    stats["reads"] += 1
+                    stats["readers"][agent] += 1
+                elif hit_kind == "write":
+                    stats["writes"] += 1
+                    stats["writers"][agent] += 1
+                else:
+                    stats["browses"] += 1
+            for m in _SKILL_RE.finditer(text):
+                # Only consumption counts as a use — not browsing, not
+                # authoring (Write/Edit or shell redirects into skills/).
+                if kind != "read":
+                    continue
+                if tool == "Bash" and _SHELL_REDIRECT_RE.search(text[: m.start()]):
+                    continue
+                skills[m.group(1)]["uses"] += 1
+                skills[m.group(1)]["users"][agent] += 1
+
+    return dict(notes), dict(skills), unresolved
+
+
+def inventory(notes_dir: Path, skills_dir: Path) -> tuple[list[str], list[str]]:
+    """Files that exist on disk: (note relpaths, skill names)."""
+    note_files = []
+    if notes_dir.is_dir():
+        note_files = sorted(
+            str(p.relative_to(notes_dir))
+            for p in notes_dir.rglob("*.md")
+            if "_archive" not in p.relative_to(notes_dir).parts
+        )
+    skill_names = []
+    if skills_dir.is_dir():
+        skill_names = sorted(p.parent.name for p in skills_dir.glob("*/SKILL.md"))
+    return note_files, skill_names
+
+
+def _fmt_agents(counts: dict) -> str:
+    return ", ".join(f"{a}({n})" for a, n in sorted(counts.items(), key=lambda kv: -kv[1]))
+
+
+def render_text(report: dict, top: int) -> str:
+    out = []
+    sk = report["skills"]
+    out.append(f"== Skills ({len(sk['on_disk'])} on disk) ==")
+    ranked = sorted(sk["usage"].items(), key=lambda kv: -kv[1]["uses"])[:top]
+    if ranked:
+        width = max(len(name) for name, _ in ranked)
+        for name, s in ranked:
+            out.append(
+                f"  {name:<{width}}  uses={s['uses']:<4} agents={len(s['users'])}  {_fmt_agents(s['users'])}"
+            )
+    if sk["never_used"]:
+        out.append(f"  never used ({len(sk['never_used'])}): {', '.join(sk['never_used'])}")
+
+    nt = report["notes"]
+    out.append("")
+    out.append(f"== Notes ({len(nt['on_disk'])} on disk) ==")
+    ranked = sorted(nt["usage"].items(), key=lambda kv: -kv[1]["reads"])[:top]
+    if ranked:
+        width = max(len(p) for p, _ in ranked)
+        for path, s in ranked:
+            out.append(
+                f"  {path:<{width}}  reads={s['reads']:<4} writes={s['writes']:<3} "
+                f"distinct readers={len(s['readers'])}  {_fmt_agents(s['readers'])}"
+            )
+    if nt["never_read"]:
+        out.append(f"  never read ({len(nt['never_read'])}):")
+        for p in nt["never_read"]:
+            out.append(f"    {p}")
+    if nt["unresolved_reads"]:
+        out.append(
+            f"  (+{nt['unresolved_reads']} `coral notes --read N` calls that "
+            f"can't be attributed to a specific note)"
+        )
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("logs_dir", nargs="?", default=".claude/logs", help="agent logs dir")
+    parser.add_argument("--notes-dir", default=".claude/notes")
+    parser.add_argument("--skills-dir", default=".claude/skills")
+    parser.add_argument("--agent", help="only count one agent's activity")
+    parser.add_argument("--top", type=int, default=30, help="max rows per table")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    logs_dir = Path(args.logs_dir)
+    if not logs_dir.is_dir():
+        print(f"error: logs dir not found: {logs_dir}", file=sys.stderr)
+        return 1
+
+    note_usage, skill_usage, unresolved = scan_logs(logs_dir, args.agent)
+    notes_on_disk, skills_on_disk = inventory(Path(args.notes_dir), Path(args.skills_dir))
+
+    read_notes = {p for p, s in note_usage.items() if s["reads"] or s["browses"]}
+    report = {
+        "notes": {
+            "on_disk": notes_on_disk,
+            "usage": {
+                p: {
+                    "reads": s["reads"],
+                    "writes": s["writes"],
+                    "browses": s["browses"],
+                    "readers": dict(s["readers"]),
+                    "writers": dict(s["writers"]),
+                }
+                for p, s in note_usage.items()
+            },
+            "never_read": [p for p in notes_on_disk if p not in read_notes],
+            "unresolved_reads": unresolved,
+        },
+        "skills": {
+            "on_disk": skills_on_disk,
+            "usage": {
+                n: {"uses": s["uses"], "users": dict(s["users"])} for n, s in skill_usage.items()
+            },
+            "never_used": [n for n in skills_on_disk if n not in skill_usage],
+        },
+    }
+
+    if args.as_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report, args.top))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/coral/template/skills/skill-creator/SKILL.md
+++ b/coral/template/skills/skill-creator/SKILL.md
@@ -15,6 +15,21 @@ Create skills by analyzing your own work patterns — you are both creator and e
 
 Before drafting, identify what skill to build and confirm it doesn't already exist.
 
+### Admission Gate (read first)
+
+Read `references/meta-skill.md` — the admission standards for the shared
+library — before drafting anything. In short, a skill must clear all five:
+
+1. **Recurrence**: the pattern showed up ≥3 times (or in 2+ agents independently)
+2. **Outcome link**: it's tied to better scores or major time savings, with evidence you can cite
+3. **Beyond base-model competence**: a fresh agent without it would plausibly fail
+4. **No existing home**: nothing at 70%+ overlap (update that skill instead)
+5. **Generalizes**: phrased for the kind of problem, not the current file/dataset
+
+If any fails, stop here and write a note instead — a rejected skill is a
+good outcome, because every skill's description permanently occupies every
+agent's context. The gate is where library quality is decided.
+
 ### Pattern Detection
 
 Scan these sources for repeated, reusable patterns:
@@ -34,6 +49,10 @@ coral skills
 ```
 
 Read each relevant `SKILL.md` frontmatter. If an existing skill has 70%+ overlap with your candidate, **update that skill** instead of creating a new one.
+
+If an adjacent skill exists but never gets used (check with
+`python .claude/skills/scan-usage/scripts/scan_usage.py` if available), fix
+its description rather than creating a sibling that splits the trigger.
 
 ### Output
 
@@ -362,13 +381,15 @@ The `agents/` directory contains instructions for specialized subagents. Read th
 - `agents/comparator.md` — Blind A/B comparison between two outputs
 - `agents/analyzer.md` — Analyze benchmark results and why one version beat another
 
-The `references/` directory has schema documentation:
+The `references/` directory has schema and policy documentation:
+- `references/meta-skill.md` — admission standards for the shared library (read before drafting)
 - `references/schemas.md` — JSON structures for evals.json, grading.json, benchmark.json, etc.
 
 ---
 
 ## Summary
 
+0. **Gate** the candidate against `references/meta-skill.md` — reject freely
 1. **Analyze** your work patterns for reusable skills
 2. **Draft** the SKILL.md following the writing guide
 3. **Test** with generated cases (with-skill vs baseline)

--- a/coral/template/skills/skill-creator/references/meta-skill.md
+++ b/coral/template/skills/skill-creator/references/meta-skill.md
@@ -1,0 +1,88 @@
+# The Meta-Skill — Admission Standards for the Shared Skill Library
+
+Read this before drafting any new skill. It defines what deserves to enter
+the shared library, what belongs elsewhere, and the consistency standards
+every skill must meet.
+
+**Why a gate exists at birth.** Every skill's description is loaded into
+*every* agent's context for trigger-matching, permanently. A weak skill is
+not neutral: it dilutes triggering for every good skill, adds a
+near-duplicate for future dedup work, and burdens the librarian's
+retirement pass. Research on self-evolving skill libraries finds that
+ungoverned LLM-authored skills contribute roughly nothing on their own —
+the value comes from curation: strict admission plus evidence-based
+retirement. Cheap prevention here beats expensive cleanup later.
+
+## Admission gate
+
+All five must hold before you draft. If any fails, write a note instead
+(or update an existing skill) — a rejected skill is a good outcome.
+
+1. **Recurrence evidence.** The pattern appeared at least 3 times in real
+   work — across your own attempts, or independently in 2+ agents (check
+   notes and attempt history). A clever trick used once is a note, not a
+   skill.
+2. **Outcome link.** The pattern is tied to results: attempts using it
+   scored better, or it repeatedly saved substantial time or avoided a
+   recurring failure. "Seems useful" without an attempt or note to point
+   at does not pass. Record the evidence — you will cite it in the spec.
+3. **Beyond base-model competence.** Would a fresh agent without this
+   skill plausibly fail or waste real time? If the model already does it
+   fine when asked, packaging it adds context cost and zero capability.
+4. **No existing home.** Run `coral skills` and read the frontmatter of
+   anything adjacent. At 70%+ overlap, update that skill instead. If an
+   adjacent skill exists but is never used (check the librarian's usage
+   scan, or run `.claude/skills/scan-usage/scripts/scan_usage.py`), fix
+   its description — don't birth a sibling that will split the trigger.
+5. **Generalizes past this task-state.** The skill must be phrased in
+   terms of the *kind* of problem, not the current file names, dataset,
+   or attempt. If it only works for the exact situation you're in now,
+   it's a note about that situation.
+
+## Skill vs note
+
+| Content | Home |
+|---|---|
+| A finding, measurement, comparison, or dead end | Note |
+| Config values, magic constants, environment quirks | Note |
+| A repeatable procedure with steps and/or scripts | Skill |
+| A workflow 2+ agents keep reinventing | Skill |
+| An insight about *this* codebase's structure | Note (skills outlive context) |
+
+## Scope and granularity
+
+- **One workflow per skill.** If the SKILL.md needs "Part A / Part B" for
+  unrelated procedures, that's two skills — or one skill and one rejection.
+- **Deterministic steps become `scripts/`**, not prose. Prose instructions
+  drift; scripts don't.
+- **Kebab-case name that says what it does** (`profile-kernel`, not
+  `helper-v2` or `agent3-tricks`).
+- Keep SKILL.md focused (the writing guide's 500-line ceiling); push
+  depth into `references/`.
+
+## Description standards
+
+The frontmatter description is the skill's entire trigger surface:
+
+- State what it does AND the concrete situations that should trigger it.
+- Include the vocabulary a *different* agent would use when hitting the
+  problem — not just your own phrasing. A description only its author can
+  trigger produces a skill only its author uses.
+- Name the situations where it should NOT trigger if near-misses are
+  likely.
+
+## Consistency with the library
+
+- Match the structure and tone of the bundled skills (imperative voice,
+  explain *why* over ALWAYS/NEVER walls, progressive disclosure).
+- Stamp `creator:` in the frontmatter (see SKILL.md "Frontmatter
+  discipline") — unattributed skills are excluded from provenance and
+  migration flows.
+
+## Lifecycle expectations
+
+Admission is not tenure. The librarian periodically runs a usage scan over
+agent logs; skills that go unused get their descriptions rewritten and are
+eventually archived. Design for discovery (description quality), and when
+you improve a workflow, update the existing skill in place — history lives
+in the checkpoint repo, so edits are safe and forks are clutter.

--- a/coral/template/skills/skill-creator/references/meta-skill.md
+++ b/coral/template/skills/skill-creator/references/meta-skill.md
@@ -49,6 +49,11 @@ All five must hold before you draft. If any fails, write a note instead
 | A workflow 2+ agents keep reinventing | Skill |
 | An insight about *this* codebase's structure | Note (skills outlive context) |
 
+The same principles govern the note side — placement over duplication,
+update-vs-new, discoverability — via the "Before You Write" check in the
+`create-notes` skill. Route note-shaped content there, not to a thinner
+gate.
+
 ## Scope and granularity
 
 - **One workflow per skill.** If the SKILL.md needs "Part A / Part B" for

--- a/tests/test_meta_skill.py
+++ b/tests/test_meta_skill.py
@@ -1,0 +1,30 @@
+"""The meta-skill admission gate stays wired into every skill-authoring path.
+
+Library quality is decided at birth: skill-creator and the librarian are the
+two places agents package new skills, and both must route candidates through
+the admission standards in skill-creator's references/meta-skill.md. This
+test is the regression gate for that wiring surviving future prompt edits.
+"""
+
+from pathlib import Path
+
+_META = Path("coral/template/skills/skill-creator/references/meta-skill.md")
+
+
+def test_meta_skill_document_exists_with_gate():
+    text = _META.read_text(encoding="utf-8").lower()
+    assert "admission gate" in text
+    # The five criteria that make a candidate library-worthy.
+    for criterion in ("recurrence", "outcome", "base-model", "overlap", "generalize"):
+        assert criterion in text, f"meta-skill.md must keep the {criterion!r} criterion"
+
+
+def test_skill_creator_routes_through_admission_gate():
+    text = Path("coral/template/skills/skill-creator/SKILL.md").read_text(encoding="utf-8")
+    assert "references/meta-skill.md" in text
+    assert "Admission Gate" in text
+
+
+def test_librarian_routes_through_admission_gate():
+    text = Path("coral/template/agents/librarian.md").read_text(encoding="utf-8")
+    assert "skill-creator/references/meta-skill.md" in text

--- a/tests/test_meta_skill.py
+++ b/tests/test_meta_skill.py
@@ -1,9 +1,12 @@
-"""The meta-skill admission gate stays wired into every skill-authoring path.
+"""The meta-skill admission gate stays wired into every knowledge-authoring path.
 
 Library quality is decided at birth: skill-creator and the librarian are the
 two places agents package new skills, and both must route candidates through
-the admission standards in skill-creator's references/meta-skill.md. This
-test is the regression gate for that wiring surviving future prompt edits.
+the admission standards in skill-creator's references/meta-skill.md; the
+same principles (update-vs-new placement, note-vs-skill routing,
+discoverability) apply to note creation via create-notes' before-you-write
+check. This test is the regression gate for that wiring surviving future
+prompt edits.
 """
 
 from pathlib import Path
@@ -28,3 +31,12 @@ def test_skill_creator_routes_through_admission_gate():
 def test_librarian_routes_through_admission_gate():
     text = Path("coral/template/agents/librarian.md").read_text(encoding="utf-8")
     assert "skill-creator/references/meta-skill.md" in text
+
+
+def test_create_notes_applies_admission_principles():
+    text = Path("coral/template/skills/create-notes/SKILL.md").read_text(encoding="utf-8")
+    assert "Before You Write" in text
+    # Update-vs-new placement, note-vs-skill routing, and discoverability.
+    assert "update that note" in text
+    assert "skill-creator/references/meta-skill.md" in text
+    assert "scan-usage" in text

--- a/tests/test_scan_usage.py
+++ b/tests/test_scan_usage.py
@@ -1,0 +1,309 @@
+"""Tests for the bundled scan-usage skill script (agent log usage attribution)."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).parent.parent
+    / "coral"
+    / "template"
+    / "skills"
+    / "scan-usage"
+    / "scripts"
+    / "scan_usage.py"
+)
+
+
+@pytest.fixture(scope="module")
+def scan_usage():
+    spec = importlib.util.spec_from_file_location("scan_usage", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _assistant_line(*blocks: dict) -> str:
+    return json.dumps({"type": "assistant", "message": {"content": list(blocks)}})
+
+
+def _tool_use(name: str, tool_input: dict) -> dict:
+    return {"type": "tool_use", "name": name, "input": tool_input}
+
+
+def _write_log(logs_dir: Path, name: str, lines: list[str]) -> None:
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / name).write_text("\n".join(lines) + "\n")
+
+
+def test_read_tool_counts_note_read(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-1.0.log",
+        [
+            _assistant_line(
+                _tool_use(
+                    "Read", {"file_path": "/run/agents/agent-1/.claude/notes/experiments/greedy.md"}
+                )
+            )
+        ],
+    )
+    notes, skills, unresolved = scan_usage.scan_logs(tmp_path)
+    assert notes["experiments/greedy.md"]["reads"] == 1
+    assert notes["experiments/greedy.md"]["readers"] == {"agent-1": 1}
+    assert skills == {}
+    assert unresolved == 0
+
+
+def test_bash_cat_counts_read_but_redirect_counts_write(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-2.0.log",
+        [
+            _assistant_line(_tool_use("Bash", {"command": "cat .claude/notes/findings.md"})),
+            _assistant_line(_tool_use("Bash", {"command": "echo hi > .claude/notes/mine.md"})),
+            _assistant_line(
+                _tool_use("Bash", {"command": "python x.py | tee /abs/path/.claude/notes/log.md"})
+            ),
+        ],
+    )
+    notes, _, _ = scan_usage.scan_logs(tmp_path)
+    assert notes["findings.md"]["reads"] == 1
+    assert notes["mine.md"]["writes"] == 1
+    assert notes["mine.md"]["reads"] == 0
+    assert notes["log.md"]["writes"] == 1
+
+
+def test_write_and_edit_tools_count_as_writes(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-1.0.log",
+        [
+            _assistant_line(
+                _tool_use("Write", {"file_path": ".claude/notes/new.md", "content": "x"})
+            ),
+            _assistant_line(_tool_use("Edit", {"file_path": ".claude/notes/new.md"})),
+        ],
+    )
+    notes, _, _ = scan_usage.scan_logs(tmp_path)
+    assert notes["new.md"]["writes"] == 2
+    assert notes["new.md"]["reads"] == 0
+
+
+def test_glob_counts_browse_not_read(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-1.0.log",
+        [_assistant_line(_tool_use("Glob", {"pattern": ".claude/notes/research/topic.md"}))],
+    )
+    notes, _, _ = scan_usage.scan_logs(tmp_path)
+    assert notes["research/topic.md"]["browses"] == 1
+    assert notes["research/topic.md"]["reads"] == 0
+
+
+def test_tool_results_are_ignored(scan_usage, tmp_path):
+    # A directory listing in a tool result must not mark notes as read.
+    result_line = json.dumps(
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "content": "found .claude/notes/a.md and .claude/notes/b.md",
+                    }
+                ]
+            },
+        }
+    )
+    _write_log(tmp_path, "agent-1.0.log", [result_line])
+    notes, skills, _ = scan_usage.scan_logs(tmp_path)
+    assert notes == {}
+    assert skills == {}
+
+
+def test_skill_uses_from_skill_tool_read_and_cli(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-1.0.log",
+        [
+            _assistant_line(_tool_use("Skill", {"skill": "coral:deep-research", "args": "q"})),
+            _assistant_line(
+                _tool_use("Read", {"file_path": ".claude/skills/organize-files/SKILL.md"})
+            ),
+            _assistant_line(
+                _tool_use(
+                    "Bash", {"command": "python .claude/skills/organize-files/scripts/audit.sh"}
+                )
+            ),
+            _assistant_line(_tool_use("Bash", {"command": "coral skills --read skill-creator"})),
+        ],
+    )
+    _, skills, _ = scan_usage.scan_logs(tmp_path)
+    assert skills["deep-research"]["uses"] == 1
+    assert skills["organize-files"]["uses"] == 2
+    assert skills["skill-creator"]["uses"] == 1
+
+
+def test_authoring_a_skill_is_not_a_use(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-1.0.log",
+        [
+            _assistant_line(_tool_use("Write", {"file_path": ".claude/skills/my-tool/SKILL.md"})),
+            _assistant_line(
+                _tool_use("Bash", {"command": "echo x > .claude/skills/my-tool/scripts/run.py"})
+            ),
+            _assistant_line(_tool_use("Glob", {"pattern": ".claude/skills/my-tool/*"})),
+        ],
+    )
+    _, skills, _ = scan_usage.scan_logs(tmp_path)
+    assert "my-tool" not in skills
+
+
+def test_bare_directory_listing_matches_nothing(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-1.0.log",
+        [
+            _assistant_line(
+                _tool_use("Bash", {"command": "ls .claude/notes/ && ls .claude/skills/"})
+            )
+        ],
+    )
+    notes, skills, _ = scan_usage.scan_logs(tmp_path)
+    assert notes == {}
+    assert skills == {}
+
+
+def test_coral_notes_read_counts_unresolved(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-1.0.log",
+        [_assistant_line(_tool_use("Bash", {"command": "coral notes --read 3"}))],
+    )
+    notes, _, unresolved = scan_usage.scan_logs(tmp_path)
+    assert notes == {}
+    assert unresolved == 1
+
+
+def test_codex_style_command_events(scan_usage, tmp_path):
+    lines = [
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "command_execution", "command": "cat .codex/notes/plan.md"},
+            }
+        )
+    ]
+    _write_log(tmp_path, "agent-1.0.log", lines)
+    notes, _, _ = scan_usage.scan_logs(tmp_path)
+    assert notes["plan.md"]["reads"] == 1
+
+
+def test_agent_filter_and_multiple_logs(scan_usage, tmp_path):
+    read = _assistant_line(_tool_use("Read", {"file_path": ".claude/notes/shared.md"}))
+    _write_log(tmp_path, "agent-1.0.log", [read])
+    _write_log(tmp_path, "agent-1.1.log", [read])
+    _write_log(tmp_path, "agent-2.0.log", [read])
+
+    notes, _, _ = scan_usage.scan_logs(tmp_path)
+    assert notes["shared.md"]["reads"] == 3
+    assert notes["shared.md"]["readers"] == {"agent-1": 2, "agent-2": 1}
+
+    notes, _, _ = scan_usage.scan_logs(tmp_path, only_agent="agent-2")
+    assert notes["shared.md"]["readers"] == {"agent-2": 1}
+
+
+def test_malformed_lines_are_skipped(scan_usage, tmp_path):
+    _write_log(
+        tmp_path,
+        "agent-1.0.log",
+        [
+            "not json at all",
+            '{"type": "assistant"}',
+            '{"type": "assistant", "message": {"content": "plain string"}}',
+            "[1, 2, 3]",
+            _assistant_line(_tool_use("Read", {"file_path": ".claude/notes/ok.md"})),
+        ],
+    )
+    notes, _, _ = scan_usage.scan_logs(tmp_path)
+    assert notes["ok.md"]["reads"] == 1
+
+
+def test_inventory_and_never_read(scan_usage, tmp_path):
+    notes_dir = tmp_path / "notes"
+    (notes_dir / "research").mkdir(parents=True)
+    (notes_dir / "research" / "seen.md").write_text("x")
+    (notes_dir / "research" / "unseen.md").write_text("x")
+    (notes_dir / "_archive").mkdir()
+    (notes_dir / "_archive" / "old.md").write_text("x")
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "used-skill").mkdir(parents=True)
+    (skills_dir / "used-skill" / "SKILL.md").write_text("x")
+    (skills_dir / "dead-skill").mkdir()
+    (skills_dir / "dead-skill" / "SKILL.md").write_text("x")
+
+    note_files, skill_names = scan_usage.inventory(notes_dir, skills_dir)
+    assert note_files == ["research/seen.md", "research/unseen.md"]
+    assert skill_names == ["dead-skill", "used-skill"]
+
+
+def test_cli_json_end_to_end(scan_usage, tmp_path):
+    import subprocess
+    import sys
+
+    logs = tmp_path / "logs"
+    _write_log(
+        logs,
+        "agent-1.0.log",
+        [
+            _assistant_line(_tool_use("Read", {"file_path": ".claude/notes/seen.md"})),
+            _assistant_line(_tool_use("Skill", {"skill": "used-skill"})),
+        ],
+    )
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "seen.md").write_text("x")
+    (notes_dir / "unseen.md").write_text("x")
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "used-skill").mkdir(parents=True)
+    (skills_dir / "used-skill" / "SKILL.md").write_text("x")
+    (skills_dir / "dead-skill").mkdir()
+    (skills_dir / "dead-skill" / "SKILL.md").write_text("x")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            str(logs),
+            "--notes-dir",
+            str(notes_dir),
+            "--skills-dir",
+            str(skills_dir),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    report = json.loads(proc.stdout)
+    assert report["notes"]["never_read"] == ["unseen.md"]
+    assert report["notes"]["usage"]["seen.md"]["reads"] == 1
+    assert report["skills"]["never_used"] == ["dead-skill"]
+    assert report["skills"]["usage"]["used-skill"]["uses"] == 1
+
+
+def test_cli_missing_logs_dir_errors(tmp_path):
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(tmp_path / "nope")],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 1
+    assert "not found" in proc.stderr


### PR DESCRIPTION
## Motivation

Inspired by the "library drift" line of work on self-evolving skill libraries (arXiv:2605.19576): ungoverned LLM-authored skills contribute roughly nothing on their own — the value comes from governance, i.e. evidence-based curation at retirement time and strict admission at birth time. CORAL already has the roles (librarian subagent, skill-creator, create-notes) but their decisions were disconnected from outcome evidence. This PR wires them together.

## What's in here

**1. `scan-usage` bundled skill — usage attribution from agent logs**

Instead of asking agents to self-report which notes/skills they used, `scripts/scan_usage.py` scans every agent's session log (`.claude/logs/*.log`, NDJSON) and counts *agent-initiated* tool calls touching `notes/` and `skills/`:

- `Read` / Bash `cat|sed|grep` of a specific note → read; `Write`/`Edit` and shell redirects (`>`, `tee`) → write; `Glob`/`Grep` → browse
- `Skill` tool invocations, reads/executions under `skills/<name>/`, `coral skills --read <name>` → skill use (authoring a skill is not a use)
- Tool *results* are ignored, so `ls notes/` output doesn't mark every note as read
- Diffs against disk to report **never-read notes** and **never-used skills**; per-agent breakdown; `--json`
- Tolerant of codex-style command-execution JSONL; known blind spot documented (subagent tool calls aren't visible in logs)

The librarian template now runs this scan before touching anything, and applies an **evidence floor**: archive only on sustained zero reads with real run activity behind it (premature retirement destroys knowledge), never delete.

**2. Meta-skill admission standards (`skill-creator/references/meta-skill.md`)**

A five-point admission gate applied before drafting any new skill — recurrence evidence (≥3 occurrences or 2+ agents), outcome link (tied to scores/time saved, with citable evidence), beyond base-model competence, no existing home (70%+ overlap → update instead; unused adjacent skill → fix its description, don't birth a sibling), generalizes past the current task-state — plus skill-vs-note placement rules, scope/description standards, and lifecycle expectations. Both authoring paths (skill-creator and the librarian's extract-skills step) route through it.

**3. Same principles applied to note creation (`create-notes`)**

A "Before You Write — Admission and Placement" check: search for an existing home first (update / `refutes:` / `supersedes:` instead of forking near-duplicates; per-eval experiment notes stay append-only), route repeatable procedures to skill-creator's gate, and design for discovery — since the librarian's usage scan archives notes nobody reads.

## Tests

- `tests/test_scan_usage.py` — 15 cases for the scanner (read/write/browse semantics, redirect detection, tool-result immunity, codex events, agent attribution, CLI e2e)
- `tests/test_meta_skill.py` — regression gate that the admission wiring survives future prompt edits (skill-creator, librarian, create-notes)
- Full suite: 636 passed, 1 skipped; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)