### PR TITLE
feat(template): co-evolve notes schema

### DIFF
--- a/coral/template/coral.md.template
+++ b/coral/template/coral.md.template
@@ -267,6 +267,8 @@ You are part of a team. When you learn something — whether a success or a fail
 
 **Write notes** when you discover something other agents should know. The `create-notes` skill (`{shared_dir}/skills/create-notes/SKILL.md`) is the source of truth for naming, frontmatter (including the structured-trace schema that populates the dashboard knowledge graph), and the per-variant section shape. Don't write a note from scratch — stamp a skeleton with `python {shared_dir}/skills/create-notes/scripts/stamp.py <variant>`, fill it in, and run `lint.py` on the result before considering it done.
 
+The notes schema is a living, team-owned contract. Agents collectively maintain and co-evolve the notes schema as needs emerge. Follow the schema-change workflow in `create-notes`: keep the field reference, note skeletons, and lint rules aligned, and preserve existing notes unless the team deliberately documents a migration.
+
 **Build or update a skill** after every eval. Any technique, script, or workflow that improved your score (or that you'd use again) belongs in a skill:
 ```
 mkdir -p {shared_dir}/skills/your-tool/scripts {shared_dir}/skills/your-tool/examples

--- a/coral/template/coral_single.md.template
+++ b/coral/template/coral_single.md.template
@@ -132,6 +132,8 @@ Notes about what you've discovered — things that help you (or future agents) m
 
 Write notes as individual files in `{shared_dir}/notes/` via the `create-notes` skill (`{shared_dir}/skills/create-notes/SKILL.md`). The skill is the source of truth for naming, frontmatter (including the structured-trace schema that populates the dashboard knowledge graph), and the per-variant section shape — don't write a note from scratch. Stamp a skeleton with `python {shared_dir}/skills/create-notes/scripts/stamp.py <variant>`, fill it in, and run `lint.py` on the result before considering it done.
 
+The notes schema is a living contract. You maintain and co-evolve this living notes schema as your needs emerge. Follow the schema-change workflow in `create-notes`: keep the field reference, note skeletons, and lint rules aligned, and preserve existing notes unless you deliberately document a migration.
+
 Not every eval needs a note — only write when you genuinely have something worth recording.
 
 ### Skills (MANDATORY)

--- a/coral/template/skills/create-notes/SKILL.md
+++ b/coral/template/skills/create-notes/SKILL.md
@@ -271,6 +271,17 @@ Plus, when applicable: `commit:` (experiment notes), `generation:` (focus notes,
 
 The hub now makes the gap loud, not silent: a `creator:`-less note shows as `(unknown)` in `coral notes`, lands in `scripts/unattributed.py` output, and renders with `creator: unknown` in the knowledge-graph node. If you see your own note tagged `(unknown)`, append a `creator:` line — the team-level views still won't pick it up until you do.
 
+### Schema stewardship (shared and evolving)
+
+The notes schema is a living, team-owned contract. Agents collectively maintain and co-evolve the notes schema
+as needs emerge; do not treat it as fixed boilerplate owned only by the
+framework. Prefer extending an existing convention over inventing a parallel one.
+
+When the schema changes, update `references/frontmatter-spec.md`, the relevant
+`scripts/stamp.py` skeletons, and `scripts/lint.py` checks together so the written
+contract and its tooling stay aligned. Keep existing notes readable unless the
+team deliberately introduces and documents a migration.
+
 ### Structured trace (expected for every new note)
 
 Beyond `creator:` / `created:`, the frontmatter carries a *structured-trace* schema that the dashboard's **Knowledge → Graph** view consumes. Nodes are sized by `confidence`, colored by `status`, and typed edges come from `supersedes:` / `refutes:` plus any markdown / wiki links in the body. The framework uses these fields to filter, relate, and verify notes — a free-text note without them is a dot floating in the graph, invisible to team-level claim / status / confidence aggregations.

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,5 +1,7 @@
 """Tests for CORAL.md template generation."""
 
+from pathlib import Path
+
 from coral.config import AgentConfig, CoralConfig, GraderConfig, TaskConfig
 from coral.template.coral_md import generate_coral_md
 
@@ -52,6 +54,7 @@ def test_generate_coral_md_has_required_sections():
     assert "coral log --search" in md
     assert ".claude/notes" in md
     assert ".claude/skills/" in md
+    assert "collectively maintain and co-evolve the notes schema" in md
 
 
 def test_generate_coral_md_without_optional_sections():
@@ -102,6 +105,16 @@ def test_generate_coral_md_single_agent():
     assert "notes" in md.lower()
     assert "skills" in md.lower()
     assert "Record Knowledge" in md
+    assert "maintain and co-evolve this living notes schema" in md
+
+
+def test_create_notes_skill_assigns_collective_schema_stewardship():
+    skill = Path("coral/template/skills/create-notes/SKILL.md").read_text(encoding="utf-8")
+
+    assert "collectively maintain and co-evolve the notes schema" in skill
+    assert "frontmatter-spec.md" in skill
+    assert "stamp.py" in skill
+    assert "lint.py" in skill
 
 
 def test_generate_coral_md_tune_guardrails_present():


### PR DESCRIPTION
## Motivation

The notes schema is currently documented as a source of truth that agents consume, but it does not explicitly assign agents responsibility for maintaining and evolving that shared contract. Make schema stewardship an explicit part of both multi-agent and single-agent CORAL guidance.

*Authored with assistance from Codex. The human author requested the change; they should complete the final line-by-line review before merge.*

## Changes

- Describe the notes schema as a living, team-owned contract that agents collectively maintain and co-evolve.
- Require schema changes to keep the field reference, note skeletons, and lint rules aligned while preserving backward compatibility.
- Add corresponding multi-agent and single-agent `CORAL.md` guidance.
- Add regression coverage for the bundled skill and both generated instruction variants.

## Test plan

- `uv run pytest tests/ -v` — 621 passed, 1 skipped.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — 124 files already formatted.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [x] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
