### PR TITLE
docs: unify site navigation and theme

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -4,6 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Evolve Like Coral: Towards Autonomous Multi-Agent Evolution</title>
+<script>
+(function(){
+  var saved=localStorage.getItem('theme');
+  var prefersDark=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var theme=saved==='dark'||(saved!=='light'&&prefersDark)?'dark':'light';
+  document.documentElement.dataset.theme=theme;
+  document.documentElement.style.colorScheme=theme;
+})();
+</script>
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700&family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=DM+Mono:wght@400;500&display=swap');
 
@@ -12,7 +21,7 @@
   --serif:'Source Serif 4',Georgia,serif;
   --mono:'DM Mono','SF Mono',Consolas,monospace;
   --r:14px;--r-sm:10px;--r-pill:20px;
-  --nav-h:52px;--toc-w:180px;
+  --nav-h:56px;--toc-w:180px;
 }
 [data-theme="light"]{
   --bg:#f3f6fb;--card:#e8edf6;--elevated:#dde4f0;--deep:#d2daea;
@@ -20,6 +29,15 @@
   --t1:#18222e;--t2:#26323f;--t3:#415060;--t4:#647585;--t5:#8e9eae;
   --code-t:#ced4dc;--badge-bg:#18222e;--badge-t:#f3f6fb;
   --link:#2a5282;--link-h:#18222e;
+  --nav-active:rgba(190,200,216,.5);
+}
+[data-theme="dark"]{
+  --bg:#111821;--card:#18222e;--elevated:#202b38;--deep:#263442;
+  --code-bg:#0b1016;--border:#344454;--line:#647585;
+  --t1:#edf2f7;--t2:#c7d1dc;--t3:#aebbc8;--t4:#9eacba;--t5:#788898;
+  --code-t:#d7dfe8;--badge-bg:#edf2f7;--badge-t:#111821;
+  --link:#a9c7e8;--link-h:#edf2f7;
+  --nav-active:rgba(52,68,84,.5);
 }
 
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -32,17 +50,35 @@ a:hover{color:var(--link-h)}
 
 /* NAV */
 .nav{position:sticky;top:0;z-index:100;height:var(--nav-h);display:flex;
-  align-items:center;justify-content:space-between;padding:0 28px;
+  align-items:center;padding:0 24px;
   background:var(--bg);border-bottom:.7px solid var(--border);transition:background .2s,border-color .2s}
 .nav-logo{font-family:var(--sans);font-size:17px;font-weight:700;color:var(--t1);
-  display:flex;align-items:center;letter-spacing:.02em;transition:color .2s}
-.nav-r{display:flex;align-items:center;gap:10px}
-.nav-link{font-size:12.5px;font-weight:500;color:var(--t4);padding:5px 10px;border-radius:var(--r-sm);transition:all .15s}
-.nav-link:hover{color:var(--t2);background:var(--card)}
-.gh-pill{display:inline-flex;align-items:center;gap:5px;padding:5px 12px;border-radius:var(--r-pill);
-  background:var(--badge-bg);color:var(--badge-t);font-size:11px;font-weight:500;letter-spacing:.02em;transition:opacity .15s}
-.gh-pill:hover{opacity:.85;color:var(--badge-t)}
-.gh-pill svg{flex-shrink:0}
+  display:flex;align-items:center;gap:10px;letter-spacing:.02em;transition:color .2s}
+.nav-logo:hover{color:var(--t1)}
+.nav-logo img{width:28px;height:28px;object-fit:contain}
+.nav-links{display:flex;align-items:center;gap:2px;margin-left:22px}
+.nav-link{font-size:14px;font-weight:500;color:var(--t4);padding:7px 9px;border-radius:6px;transition:all .15s}
+.nav-link:hover{color:var(--t2);background:var(--nav-active)}
+.nav-link.active{color:var(--t1);background:var(--nav-active)}
+.nav-actions{display:flex;align-items:center;gap:8px;margin-left:auto}
+.theme-toggle{display:inline-flex;align-items:center;padding:4px;border:.7px solid var(--border);border-radius:999px;
+  background:transparent;color:var(--t4);cursor:pointer;transition:border-color .2s}
+.theme-icon{display:flex;align-items:center;justify-content:center;width:26px;height:26px;padding:6px;border-radius:999px}
+.theme-icon svg{width:14px;height:14px}
+[data-theme="light"] .theme-sun,[data-theme="dark"] .theme-moon{background:var(--nav-active);color:var(--t1)}
+.gh-link{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;color:var(--t1);transition:background .15s}
+.gh-link:hover{color:var(--t1);background:var(--nav-active)}
+.gh-link svg{width:18px;height:18px}
+.nav-menu{display:none;margin-left:auto;position:relative}
+.nav-menu summary{display:flex;align-items:center;justify-content:center;width:38px;height:38px;border:.7px solid var(--border);
+  border-radius:8px;color:var(--t1);cursor:pointer;list-style:none}
+.nav-menu summary::-webkit-details-marker{display:none}
+.nav-menu summary svg{width:20px;height:20px;transition:transform .2s}
+.nav-menu[open] summary svg{transform:rotate(180deg)}
+.nav-menu-panel{position:absolute;top:46px;right:-8px;width:210px;padding:10px;border:.7px solid var(--border);
+  border-radius:12px;background:var(--bg);box-shadow:0 16px 40px rgba(0,0,0,.14)}
+.nav-menu-panel .nav-link{display:block;margin-bottom:2px}
+.nav-menu-tools{display:flex;align-items:center;justify-content:space-between;margin-top:8px;padding-top:8px;border-top:.7px solid var(--border)}
 
 /* HERO */
 .hero-wrap{max-width:900px;margin:0 auto;padding:0 28px}
@@ -205,7 +241,7 @@ a:hover{color:var(--link-h)}
 @media(max-width:768px){
   .hero-wrap{padding:0 16px}
   .layout{padding:0 16px 56px}
-  .nav{padding:0 16px}.nav-link{display:none}
+  .nav{padding:0 16px}.nav-links,.nav-actions{display:none}.nav-menu{display:block}
   .hero h1{font-size:42px}
   .hero{padding:48px 0 28px}
   .hero-sub{font-size:14px}
@@ -245,15 +281,38 @@ a:hover{color:var(--link-h)}
 
 <!-- NAV -->
 <nav class="nav">
-  <a href="https://coral.compounding-intelligence.ai/" class="nav-logo">CORAL</a>
-  <div class="nav-r">
-    <a href="https://coral.compounding-intelligence.ai/docs/" class="nav-link">Docs</a>
-    <a href="https://coral.compounding-intelligence.ai/blogs/" class="nav-link" style="color:var(--t1)">Blog</a>
-    <a href="https://github.com/Human-Agent-Society/Coral" class="gh-pill">
-      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-      GitHub
+  <a href="/" class="nav-logo"><img src="/coral_logo.png" alt="">CORAL</a>
+  <div class="nav-links">
+    <a href="/" class="nav-link">Home</a>
+    <a href="/docs/" class="nav-link">Docs</a>
+    <a href="/blogs/" class="nav-link active" aria-current="page">Blogs</a>
+  </div>
+  <div class="nav-actions">
+    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle Theme">
+      <span class="theme-icon theme-sun"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.42-1.42M17.66 6.34l1.41-1.41"/></svg></span>
+      <span class="theme-icon theme-moon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></span>
+    </button>
+    <a href="https://github.com/Human-Agent-Society/CORAL" class="gh-link" aria-label="GitHub">
+      <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
     </a>
   </div>
+  <details class="nav-menu">
+    <summary aria-label="Toggle Menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg></summary>
+    <div class="nav-menu-panel">
+      <a href="/" class="nav-link">Home</a>
+      <a href="/docs/" class="nav-link">Docs</a>
+      <a href="/blogs/" class="nav-link active" aria-current="page">Blogs</a>
+      <div class="nav-menu-tools">
+        <a href="https://github.com/Human-Agent-Society/CORAL" class="gh-link" aria-label="GitHub">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle Theme">
+          <span class="theme-icon theme-sun"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.42-1.42M17.66 6.34l1.41-1.41"/></svg></span>
+          <span class="theme-icon theme-moon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></span>
+        </button>
+      </div>
+    </div>
+  </details>
 </nav>
 
 <!-- HERO -->
@@ -634,6 +693,17 @@ a:hover{color:var(--link-h)}
 </footer>
 
 <script>
+
+function setTheme(theme){
+  document.documentElement.dataset.theme=theme;
+  document.documentElement.style.colorScheme=theme;
+  localStorage.setItem('theme',theme);
+}
+document.querySelectorAll('[data-theme-toggle]').forEach(function(button){
+  button.addEventListener('click',function(){
+    setTheme(document.documentElement.dataset.theme==='dark'?'light':'dark');
+  });
+});
 
 // Copy code
 function copyCode(b){var p=b.closest('.cb').querySelector('pre');

--- a/docs/app/docs/[[...slug]]/layout.tsx
+++ b/docs/app/docs/[[...slug]]/layout.tsx
@@ -1,11 +1,49 @@
 import { source } from '@/lib/source';
-import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import { DocsLayout, SidebarTrigger } from 'fumadocs-ui/layouts/docs';
+import { Header } from 'fumadocs-ui/layouts/home';
 import { baseOptions } from '@/lib/layout.shared';
 import type { ReactNode } from 'react';
 
 export default function Layout({ children }: { children: ReactNode }) {
+  const siteOptions = baseOptions();
+
   return (
-    <DocsLayout tree={source.getPageTree()} {...baseOptions()} themeSwitch={{ enabled: false }}>
+    <DocsLayout
+      tree={source.getPageTree()}
+      nav={{
+        title: 'Documentation',
+        url: '/docs/',
+        component: (
+          <Header
+            {...siteOptions}
+            nav={{
+              ...siteOptions.nav,
+              children: (
+                <SidebarTrigger className="ms-auto inline-flex size-9 items-center justify-center rounded-md text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground md:hidden">
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="size-5"
+                  >
+                    <rect width="18" height="18" x="3" y="3" rx="2" />
+                    <path d="M9 3v18" />
+                  </svg>
+                </SidebarTrigger>
+              ),
+            }}
+          />
+        ),
+      }}
+      links={[]}
+      searchToggle={{ enabled: false }}
+      themeSwitch={{ enabled: false }}
+      containerProps={{ className: '[--fd-nav-height:56px]' }}
+    >
       {children}
     </DocsLayout>
   );

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -7,8 +7,8 @@
   --font-fd-mono: 'DM Mono', ui-monospace, monospace;
 }
 
-/* CORAL blog palette — exact same hex values as the blog */
-html, html.light, :root {
+/* CORAL palette */
+:root, html.light {
   --color-fd-background: #f3f6fb !important;
   --color-fd-foreground: #18222e !important;
   --color-fd-muted: #dde4f0 !important;
@@ -25,23 +25,53 @@ html, html.light, :root {
   --color-fd-accent: #bec8d880 !important;
   --color-fd-accent-foreground: #18222e !important;
   --color-fd-ring: #aab4c6 !important;
+  --coral-body: #26323f;
+  --coral-inline-code: #dde4f0;
   --fd-layout-width: 100vw;
 }
 
+html.dark {
+  --color-fd-background: #111821 !important;
+  --color-fd-foreground: #edf2f7 !important;
+  --color-fd-muted: #202b38 !important;
+  --color-fd-muted-foreground: #9eacba !important;
+  --color-fd-popover: #18222e !important;
+  --color-fd-popover-foreground: #edf2f7 !important;
+  --color-fd-card: #18222e !important;
+  --color-fd-card-foreground: #edf2f7 !important;
+  --color-fd-border: #344454 !important;
+  --color-fd-primary: #edf2f7 !important;
+  --color-fd-primary-foreground: #111821 !important;
+  --color-fd-secondary: #202b38 !important;
+  --color-fd-secondary-foreground: #edf2f7 !important;
+  --color-fd-accent: #34445480 !important;
+  --color-fd-accent-foreground: #edf2f7 !important;
+  --color-fd-ring: #647585 !important;
+  --coral-body: #c7d1dc;
+  --coral-inline-code: #202b38;
+}
+
 body, #nd-sidebar, nav, aside {
-  background-color: #f3f6fb !important;
+  background-color: var(--color-fd-background) !important;
+}
+
+/* Highlight only the global navigation item for the current route. */
+#nd-nav a[data-active='true'] {
+  border-radius: 0.375rem;
+  background-color: var(--color-fd-accent);
+  color: var(--color-fd-accent-foreground);
 }
 
 /* Heading typography — Source Serif 4 */
 h1, h2, h3, h4 {
   font-family: 'Source Serif 4', Georgia, serif;
   letter-spacing: -0.015em;
-  color: #18222e;
+  color: var(--color-fd-foreground);
 }
 
 /* Body text color */
 body, p, li, td {
-  color: #26323f;
+  color: var(--coral-body);
 }
 
 /* Code block font */
@@ -51,7 +81,7 @@ pre, code {
 
 /* Inline code */
 code:not(pre code) {
-  background: #dde4f0;
+  background: var(--coral-inline-code);
 }
 
 /* Fix: fumadocs TOC scroll area mask */

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata = {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className="light" style={{ colorScheme: 'light' }}>
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
@@ -31,7 +31,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         className="flex min-h-screen flex-col"
         style={{ fontFamily: "'DM Sans', system-ui, sans-serif" }}
       >
-        <RootProvider theme={{ enabled: false }}>{children}</RootProvider>
+        <RootProvider>{children}</RootProvider>
         <Analytics />
       </body>
     </html>

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -19,9 +19,8 @@ export function baseOptions(): BaseLayoutProps {
     },
     links: [
       { text: 'Home', url: '/' },
-      { text: 'Docs', url: '/docs/' },
+      { text: 'Docs', url: '/docs/', active: 'nested-url' },
       { text: 'Blogs', url: '/blogs/' },
-      { type: 'button', text: 'Get started', url: '/docs/getting-started/' },
     ],
     githubUrl: 'https://github.com/Human-Agent-Society/CORAL',
   };

--- a/docs/tests/site-routes.test.mjs
+++ b/docs/tests/site-routes.test.mjs
@@ -30,6 +30,68 @@ test('the article serves an asset below its canonical prefix', async () => {
   assert.match(response.headers.get('content-type') ?? '', /^image\//);
 });
 
+test('the article keeps the global navigation and blog active state', async () => {
+  const { body } = await get('/blogs/evolve-like-coral/');
+  const navbar = body.match(/<nav class="nav">[\s\S]*?<\/nav>/)?.[0];
+
+  assert.ok(navbar, 'article navigation');
+  for (const href of ['/', '/docs/', '/blogs/']) {
+    assert.match(navbar, new RegExp(`href="${href}"`), href);
+  }
+  assert.match(navbar, /href="\/blogs\/"[^>]*aria-current="page"/);
+  assert.match(navbar, /data-theme-toggle/);
+  assert.match(navbar, /aria-label="GitHub"/);
+});
+
+test('docs and blogs share the global top navigation', async () => {
+  for (const path of ['/docs/', '/blogs/']) {
+    const { body } = await get(path);
+    const navbar = body.match(/<header id="nd-nav"[\s\S]*?<\/header>/)?.[0];
+
+    assert.ok(navbar, `${path} top navigation`);
+    for (const href of ['/', '/docs/', '/blogs/']) {
+      assert.match(navbar, new RegExp(`href="${href}"`), `${path} ${href}`);
+    }
+    assert.doesNotMatch(navbar, /href="\/docs\/getting-started\/"/);
+  }
+
+  const { body } = await get('/docs/');
+  const sidebar = body.match(/<aside id="nd-sidebar"[\s\S]*?<\/aside>/)?.[0];
+
+  assert.ok(sidebar, 'docs sidebar');
+  assert.doesNotMatch(sidebar, /href="\/blogs\/"/);
+  assert.doesNotMatch(sidebar, /href="\/docs\/getting-started\/"/);
+});
+
+test('the current global navigation item is the only active item', async () => {
+  const pages = [
+    ['/', ['/']],
+    ['/docs/', ['/docs/']],
+    ['/blogs/', ['/blogs/']],
+    ['/docs/getting-started/', ['/docs/']],
+  ];
+
+  for (const [path, expectedHrefs] of pages) {
+    const { body } = await get(path);
+    const navbar = body.match(/<header id="nd-nav"[\s\S]*?<\/header>/)?.[0];
+    const activeLinks = [...(navbar?.matchAll(/<a\b[^>]*data-active="true"[^>]*>/g) ?? [])]
+      .map(([tag]) => tag.match(/href="([^"]+)"/)?.[1])
+      .filter(Boolean);
+
+    assert.deepEqual([...new Set(activeLinks)], expectedHrefs, path);
+  }
+});
+
+test('theme controls include the interactive theme bootstrap', async () => {
+  for (const path of ['/', '/docs/', '/blogs/', '/blogs/evolve-like-coral/']) {
+    const { body } = await get(path);
+
+    assert.match(body, /data-theme-toggle/, `${path} theme control`);
+    assert.match(body, /localStorage/, `${path} theme bootstrap`);
+    assert.doesNotMatch(body, /<html[^>]*class="light"/, `${path} forced light theme`);
+  }
+});
+
 test('retired root-level docs are not canonical', async () => {
   const { response } = await get('/getting-started/installation');
   assert.equal(response.status, 404);


### PR DESCRIPTION
## Motivation

The unified CORAL site rendered Home and Blogs with a top navbar while Docs moved the same global links into its sidebar. The static blog article used another reduced header, and the visible theme toggle was disabled. This made navigation jump between layouts and produced misleading active states.

## Changes

- reuse the Home/Blogs header on Docs while keeping the Docs sidebar focused on documentation
- standardize Home, Docs, and Blogs active states, including nested `/docs/**` routes
- enable persisted light/dark themes and add the matching CORAL dark palette
- retain the same navigation, Blogs active state, theme toggle, GitHub link, and responsive menu on the static blog article
- add route-level regression coverage for canonical routes, shared navigation, active states, and theme bootstrap

## Test plan

- `cd docs && npm run build` (passed)
- `cd docs && npm run test:routes` (7 passed)
- `cd docs && node --test tests/blog-sync.test.mjs tests/canonical-links.test.mjs` (3 passed)
- `git diff --check` (passed)
- Manually verified desktop/mobile Home, Docs, Blogs, and article navigation, Docs nested active state, and light/dark switching at `http://127.0.0.1:3000/`.

## Affected areas

- [ ] `coral/` (core framework)
- [ ] `coral/agent/` (agent runtimes)
- [ ] `coral/cli/` (CLI commands)
- [ ] `coral/daemon/` (daemon / coordination)
- [ ] `coral/grader/` (grading)
- [ ] `coral/hooks/` (hooks)
- [ ] `coral/hub/` (hub / APIs)
- [ ] `coral/template/` (bundled templates)
- [ ] `examples/` (example tasks)
- [x] `docs/` (docs site)
- [ ] CI / packaging / release

## Checklist

- [x] This PR targets the `dev` branch (not `main`).
- [x] The title follows Conventional Commits.
- [ ] `uv run pytest tests/`
- [ ] `uv run ruff check . && uv run ruff format --check .`
- [ ] I added or updated tests under `tests/` for behavior changes.
- [ ] I updated relevant documentation (`docs/content/`, README, or bundled skill docs).
- [ ] If I changed config / serialized models / public APIs, I documented compatibility or migration impact.
- [ ] If I added a new example task, `uv run coral validate examples/<task>/task.yaml` succeeds.
- [ ] If AI-assisted, a human author has read every changed line and can defend the design.

*Authored with assistance from Codex. The behavior was reviewed interactively and the tests above were run locally; the submitting human should review every changed line before marking this PR ready.*
