### PR TITLE
docs: expose blog inside Next.js site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ htmlcov/
 site/
 docs/.next/
 docs/node_modules/
+docs/public/blog/
 docs/.source/
 docs/superpowers/
 

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -20,7 +20,7 @@ export function baseOptions(): BaseLayoutProps {
     links: [
       {
         text: 'Blog',
-        url: 'https://coral.compounding-intelligence.ai/',
+        url: '/blog',
       },
     ],
     githubUrl: 'https://github.com/Human-Agent-Society/CORAL',

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -3,6 +3,14 @@ import { createMDX } from 'fumadocs-mdx/next';
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/blog',
+        destination: '/blog/index.html',
+      },
+    ];
+  },
 };
 
 const withMDX = createMDX();

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "predev": "node scripts/sync-blog.mjs",
     "dev": "next dev",
+    "prebuild": "node scripts/sync-blog.mjs",
     "build": "fumadocs-mdx && next build",
     "postinstall": "fumadocs-mdx",
     "start": "next start"

--- a/docs/scripts/sync-blog.mjs
+++ b/docs/scripts/sync-blog.mjs
@@ -1,0 +1,17 @@
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const blogSource = resolve(scriptDirectory, '../../blog');
+const blogOutput = resolve(scriptDirectory, '../public/blog');
+
+await rm(blogOutput, { force: true, recursive: true });
+await mkdir(blogOutput, { recursive: true });
+await cp(blogSource, blogOutput, { recursive: true });
+
+const indexPath = resolve(blogOutput, 'index.html');
+const indexHtml = await readFile(indexPath, 'utf8');
+const htmlWithBasePath = indexHtml.replace('<head>', '<head>\n<base href="/blog/">');
+
+await writeFile(indexPath, htmlWithBasePath);


### PR DESCRIPTION
## Motivation

The CORAL blog remains independently hosted on GitHub Pages, but the Docs navigation should open the same blog at a first-party path on the Next.js documentation site instead of navigating users to another domain.

## Changes

- Sync the canonical `blog/` directory into the Docs public assets before development and production builds.
- Serve the synced entry page at `/blog` through a Next.js rewrite.
- Add a `/blog/` base URL to the generated copy so images and other relative assets resolve inside the Docs site.
- Change the Docs navigation Blog link to the internal `/blog` path.
- Keep generated Blog assets out of git; `blog/` remains the single source of truth.

GitHub Pages remains enabled and unchanged at `https://coral.compounding-intelligence.ai`.

## Test plan

- `npm run build` in `docs/` — passed; 33 static pages generated.
- Started the production server with `npm start -- --hostname 127.0.0.1 --port 3017`.
- `GET /blog` — HTTP 200 with the CORAL Blog HTML and `/blog/` base path.
- `GET /blog/coral_logo.png` — HTTP 200, `image/png`.
- `GET /blog/stages.png` — HTTP 200, `image/png`.
- `git diff --check` — passed.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

*Authored with assistance from Codex. The submitting human should read every changed line before merge and confirm the final checklist item.*
