### PR TITLE
docs: update CORAL site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
-[![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://human-agent-society.github.io/CORAL/)
+[![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/)
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-3776AB.svg?logo=python&logoColor=white)](https://python.org)
 
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-<a href="#installation">Installation</a> · <a href="#plugin-drive-coral-from-your-own-agent">Plugin</a> · <a href="#supported-agents">Supported Agents</a> · <a href="#how-it-works">How It Works</a> · <a href="#examples">Examples</a> · <a href="https://docs.coralxyz.com/">Docs</a> · <a href="https://arxiv.org/abs/2604.01658v1">Paper</a>
+<a href="#installation">Installation</a> · <a href="#plugin-drive-coral-from-your-own-agent">Plugin</a> · <a href="#supported-agents">Supported Agents</a> · <a href="#how-it-works">How It Works</a> · <a href="#examples">Examples</a> · <a href="https://docs.coral.compounding-intelligence.ai/">Docs</a> · <a href="https://arxiv.org/abs/2604.01658v1">Paper</a>
 </p>
 
 **CORAL** is infrastructure for **autonomous AI agent organizations** that run experiments, share knowledge, and continuously improve solutions. Give it a codebase and a grader, and CORAL handles the rest: isolated workspaces, safe evaluation, persistent shared state, and multi-agent collaboration. Natively integrated with Claude Code, OpenCode, Codex, Cursor Agent, and Kiro.
@@ -24,11 +24,11 @@
 
 - **[2026-07-08]** **CORAL** has been accepted to **COLM 2026**! 🎉
 - **[2026-06-24]** The Docker session now isolates the agent from the grader: each agent runs as an unprivileged user (manager and grader stay root), so agents can no longer read `.coral/private/` (grader venv, answer keys) — not even via Bash. On the host this stays opt-in via `agents.isolate_user`.
-- **[2026-06-13]** Legacy `eval/grader.py` grader auto-discovery is deprecated and removed — wire graders via `grader.entrypoint` pointing at a packaged grader. See the [custom grader guide](https://docs.coralxyz.com/guides/custom-grader).
+- **[2026-06-13]** Legacy `eval/grader.py` grader auto-discovery is deprecated and removed — wire graders via `grader.entrypoint` pointing at a packaged grader. See the [custom grader guide](https://docs.coral.compounding-intelligence.ai/guides/custom-grader).
 - **[2026-06-06]** CORAL v0.6.0 adds multi-island runs: partition agents into isolated islands with scoped attempts, notes, skills, heartbeat state, and migration between islands for broader exploration.
-- **[2026-04-24]** Rubric judges — two reusable LLM-judge grader packages for open-ended tasks (reports, memos, legal analysis). See the [Rubric Judges guide](https://docs.coralxyz.com/guides/rubric-judge).
+- **[2026-04-24]** Rubric judges — two reusable LLM-judge grader packages for open-ended tasks (reports, memos, legal analysis). See the [Rubric Judges guide](https://docs.coral.compounding-intelligence.ai/guides/rubric-judge).
 - **[2026-04-03]** Our paper, "CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery," is now out! Check it out on [Arxiv](https://arxiv.org/abs/2604.01658v1).
-- **[2026-03-18]** CORAL is released! Check out our [blog post](https://human-agent-society.github.io/CORAL/).
+- **[2026-03-18]** CORAL is released! Check out our [blog post](https://coral.compounding-intelligence.ai/).
 
 ![CORAL demo — autonomous AI coding agents running in parallel git worktrees, sharing knowledge through a common state directory](assets/demo.gif)
 
@@ -38,7 +38,7 @@
 curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
 ```
 
-Installs the **latest `coral` release** globally via `uv tool install`. Pin a specific release with `CORAL_VERSION=<tag>` if you need to. See [Installation docs](https://docs.coralxyz.com/getting-started/installation) for manual install, dev setup, and prerequisites.
+Installs the **latest `coral` release** globally via `uv tool install`. Pin a specific release with `CORAL_VERSION=<tag>` if you need to. See [Installation docs](https://docs.coral.compounding-intelligence.ai/getting-started/installation) for manual install, dev setup, and prerequisites.
 
 ```bash
 coral init my-task                       # scaffold a task
@@ -73,7 +73,7 @@ use coral to optimize this — make sample() in saga/decode.py faster without ch
 
 The plugin scaffolds a gitignored `.coral_workspace/`, drops your code into a `seed/`, writes a grader for your metric, and loops `coral validate` until the task is launch-ready — then hands you the `coral start` command. On Claude Code a `coral-task-author` subagent does the whole grind autonomously (and a `coral-run-doctor` triages a stuck run); on any harness the bundled skills walk the same path.
 
-Skills: `coral-quickstart` (install → setup → `.coral_workspace/`), `setting-up-coral` (runtime bindings), `creating-a-coral-task` (grader authoring), `running-coral-experiments` (operate a run). See the [Harness Plugin guide](https://docs.coralxyz.com/guides/plugin) or [`plugin/README.md`](plugin/README.md) for agents, the skills-dir alternative, and other harnesses.
+Skills: `coral-quickstart` (install → setup → `.coral_workspace/`), `setting-up-coral` (runtime bindings), `creating-a-coral-task` (grader authoring), `running-coral-experiments` (operate a run). See the [Harness Plugin guide](https://docs.coral.compounding-intelligence.ai/guides/plugin) or [`plugin/README.md`](plugin/README.md) for agents, the skills-dir alternative, and other harnesses.
 
 ### Supported Agents
 
@@ -85,7 +85,7 @@ Skills: `coral-quickstart` (install → setup → `.coral_workspace/`), `setting
 | [Kiro](https://kiro.dev) | `kiro` |
 | [OpenCode](https://github.com/opencode-ai/opencode) | `opencode` |
 
-Each agent must be installed and authenticated separately. Per-runtime config — including the [LiteLLM gateway](https://docs.coralxyz.com/guides/gateway) for custom models — is documented at [Agent Runtimes](https://docs.coralxyz.com/guides/agent-runtimes).
+Each agent must be installed and authenticated separately. Per-runtime config — including the [LiteLLM gateway](https://docs.coral.compounding-intelligence.ai/guides/gateway) for custom models — is documented at [Agent Runtimes](https://docs.coral.compounding-intelligence.ai/guides/agent-runtimes).
 
 ### How It Works
 
@@ -95,7 +95,7 @@ Each agent must be installed and authenticated separately. Per-runtime config �
 
 Each agent runs in its own git worktree. Shared state (attempts, notes, skills) lives in `.coral/public/` and is symlinked into every worktree — agents see each other's work in real time. A grader daemon scores every commit. The manager interrupts agents with heartbeat prompts (`reflect`, `consolidate`, `pivot`).
 
-Deeper dive: [Concepts](https://docs.coralxyz.com/concepts) · [Multi-agent runs](https://docs.coralxyz.com/guides/multi-agent) · [Eval loop](https://docs.coralxyz.com/concepts/eval-loop)
+Deeper dive: [Concepts](https://docs.coral.compounding-intelligence.ai/concepts) · [Multi-agent runs](https://docs.coral.compounding-intelligence.ai/guides/multi-agent) · [Eval loop](https://docs.coral.compounding-intelligence.ai/concepts/eval-loop)
 
 ### Examples
 
@@ -111,7 +111,7 @@ Ready-to-run task configurations in `examples/`:
 | **spaceship_titanic**      | ML           | Kaggle competition                                          |
 | **stanford_covid_vaccine** | Bio/ML       | mRNA degradation prediction                                 |
 
-Full catalogue and walkthroughs at [Examples docs](https://docs.coralxyz.com/examples).
+Full catalogue and walkthroughs at [Examples docs](https://docs.coral.compounding-intelligence.ai/examples).
 
 ### Development
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,7 +14,7 @@
 </p>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
-[![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://human-agent-society.github.io/CORAL/)
+[![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/)
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-3776AB.svg?logo=python&logoColor=white)](https://python.org)
 
@@ -23,7 +23,7 @@
 </div>
 
 <p align="center">
-<a href="#安装">安装</a> · <a href="#插件在你自己的-agent-里使用-coral">插件</a> · <a href="#支持的-agent">支持的 Agent</a> · <a href="#工作原理">工作原理</a> · <a href="#示例">示例</a> · <a href="https://docs.coralxyz.com/">文档</a> · <a href="https://arxiv.org/abs/2604.01658v1">论文</a>
+<a href="#安装">安装</a> · <a href="#插件在你自己的-agent-里使用-coral">插件</a> · <a href="#支持的-agent">支持的 Agent</a> · <a href="#工作原理">工作原理</a> · <a href="#示例">示例</a> · <a href="https://docs.coral.compounding-intelligence.ai/">文档</a> · <a href="https://arxiv.org/abs/2604.01658v1">论文</a>
 </p>
 
 **CORAL** 是用于构建**自主 AI Agent 组织**的基础设施 —— Agent 持续运行实验、共享知识、不断进化。只需提供代码库和评分脚本，CORAL 负责其余的一切：隔离工作空间、安全评估、持久共享状态、多 Agent 协作。原生集成 Claude Code、OpenCode、Codex、Cursor Agent、Kiro。
@@ -32,10 +32,10 @@
 
 - **[2026-07-08]** CORAL 已被 **COLM 2026** 接收！🎉
 - **[2026-06-24]** Docker 会话现在会隔离 agent 与 grader：每个 agent 以非特权用户运行（manager 与 grader 仍为 root），agent 将无法读取 `.coral/private/`（grader 虚拟环境、答案 key）—— 即使通过 Bash 也不行。在宿主机上仍可通过 `agents.isolate_user` 选择启用。
-- **[2026-06-13]** 旧版 `eval/grader.py` grader 自动发现已废弃并移除 —— 改用 `grader.entrypoint` 指向打包的 grader。详见 [自定义 Grader 文档](https://docs.coralxyz.com/guides/custom-grader)。
-- **[2026-04-24]** 新增 Rubric 评审 —— 两个开箱即用的 LLM 评审 grader 包，专为开放式任务（报告、备忘、法律分析）设计。详见 [Rubric Judges 文档](https://docs.coralxyz.com/guides/rubric-judge)。
+- **[2026-06-13]** 旧版 `eval/grader.py` grader 自动发现已废弃并移除 —— 改用 `grader.entrypoint` 指向打包的 grader。详见 [自定义 Grader 文档](https://docs.coral.compounding-intelligence.ai/guides/custom-grader)。
+- **[2026-04-24]** 新增 Rubric 评审 —— 两个开箱即用的 LLM 评审 grader 包，专为开放式任务（报告、备忘、法律分析）设计。详见 [Rubric Judges 文档](https://docs.coral.compounding-intelligence.ai/guides/rubric-judge)。
 - **[2026-04-03]** 我们的论文 "CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery" 现已发布！请查看 [Arxiv](https://arxiv.org/abs/2604.01658v1)。
-- **[2026-03-18]** CORAL 正式发布！点击查看 [Blog](https://human-agent-society.github.io/CORAL/)。
+- **[2026-03-18]** CORAL 正式发布！点击查看 [Blog](https://coral.compounding-intelligence.ai/)。
 
 ![CORAL 多 Agent 自主编程演示 —— 多个编程 Agent 在独立 git worktree 中并行运行,通过共享状态目录交换知识](assets/demo.gif)
 
@@ -45,7 +45,7 @@
 curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
 ```
 
-通过 `uv tool install` 全局安装**最新版 `coral`**。如确需指定版本，设置 `CORAL_VERSION=<tag>`。手动安装、开发模式、前置依赖等详见[安装文档](https://docs.coralxyz.com/getting-started/installation)。
+通过 `uv tool install` 全局安装**最新版 `coral`**。如确需指定版本，设置 `CORAL_VERSION=<tag>`。手动安装、开发模式、前置依赖等详见[安装文档](https://docs.coral.compounding-intelligence.ai/getting-started/installation)。
 
 ```bash
 coral init my-task                       # 生成任务模板
@@ -80,7 +80,7 @@ codex plugin add coral@coral-marketplace
 
 插件会自动开一个被 gitignore 的 `.coral_workspace/`，把你的代码放进 `seed/`，按你的指标写好 grader，并反复跑 `coral validate` 直到任务可启动——最后把 `coral start` 命令交给你。在 Claude Code 上，`coral-task-author` 子 agent 会自主完成整个搭建过程（另有 `coral-run-doctor` 负责诊断卡住的 run）；在其他 harness 上，打包的 skill 会带你走同样的流程。
 
-包含的 skill：`coral-quickstart`（安装 → setup → `.coral_workspace/`）、`setting-up-coral`（运行时绑定）、`creating-a-coral-task`（编写 grader）、`running-coral-experiments`（运维一个 run）。子 agent、skill 目录手动安装方式及其他 harness，见[插件指南](https://docs.coralxyz.com/guides/plugin)或 [`plugin/README.md`](plugin/README.md)。
+包含的 skill：`coral-quickstart`（安装 → setup → `.coral_workspace/`）、`setting-up-coral`（运行时绑定）、`creating-a-coral-task`（编写 grader）、`running-coral-experiments`（运维一个 run）。子 agent、skill 目录手动安装方式及其他 harness，见[插件指南](https://docs.coral.compounding-intelligence.ai/guides/plugin)或 [`plugin/README.md`](plugin/README.md)。
 
 ### 支持的 Agent
 
@@ -92,7 +92,7 @@ codex plugin add coral@coral-marketplace
 | [Kiro](https://kiro.dev) | `kiro` |
 | [OpenCode](https://github.com/opencode-ai/opencode) | `opencode` |
 
-每个 Agent 需自行安装并完成认证。各运行时的详细配置（含[ LiteLLM Gateway](https://docs.coralxyz.com/guides/gateway) 自定义模型代理）见 [Agent 运行时文档](https://docs.coralxyz.com/guides/agent-runtimes)。
+每个 Agent 需自行安装并完成认证。各运行时的详细配置（含[ LiteLLM Gateway](https://docs.coral.compounding-intelligence.ai/guides/gateway) 自定义模型代理）见 [Agent 运行时文档](https://docs.coral.compounding-intelligence.ai/guides/agent-runtimes)。
 
 ### 工作原理
 
@@ -102,7 +102,7 @@ codex plugin add coral@coral-marketplace
 
 每个 Agent 跑在自己的 git worktree 里。共享状态（历史记录、笔记、技能）放在 `.coral/public/`，软链到所有 worktree —— Agent 实时看到彼此的工作。Grader 守护进程为每次提交打分。后台管理器通过心跳机制打断 Agent 并注入指令（`reflect`、`consolidate`、`pivot`）。
 
-深入阅读：[核心概念](https://docs.coralxyz.com/concepts) · [多 Agent 运行](https://docs.coralxyz.com/guides/multi-agent) · [评估循环](https://docs.coralxyz.com/concepts/eval-loop)
+深入阅读：[核心概念](https://docs.coral.compounding-intelligence.ai/concepts) · [多 Agent 运行](https://docs.coral.compounding-intelligence.ai/guides/multi-agent) · [评估循环](https://docs.coral.compounding-intelligence.ai/concepts/eval-loop)
 
 ### 示例
 
@@ -118,7 +118,7 @@ codex plugin add coral@coral-marketplace
 | **spaceship_titanic** | 机器学习 | Kaggle 竞赛 |
 | **stanford_covid_vaccine** | 生物/ML | mRNA 降解预测 |
 
-完整任务清单与详解见[示例文档](https://docs.coralxyz.com/examples)。
+完整任务清单与详解见[示例文档](https://docs.coral.compounding-intelligence.ai/examples)。
 
 ### 开发
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -245,9 +245,9 @@ a:hover{color:var(--link-h)}
 
 <!-- NAV -->
 <nav class="nav">
-  <a href="https://docs.coralxyz.com" class="nav-logo">CORAL</a>
+  <a href="https://docs.coral.compounding-intelligence.ai" class="nav-logo">CORAL</a>
   <div class="nav-r">
-    <a href="https://docs.coralxyz.com" class="nav-link">Docs</a>
+    <a href="https://docs.coral.compounding-intelligence.ai" class="nav-link">Docs</a>
     <a href="#" class="nav-link" style="color:var(--t1)">Blog</a>
     <a href="https://github.com/Human-Agent-Society/Coral" class="gh-pill">
       <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -300,7 +300,7 @@ a:hover{color:var(--link-h)}
     <div class="hero-btns">
       <a href="https://arxiv.org/abs/2604.01658v1" class="btn btn-dark">Paper</a>
       <a href="https://github.com/Human-Agent-Society/Coral" class="btn btn-dark">Code</a>
-      <a href="https://docs.coralxyz.com" class="btn btn-dark">Documentation</a>
+      <a href="https://docs.coral.compounding-intelligence.ai" class="btn btn-dark">Documentation</a>
     </div>
   </header>
 

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -20,7 +20,7 @@ export function baseOptions(): BaseLayoutProps {
     links: [
       {
         text: 'Blog',
-        url: 'https://human-agent-society.github.io/CORAL/',
+        url: 'https://coral.compounding-intelligence.ai/',
       },
     ],
     githubUrl: 'https://github.com/Human-Agent-Society/CORAL',

--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ Next steps:
   coral init my-task                    Scaffold a new task
   coral start -c my-task/task.yaml      Launch agents
 
-Docs:  https://human-agent-society.github.io/CORAL/
+Docs:  https://docs.coral.compounding-intelligence.ai/
 EOF
 else
   warn "Install succeeded, but 'coral' is not on PATH in this shell."

--- a/plugin/AGENTS.md
+++ b/plugin/AGENTS.md
@@ -13,4 +13,4 @@ install the plugin but still want the agent to reach for CORAL.
 - **Run / manage experiments**: use the `running-coral-experiments` skill. Drive `coral start / status / log / show / resume / stop`; pass per-run overrides as dotlist args (`agents.count=4`).
 - **What is it / install**: use the `coral-quickstart` skill.
 
-Don't memorize flags — run `coral <cmd> --help`. The in-run eval loop (`coral eval`) is documented in the generated `CORAL.md` each agent reads automatically. Docs: https://docs.coralxyz.com/
+Don't memorize flags — run `coral <cmd> --help`. The in-run eval loop (`coral eval`) is documented in the generated `CORAL.md` each agent reads automatically. Docs: https://docs.coral.compounding-intelligence.ai/

--- a/plugin/hooks/session-start.py
+++ b/plugin/hooks/session-start.py
@@ -64,7 +64,7 @@ def _missing_context() -> str:
         "uv tool install coral\n"
         "```\n\n"
         "Then the `creating-a-coral-task` and `running-coral-experiments` skills apply. "
-        "Docs: https://docs.coralxyz.com/\n"
+        "Docs: https://docs.coral.compounding-intelligence.ai/\n"
     )
 
 

--- a/plugin/skills/coral-quickstart/SKILL.md
+++ b/plugin/skills/coral-quickstart/SKILL.md
@@ -102,4 +102,4 @@ If `coral validate` succeeds, the grader can score the seed; most "agents are st
 | **Author** a task / write a grader | `creating-a-coral-task` | `coral init`, `coral validate` |
 | **Run / manage** experiments | `running-coral-experiments` | `coral start / status / log / show / resume / stop` |
 
-The eval loop *inside* a run (`coral eval -m "..."` → score → iterate) is driven by the agents themselves — they read it from the `CORAL.md` CORAL generates, so you never run it by hand. Docs: https://docs.coralxyz.com/
+The eval loop *inside* a run (`coral eval -m "..."` → score → iterate) is driven by the agents themselves — they read it from the `CORAL.md` CORAL generates, so you never run it by hand. Docs: https://docs.coral.compounding-intelligence.ai/

--- a/plugin/skills/creating-a-coral-task/SKILL.md
+++ b/plugin/skills/creating-a-coral-task/SKILL.md
@@ -99,4 +99,4 @@ Once one agent evals cleanly, raise `agents.count`. Driving the run from here is
 | `parallel.max_workers > 1` with an unsafe grader | Sporadic port/GPU/scratch collisions | Leave at `1` unless provably concurrency-safe. |
 | Skipping `coral validate` | Agents start, fail every eval identically | Always validate first. |
 
-When in doubt, run `coral init throwaway` and read the generated files. Full config schema: https://docs.coralxyz.com/api/config
+When in doubt, run `coral init throwaway` and read the generated files. Full config schema: https://docs.coral.compounding-intelligence.ai/api/config

--- a/plugin/skills/creating-a-coral-task/references/rubric-judges.md
+++ b/plugin/skills/creating-a-coral-task/references/rubric-judges.md
@@ -72,4 +72,4 @@ Trade-off: more adaptive, but the moving target makes scores across evals less d
 - **Make the artifact filename a hard contract** in `task.description` — the judge grades exactly `files: [...]`; if the agent writes `final_report.md` and you asked for `report.md`, every eval fails.
 - **Judges cost an LLM call (or many) per eval.** Keep `agents.count` modest and `grader.parallel.max_workers: 1` unless you've confirmed the judge is concurrency-safe and you have the budget.
 - **Copy a judge package as your starting point** (`cp -r examples/race-japan-elderly/grader my-task/grader`) and edit the rubric — faster than wiring one from scratch.
-- These are the same packages the README's "Rubric Judges" guide documents: https://docs.coralxyz.com/guides/rubric-judge
+- These are the same packages the README's "Rubric Judges" guide documents: https://docs.coral.compounding-intelligence.ai/guides/rubric-judge

--- a/plugin/skills/creating-a-coral-task/references/task-yaml.md
+++ b/plugin/skills/creating-a-coral-task/references/task-yaml.md
@@ -104,4 +104,4 @@ sharing:
   skills: true                  # shared skills visible across agents
 ```
 
-Turn pieces off to make agents explore more independently. Full schema with every field: https://docs.coralxyz.com/api/config
+Turn pieces off to make agents explore more independently. Full schema with every field: https://docs.coral.compounding-intelligence.ai/api/config

--- a/plugin/skills/running-coral-experiments/SKILL.md
+++ b/plugin/skills/running-coral-experiments/SKILL.md
@@ -82,4 +82,4 @@ coral stop                                  # done
 - **Steer / fork / heartbeat tuning** → [references/steering.md](references/steering.md)
 - **Budget classes, islands, gateway, troubleshooting matrix** → [references/scaling-and-ops.md](references/scaling-and-ops.md)
 
-Note: `coral eval / diff / revert / checkout / wait` are **agent-side** commands run *inside* a worktree during a run — agents already know them from the generated `CORAL.md`. As the operator you rarely touch them; you drive the verbs above. Full CLI reference: https://docs.coralxyz.com/cli/reference
+Note: `coral eval / diff / revert / checkout / wait` are **agent-side** commands run *inside* a worktree during a run — agents already know them from the generated `CORAL.md`. As the operator you rarely touch them; you drive the verbs above. Full CLI reference: https://docs.coral.compounding-intelligence.ai/cli/reference

--- a/plugin/skills/running-coral-experiments/references/scaling-and-ops.md
+++ b/plugin/skills/running-coral-experiments/references/scaling-and-ops.md
@@ -47,7 +47,7 @@ coral start -c task.yaml agents.gateway.enabled=true \
   agents.gateway.port=4000 agents.gateway.config=./litellm_config.yaml
 ```
 
-`agents.gateway.api_key` is auto-generated if empty. Full gateway setup: https://docs.coralxyz.com/guides/gateway
+`agents.gateway.api_key` is auto-generated if empty. Full gateway setup: https://docs.coral.compounding-intelligence.ai/guides/gateway
 
 ## Reading the shared brain
 
@@ -76,4 +76,4 @@ Notes and skills are where agents record what's working — a fast way to unders
 | Leaderboard looks upside down | `grader.direction` wrong | This is a task-authoring bug — fix `direction` in `task.yaml` (the `creating-a-coral-task` skill). |
 | Run won't resume / picks the wrong run | Multiple runs for the task | Disambiguate: `coral runs --all` to list, then `coral resume --task <name> --run <id>`. |
 
-Most run-health questions answer themselves from three commands: `coral status` (who's alive), `coral log --class grader_error` (is the grader healthy), and `coral show <hash> --diff` (what the leader actually did). Full CLI reference: https://docs.coralxyz.com/cli/reference
+Most run-health questions answer themselves from three commands: `coral status` (who's alive), `coral log --class grader_error` (is the grader healthy), and `coral show <hash> --diff` (what the leader actually did). Full CLI reference: https://docs.coral.compounding-intelligence.ai/cli/reference

--- a/plugin/skills/setting-up-coral/SKILL.md
+++ b/plugin/skills/setting-up-coral/SKILL.md
@@ -82,7 +82,7 @@ Bindings store **no credentials** — each runtime owns its own login. The hello
 | Kiro | `kiro` | `kiro-cli` setup |
 | OpenCode | `opencode` | `opencode` auth |
 
-Codex reasoning effort is a runtime option, not a model: `coral setup agent --name codex-high --runtime codex --option model_reasoning_effort=high`. For custom or self-hosted models across runtimes, route through the LiteLLM gateway (`agents.gateway` in `task.yaml`): https://docs.coralxyz.com/guides/gateway
+Codex reasoning effort is a runtime option, not a model: `coral setup agent --name codex-high --runtime codex --option model_reasoning_effort=high`. For custom or self-hosted models across runtimes, route through the LiteLLM gateway (`agents.gateway` in `task.yaml`): https://docs.coral.compounding-intelligence.ai/guides/gateway
 
 ## 4. Use a binding in a task
 
@@ -109,4 +109,4 @@ agents:
 
 ## Where this sits
 
-`coral-quickstart` (install) → **`setting-up-coral`** (bindings, here) → `creating-a-coral-task` (author) → `running-coral-experiments` (run). Setup is optional — you can put `runtime`/`model` straight in `task.yaml` — but bindings + `coral agents doctor` are the reliable way to confirm a runtime is installed *and authenticated* before you launch agents. Full reference: https://docs.coralxyz.com/guides/agent-bindings
+`coral-quickstart` (install) → **`setting-up-coral`** (bindings, here) → `creating-a-coral-task` (author) → `running-coral-experiments` (run). Setup is optional — you can put `runtime`/`model` straight in `task.yaml` — but bindings + `coral agents doctor` are the reliable way to confirm a runtime is installed *and authenticated* before you launch agents. Full reference: https://docs.coral.compounding-intelligence.ai/guides/agent-bindings


### PR DESCRIPTION
## Motivation

CORAL's documentation and blog domains moved to the `compounding-intelligence.ai` domain. Existing README, docs navigation, installer output, blog, plugin guidance, and bundled skill links still referenced the legacy hosts.

## Changes

- Replace documentation links with `https://docs.coral.compounding-intelligence.ai`.
- Replace GitHub Pages blog links with `https://coral.compounding-intelligence.ai`.
- Keep the installer output aligned with the documentation site.

## Test plan

- `uv run pytest tests/ -q` — 614 passed, 1 skipped.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — 124 files already formatted.
- `git diff --check` — passed.
- Confirmed `https://docs.coral.compounding-intelligence.ai` returns HTTP 200.
- Confirmed no `docs.coralxyz.com` or `human-agent-society.github.io/CORAL` references remain in tracked source files.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: READMEs, blog, installer output, plugin guidance and skills

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

*Authored with assistance from Codex. The submitting human should read every changed line before merge and confirm the final checklist item.*
