### PR TITLE
docs: add dev-to-main promotion skill

### DIFF
--- a/.claude/skills/promoting-dev-to-main/SKILL.md
+++ b/.claude/skills/promoting-dev-to-main/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: promoting-dev-to-main
+description: Use when preparing, reviewing, resolving conflicts for, or merging a CORAL release pull request from the long-lived dev branch into main.
+---
+
+# Promoting dev to main
+
+## Core rule
+
+Merge `dev → main` release PRs with a **merge commit**. Never squash or rebase
+these promotions.
+
+Ordinary contribution PRs still target `dev` and may be squash-merged. The
+release promotion is the exception because `main` must retain `dev` in its
+ancestry. Squashing a promotion makes the next release re-present old commits
+and can create large false conflicts.
+
+## Workflow
+
+1. Confirm the PR is exactly `base=main`, `head=dev` and no duplicate release
+   PR is open.
+2. Review `main..dev`, required CI, and deployment checks.
+3. In GitHub, open the merge-method dropdown and choose **Create a merge
+   commit**. With the CLI, use:
+
+   ```bash
+   gh pr merge <number> --repo Human-Agent-Society/CORAL --merge
+   ```
+
+4. Keep the long-lived `dev` branch. Do not delete or force-push it.
+5. Fetch both branches and verify the released `dev` tip is an ancestor of
+   `main`:
+
+   ```bash
+   git fetch origin dev main
+   git merge-base --is-ancestor origin/dev origin/main
+   ```
+
+   Exit status `0` is required.
+6. Confirm post-merge CI, release automation, deployments, and production
+   smoke checks.
+
+## If GitHub reports conflicts
+
+Do not force-rebase the shared `dev` branch. First inspect the topology and
+reproduce conflicts with `git merge-tree`.
+
+If an earlier release was squash-merged, `main` may have the same tree as an
+earlier `dev` commit without sharing its ancestry. Verify tree equivalence
+before choosing a repair. Prefer merging `main` back into `dev` and pushing
+normally; use an ancestry-only `ours` merge only when exact tree equality
+proves `main` contains no unique content to preserve.
+
+## Red flags
+
+- GitHub's primary button says **Squash and merge**.
+- A command uses `--squash`, `--rebase`, or a force-push.
+- The release workflow proposes deleting `dev`.
+- Conflict resolution starts before checking commit topology and tree equality.
+
+Stop when any red flag appears and return to the workflow above.
+
+## Quick reference
+
+| PR | Allowed merge method |
+|---|---|
+| Feature/fix/docs branch → `dev` | Repository default; usually squash |
+| `dev` → `main` release promotion | Merge commit only |

--- a/.claude/skills/promoting-dev-to-main/agents/openai.yaml
+++ b/.claude/skills/promoting-dev-to-main/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Promote dev to main"
+  short_description: "Safely promote CORAL dev releases to main"
+  default_prompt: "Use $promoting-dev-to-main to prepare and merge the CORAL dev-to-main release PR."


### PR DESCRIPTION
## Motivation

The previous `dev → main` release was squash-merged, which left the branches with equivalent content but disconnected ancestry. The next release PR then reported large false conflicts. Encode the release-specific merge rule as a reusable repository skill.

*Authored with assistance from Codex. The human author should review the skill before merge.*

## Changes

- Add the `promoting-dev-to-main` repository skill.
- Require merge commits for `dev → main` release promotions while preserving squash as the normal feature-PR convention.
- Document pre-merge checks, the exact `gh pr merge --merge` command, post-merge ancestry verification, and safe conflict diagnosis without force-rebasing `dev`.
- Add UI metadata for skill discovery.

## Test plan

- `quick_validate.py .claude/skills/promoting-dev-to-main` — passed.
- `git diff --check` — passed.
- Ran two no-skill baseline scenarios and one forward-test using the new skill.
- The forward-test rejected squash/rebase/force-push, selected a merge commit, required tree-equivalence evidence before an ancestry-only repair, and verified `origin/dev` is an ancestor of `origin/main` after release.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: repository agent skill under `.claude/skills/`

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: not applicable.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
