### PR TITLE
feat(gateway): add MiniMax model routes

### DIFF
--- a/coral/gateway/config.py
+++ b/coral/gateway/config.py
@@ -9,6 +9,46 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+_MINIMAX_OPENAI_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh": "https://api.minimaxi.com/v1",
+}
+_MINIMAX_ANTHROPIC_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/anthropic",
+    "cn_zh": "https://api.minimaxi.com/anthropic",
+}
+_MINIMAX_MODEL_IDS = ("MiniMax-M3", "MiniMax-M2.7")
+
+
+def _minimax_model_entries(model_id: str) -> list[dict]:
+    """Build regional OpenAI-compatible and Anthropic-compatible routes."""
+    entries = [
+        {
+            "model_name": model_id,
+            "litellm_params": {
+                "model": f"openai/{model_id}",
+                "api_key": "os.environ/MINIMAX_API_KEY",
+                "api_base": base_url,
+            },
+        }
+        for base_url in _MINIMAX_OPENAI_ENDPOINTS.values()
+    ]
+    anthropic_model_name = f"{model_id}-anthropic"
+    entries.extend(
+        {
+            "model_name": anthropic_model_name,
+            "litellm_params": {
+                "model": f"anthropic/{model_id}",
+                "api_key": "os.environ/MINIMAX_API_KEY",
+                # LiteLLM appends /v1/messages to this Anthropic base URL.
+                "api_base": base_url,
+            },
+        }
+        for base_url in _MINIMAX_ANTHROPIC_ENDPOINTS.values()
+    )
+    return entries
+
+
 # Map CORAL model shortnames to LiteLLM model identifiers
 _MODEL_MAP: dict[str, list[dict]] = {
     "sonnet": [
@@ -57,6 +97,8 @@ _MODEL_MAP: dict[str, list[dict]] = {
         },
     ],
 }
+
+_MODEL_MAP.update({model_id: _minimax_model_entries(model_id) for model_id in _MINIMAX_MODEL_IDS})
 
 
 def generate_default_litellm_config(path: Path, model: str = "sonnet") -> Path:

--- a/docs/content/docs/guides/gateway.mdx
+++ b/docs/content/docs/guides/gateway.mdx
@@ -29,6 +29,19 @@ litellm_settings:
 
 Each entry in `model_list` defines a model the gateway will serve. The `model_name` is what agents request; `litellm_params.model` is the upstream provider model. See the [LiteLLM docs](https://docs.litellm.ai/docs/proxy/configs) for full configuration options (multiple providers, load balancing, fallbacks, etc.).
 
+### MiniMax routes
+
+The generated configuration supports `MiniMax-M3` and `MiniMax-M2.7`. Each model ID includes both global and China OpenAI-compatible routes. Use the corresponding `-anthropic` alias for Anthropic-compatible routes. The Anthropic base URLs end in `/anthropic`; LiteLLM appends `/v1/messages` when it sends the request.
+
+All generated routes use `MINIMAX_API_KEY`:
+
+| Alias | Protocol | Regions |
+|-------|----------|---------|
+| `MiniMax-M3` | OpenAI-compatible | global, China |
+| `MiniMax-M3-anthropic` | Anthropic-compatible | global, China |
+| `MiniMax-M2.7` | OpenAI-compatible | global, China |
+| `MiniMax-M2.7-anthropic` | Anthropic-compatible | global, China |
+
 **2. Enable the gateway in your task config:**
 
 ```yaml

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -1,0 +1,37 @@
+"""Tests for generated LiteLLM gateway configuration."""
+
+import yaml
+
+from coral.gateway.config import generate_default_litellm_config
+
+
+def test_minimax_routes_cover_models_regions_and_protocols(tmp_path):
+    for model_id in ("MiniMax-M3", "MiniMax-M2.7"):
+        config_path = tmp_path / f"{model_id}.yaml"
+        generate_default_litellm_config(config_path, model_id)
+        routes = yaml.safe_load(config_path.read_text())["model_list"]
+
+        assert len(routes) == 4
+        assert {route["model_name"] for route in routes} == {
+            model_id,
+            f"{model_id}-anthropic",
+        }
+        assert {
+            route["litellm_params"]["api_base"]
+            for route in routes
+            if route["model_name"] == model_id
+        } == {
+            "https://api.minimax.io/v1",
+            "https://api.minimaxi.com/v1",
+        }
+        assert {
+            route["litellm_params"]["api_base"]
+            for route in routes
+            if route["model_name"] == f"{model_id}-anthropic"
+        } == {
+            "https://api.minimax.io/anthropic",
+            "https://api.minimaxi.com/anthropic",
+        }
+        assert all(
+            route["litellm_params"]["api_key"] == "os.environ/MINIMAX_API_KEY" for route in routes
+        )


### PR DESCRIPTION
## Motivation

CORAL generated LiteLLM configurations do not currently include built-in MiniMax routes, so users must define both model aliases and regional endpoints manually.

## Changes

- Add generated routes for `MiniMax-M3` and `MiniMax-M2.7` using both global and China chat-completions-compatible endpoints.
- Add message-API-compatible aliases for both models using the corresponding regional base URLs.
- Document the aliases and `MINIMAX_API_KEY`, with focused coverage for models, regions, and both supported API styles.

## Test plan

- `uv sync --extra dev --no-install-project`
- `PYTHONPATH=. uv run pytest tests/test_gateway_config.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [x] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other: <!-- specify -->

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See `AGENTS.md`.