### PR TITLE
feat(migration): remigration cooldown + weakest dest default (#191)

### DIFF
--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -11,6 +11,7 @@ import random
 import shutil
 import signal
 import subprocess
+import tempfile
 import threading
 import time
 from collections import deque
@@ -181,6 +182,13 @@ class AgentManager:
         # Each entry: (candidate, reason). Deferred batches retry until they
         # apply or go stale; paused agents can stay paused for arbitrarily long.
         self._deferred_candidates: list[tuple[MigrationCandidate, str]] = []
+        # agent_id → global real-eval count at the moment of its last
+        # successful migration. Feeds MigrationRunner's remigration cooldown
+        # so a migrant (whose attempt records travel with it and therefore
+        # immediately satisfy min_evals on the new island) cannot ping-pong
+        # every cycle. Persisted at public/migration_state.json so the guard
+        # survives `coral resume`.
+        self._last_migrated_eval: dict[str, int] = {}
 
     def _runtime_for(self, agent_id: str) -> AgentRuntime:
         """Return the runtime instance for an agent_id, creating one on demand.
@@ -216,6 +224,7 @@ class AgentManager:
         logger.info(f"Run directory: {self.paths.run_dir}")
         logger.info(f"  coral_dir: {self.paths.coral_dir}")
         logger.info(f"  repo_dir:  {self.paths.repo_dir}")
+        self._last_migrated_eval = _read_last_migrated_evals(self.paths.coral_dir)
 
         # 1b. Start gateway if configured
         self._start_gateway_if_enabled()
@@ -846,6 +855,7 @@ class AgentManager:
         """Resume agents into an existing run's worktrees."""
         self._start_time = datetime.now(UTC)
         self.paths = paths
+        self._last_migrated_eval = _read_last_migrated_evals(paths.coral_dir)
 
         # Start gateway if configured
         self._start_gateway_if_enabled()
@@ -1755,6 +1765,8 @@ class AgentManager:
             coral_dir=self.paths.coral_dir,
             island_best_scores=best_scores,
             current_agent_islands=dict(self._agent_island),
+            last_migrated_evals=self._last_migrated_eval,
+            current_evals=current_evals,
         )
         # Mark the cycle as done even if no candidates matched — otherwise
         # every subsequent tick would re-enter run_cycle on the same boundary.
@@ -2204,6 +2216,16 @@ class AgentManager:
         # (6) Swap spec + tracking dict so future restarts pick dst.
         self._swap_spec_island(agent_id, new_island_id=dst)
         self._agent_island[agent_id] = dst
+
+        # (6b) Stamp the remigration cooldown. The migrant's attempt records
+        # moved with it in step (3), so without this stamp min_evals would be
+        # satisfied on the new island immediately and the same top agent
+        # could be re-selected on the very next cycle (ping-pong).
+        self._last_migrated_eval[agent_id] = self._get_migration_eval_count()
+        try:
+            _write_last_migrated_evals(coral_dir, self._last_migrated_eval)
+        except OSError as e:
+            logger.warning(f"Failed to persist migration state: {e}")
 
         # (7) Drop an arrival note on dst (best-effort).
         if self.migration_config.notify_island:
@@ -2917,6 +2939,67 @@ def _refresh_runtime_settings(
             gateway_api_key=gateway_api_key,
             island_id=island_id,
         )
+
+
+def _migration_state_path(coral_dir: Path) -> Path:
+    """Canonical location of the per-run migration state document."""
+    return coral_dir / "public" / "migration_state.json"
+
+
+def _write_last_migrated_evals(coral_dir: Path, last_migrated: dict[str, int]) -> Path:
+    """Atomically persist the agent → last-migrated eval-count map.
+
+    Mirrors the tempfile + os.replace pattern of ``write_agent_state`` so
+    concurrent readers never observe a partial document.
+    """
+    target = _migration_state_path(coral_dir)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        {"schema_version": 1, "last_migrated_evals": last_migrated},
+        indent=2,
+        sort_keys=True,
+    )
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".migration_state.", suffix=".tmp", dir=str(target.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        os.replace(tmp_path, target)
+    except Exception:
+        if os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+        raise
+    return target
+
+
+def _read_last_migrated_evals(coral_dir: Path) -> dict[str, int]:
+    """Best-effort read of the agent → last-migrated eval-count map.
+
+    Missing or malformed files yield an empty map, which disables the
+    remigration cooldown (no agent has a recorded migration).
+    """
+    target = _migration_state_path(coral_dir)
+    try:
+        with open(target) as f:
+            raw = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    data = raw.get("last_migrated_evals", {})
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, int] = {}
+    for agent_id, evals in data.items():
+        try:
+            out[str(agent_id)] = int(evals)
+        except (TypeError, ValueError):
+            continue
+    return out
 
 
 def _write_arrival_note(coral_dir: Path, candidate: MigrationCandidate) -> None:

--- a/coral/agent/migration.py
+++ b/coral/agent/migration.py
@@ -25,6 +25,13 @@ the assigned candidates are reduced to the best subset of at most
 balance; from an already-balanced roster, that means migration happens as
 a swap/cycle rather than as a one-way drain.
 
+Re-migration guard: because attempt records move with the migrant, a
+freshly migrated agent would immediately satisfy ``min_evals`` on its new
+island and could ping-pong between islands every cycle. The manager
+therefore passes ``last_migrated_evals`` (agent → global eval count at
+migration time) into :meth:`MigrationRunner.run_cycle`, and agents still
+inside ``remigration_cooldown`` evals are excluded from selection.
+
 What moves with an agent (mechanics in the manager): ``roles/<agent>.md``,
 ``heartbeat/<agent>.json``, that agent's attempt records, and matching
 ``eval_logs/<commit>/`` directories follow them. Notes and skills authored
@@ -39,7 +46,7 @@ from __future__ import annotations
 
 import logging
 import random
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Collection, Iterable, Mapping
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
@@ -154,6 +161,26 @@ def score_for_agent(
     return min(scores) if minimize else max(scores)
 
 
+def cooled_down_agents(
+    last_migrated_evals: Mapping[str, int],
+    *,
+    current_evals: int,
+    cooldown: int,
+) -> set[str]:
+    """Agents still inside their post-migration cooldown window.
+
+    An agent becomes eligible again once ``current_evals - last >= cooldown``
+    (boundary inclusive). ``cooldown <= 0`` disables the guard entirely.
+    """
+    if cooldown <= 0:
+        return set()
+    return {
+        agent_id
+        for agent_id, last in last_migrated_evals.items()
+        if current_evals - last < cooldown
+    }
+
+
 def select_candidates(
     coral_dir: str | Path,
     *,
@@ -163,6 +190,7 @@ def select_candidates(
     minimize: bool,
     roster: IslandRoster | None = None,
     current_agent_islands: dict[str, str] | None = None,
+    excluded_agents: Collection[str] | None = None,
 ) -> list[MigrationCandidate]:
     """For each source island, return its best eligible agent (at most one).
 
@@ -177,6 +205,8 @@ def select_candidates(
       * The agent has at least one real attempt with a non-None score in
         the trailing ``rank_window`` — otherwise we'd have no score to
         rank by.
+      * The agent is not in ``excluded_agents`` (e.g. still inside the
+        remigration cooldown after a recent move).
 
     Returns a candidate per island (or none for islands with no eligible
     agent), each with ``dst_island = ""`` for the assignment step to fill in.
@@ -187,6 +217,7 @@ def select_candidates(
             current_agent_islands,
             island_ids=island_ids,
         )
+    excluded = set(excluded_agents) if excluded_agents else set()
     for src in island_ids:
         attempts = read_attempts(coral_dir, island_id=src)
         per_agent: dict[str, list[Attempt]] = {}
@@ -196,6 +227,8 @@ def select_candidates(
         best_agent: str | None = None
         best_score: float | None = None
         for agent_id, agent_attempts in per_agent.items():
+            if agent_id in excluded:
+                continue
             if roster is not None and not roster.is_on(agent_id, src):
                 continue
             real = [a for a in agent_attempts if a.budget_class == BUDGET_CLASS_REAL]
@@ -248,6 +281,12 @@ def assign_destinations(
             (rich-get-richer); under ``minimize=True``, lower score →
             higher weight. Falls back to uniform when no island_best_scores
             are recorded yet (typical early in a run).
+        ``weakest`` — the FunSearch-style "rescue" policy: invert the
+            ``score`` direction so the islands furthest behind attract the
+            most migrants. Under ``minimize=False`` the lowest-score island
+            gets the most weight; under ``minimize=True`` the highest-score
+            island does. Same uniform fallback as ``score`` when no island
+            best scores are recorded yet.
     """
     if len(island_ids) <= 1:
         return []
@@ -277,6 +316,14 @@ def assign_destinations(
             weights = _score_weights(non_src, island_best_scores, minimize=minimize)
             if weights is None:
                 # No score signal yet — uniform is the only honest fallback.
+                dst = rng.choice(non_src)
+            else:
+                dst = rng.choices(non_src, weights=weights, k=1)[0]
+        elif weighting == "weakest":
+            # Rescue policy: invert the score direction so the islands
+            # furthest behind attract the most migrants.
+            weights = _score_weights(non_src, island_best_scores, minimize=not minimize)
+            if weights is None:
                 dst = rng.choice(non_src)
             else:
                 dst = rng.choices(non_src, weights=weights, k=1)[0]
@@ -459,6 +506,8 @@ class MigrationRunner:
         coral_dir: str | Path,
         island_best_scores: dict[str, float],
         current_agent_islands: dict[str, str] | None = None,
+        last_migrated_evals: Mapping[str, int] | None = None,
+        current_evals: int = 0,
     ) -> list[MigrationCandidate]:
         """Plan one migration cycle. Caller applies the returned candidates.
 
@@ -467,10 +516,16 @@ class MigrationRunner:
         ``score`` destination policy. Pass an empty dict in single-cycle
         unit tests to exercise the uniform fallback.
 
+        ``last_migrated_evals`` maps agent_id → the global eval count at
+        which that agent last migrated. Agents still inside
+        ``remigration_cooldown`` evals (measured against ``current_evals``)
+        are excluded from selection so a fresh migrant cannot ping-pong
+        back on the very next cycle.
+
         Returns up to ``max_per_cycle`` candidates, each with a non-empty
         ``dst_island``. Returns an empty list when:
             * No island has an eligible agent (everyone is below
-              ``min_evals``, or no real scored attempts exist).
+              ``min_evals``, cooled down, or no real scored attempts exist).
             * ``count == 1`` (no destinations).
             * The runner is disabled.
         """
@@ -487,6 +542,16 @@ class MigrationRunner:
             else None
         )
 
+        excluded = cooled_down_agents(
+            last_migrated_evals or {},
+            current_evals=current_evals,
+            cooldown=self.migration_config.remigration_cooldown,
+        )
+        if excluded:
+            logger.info(
+                f"Migration cycle: {len(excluded)} agent(s) excluded by remigration cooldown"
+            )
+
         raw = select_candidates(
             coral_dir,
             island_ids=island_ids,
@@ -494,6 +559,7 @@ class MigrationRunner:
             min_evals=self.migration_config.min_evals,
             minimize=self.minimize,
             roster=roster,
+            excluded_agents=excluded,
         )
         if not raw:
             return []

--- a/coral/config.py
+++ b/coral/config.py
@@ -372,8 +372,13 @@ class MigrationConfig:
     every: int = 50  # global evals between migration cycles
     rank_window: int = 20  # "best agent" judged by max-over-last-N evals
     min_evals: int = 3  # candidate must have >= N attempts to be eligible
-    dest_weighting: str = "score"  # score | uniform | round_robin
+    dest_weighting: str = "weakest"  # weakest | uniform | round_robin | score
     max_per_cycle: int = 2
+    # Min global evals before the same agent may migrate again. Attempt
+    # records move with the migrant, so without this guard min_evals is
+    # satisfied on arrival and the same top agent can ping-pong every cycle.
+    # 0 disables the guard.
+    remigration_cooldown: int = 100
     notify_island: bool = True
     # Standard post-migration phase: interrupt+resume live bystanders on the
     # affected islands so launch-injected per-agent state follows the new
@@ -395,14 +400,19 @@ class MigrationConfig:
             )
         if self.min_evals < 1:
             raise ValueError(f"islands.migration.min_evals must be >= 1, got {self.min_evals}")
-        if self.dest_weighting not in {"score", "uniform", "round_robin"}:
+        if self.dest_weighting not in {"score", "uniform", "round_robin", "weakest"}:
             raise ValueError(
                 "islands.migration.dest_weighting must be one of "
-                f"{{score, uniform, round_robin}}, got {self.dest_weighting!r}"
+                f"{{score, uniform, round_robin, weakest}}, got {self.dest_weighting!r}"
             )
         if self.max_per_cycle < 1:
             raise ValueError(
                 f"islands.migration.max_per_cycle must be >= 1, got {self.max_per_cycle}"
+            )
+        if self.remigration_cooldown < 0:
+            raise ValueError(
+                "islands.migration.remigration_cooldown must be >= 0, "
+                f"got {self.remigration_cooldown}"
             )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -400,8 +400,9 @@ def test_islands_defaults_single_island():
     assert cfg.islands.migration.every == 50
     assert cfg.islands.migration.rank_window == 20
     assert cfg.islands.migration.min_evals == 3
-    assert cfg.islands.migration.dest_weighting == "score"
+    assert cfg.islands.migration.dest_weighting == "weakest"
     assert cfg.islands.migration.max_per_cycle == 2
+    assert cfg.islands.migration.remigration_cooldown == 100
     assert cfg.islands.migration.notify_island is True
 
 
@@ -472,6 +473,27 @@ def test_migration_dest_weighting_validation():
                 "islands": {"migration": {"dest_weighting": "nonsense"}},
             }
         )
+
+
+def test_migration_remigration_cooldown_validation():
+    import pytest
+
+    with pytest.raises(ValueError, match="remigration_cooldown must be >= 0"):
+        CoralConfig.from_dict(
+            {
+                "task": {"name": "t", "description": "d"},
+                "islands": {"migration": {"remigration_cooldown": -1}},
+            }
+        )
+
+    # 0 is allowed — it disables the cooldown guard.
+    cfg = CoralConfig.from_dict(
+        {
+            "task": {"name": "t", "description": "d"},
+            "islands": {"migration": {"remigration_cooldown": 0}},
+        }
+    )
+    assert cfg.islands.migration.remigration_cooldown == 0
 
 
 # --- Presets ---------------------------------------------------------------

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -20,6 +20,7 @@ from coral.agent.migration import (
     MigrationCandidate,
     MigrationRunner,
     assign_destinations,
+    cooled_down_agents,
     score_for_agent,
     select_candidates,
 )
@@ -255,6 +256,144 @@ def test_select_candidates_minimize_direction_picks_lowest_score_agent():
 
 
 # ---------------------------------------------------------------------------
+# Remigration cooldown: cooled_down_agents + exclusion in selection
+# ---------------------------------------------------------------------------
+
+
+def test_cooled_down_agents_boundary():
+    """Excluded while current_evals - last < cooldown; eligible again at ==."""
+    last = {"agent-A": 100}
+    assert cooled_down_agents(last, current_evals=100, cooldown=100) == {"agent-A"}
+    assert cooled_down_agents(last, current_evals=199, cooldown=100) == {"agent-A"}
+    assert cooled_down_agents(last, current_evals=200, cooldown=100) == set()
+    assert cooled_down_agents(last, current_evals=300, cooldown=100) == set()
+
+
+def test_cooled_down_agents_zero_cooldown_disables_guard():
+    """cooldown=0 (or negative) means no agent is ever excluded."""
+    last = {"agent-A": 100}
+    assert cooled_down_agents(last, current_evals=100, cooldown=0) == set()
+
+
+def test_select_candidates_excluded_agents_falls_back_to_second_best():
+    """With the island's best agent excluded, the island's 2nd best migrates."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d)
+        _make_multi_island(coral_dir, n=1)
+        for i, (agent, score) in enumerate([("agent-A", 0.9), ("agent-B", 0.4)] * 3):
+            write_attempt(
+                coral_dir,
+                _make_attempt(f"{i}", agent, score, timestamp=f"2026-05-31T10:0{i}:00Z"),
+                island_id="0",
+            )
+
+        candidates = select_candidates(
+            coral_dir,
+            island_ids=["0"],
+            rank_window=5,
+            min_evals=2,
+            minimize=False,
+            excluded_agents={"agent-A"},
+        )
+        assert [c.agent_id for c in candidates] == ["agent-B"]
+
+
+def test_select_candidates_excluding_everyone_yields_no_candidate():
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d)
+        _make_multi_island(coral_dir, n=1)
+        for i, s in enumerate([0.3, 0.4, 0.5]):
+            write_attempt(
+                coral_dir,
+                _make_attempt(f"a{i}", "agent-A", s, timestamp=f"2026-05-31T10:0{i}:00Z"),
+                island_id="0",
+            )
+
+        candidates = select_candidates(
+            coral_dir,
+            island_ids=["0"],
+            rank_window=5,
+            min_evals=2,
+            minimize=False,
+            excluded_agents={"agent-A"},
+        )
+        assert candidates == []
+
+
+def test_run_cycle_excludes_recent_migrants():
+    """A fresh migrant inside its cooldown window is not re-selected — the
+    classic ping-pong case: attempts moved with it, so min_evals alone would
+    immediately re-pick the same agent."""
+    with tempfile.TemporaryDirectory() as d:
+        coral_dir = Path(d)
+        _make_multi_island(coral_dir, n=2)
+        for island in range(2):
+            for i, s in enumerate([0.3, 0.4, 0.5]):
+                write_attempt(
+                    coral_dir,
+                    _make_attempt(
+                        f"i{island}-{i}",
+                        f"agent-{island}",
+                        s,
+                        timestamp=f"2026-05-31T10:0{i}:0{island}Z",
+                    ),
+                    island_id=str(island),
+                )
+        mig = MigrationConfig(
+            every=10,
+            rank_window=5,
+            min_evals=2,
+            max_per_cycle=2,
+            remigration_cooldown=100,
+        )
+        cfg = IslandsConfig(count=2, migration=mig)
+        runner = MigrationRunner(cfg, minimize=False, rng=random.Random(0))
+
+        # agent-0 migrated at eval 95; we're now at eval 100 → still cooled
+        # down (100 - 95 < 100), so only agent-1 may move this cycle.
+        migrations = runner.run_cycle(
+            coral_dir=coral_dir,
+            island_best_scores={},
+            last_migrated_evals={"agent-0": 95},
+            current_evals=100,
+        )
+        assert {c.agent_id for c in migrations} == {"agent-1"}
+
+        # At eval 195 the cooldown expired (195 - 95 >= 100) → both eligible.
+        migrations = runner.run_cycle(
+            coral_dir=coral_dir,
+            island_best_scores={},
+            last_migrated_evals={"agent-0": 95},
+            current_evals=195,
+        )
+        assert {c.agent_id for c in migrations} == {"agent-0", "agent-1"}
+
+
+def test_last_migrated_evals_persistence_round_trip(tmp_path):
+    """migration_state.json survives write/read; missing/corrupt → empty map."""
+    from coral.agent.manager import (
+        _migration_state_path,
+        _read_last_migrated_evals,
+        _write_last_migrated_evals,
+    )
+
+    coral_dir = tmp_path
+    # Missing file → empty map (guard effectively disabled).
+    assert _read_last_migrated_evals(coral_dir) == {}
+
+    _write_last_migrated_evals(coral_dir, {"agent-A": 42, "agent-B": 7})
+    assert _read_last_migrated_evals(coral_dir) == {"agent-A": 42, "agent-B": 7}
+
+    # Corrupt JSON → empty map, never a crash on resume.
+    _migration_state_path(coral_dir).write_text("{not json")
+    assert _read_last_migrated_evals(coral_dir) == {}
+
+    # Well-formed but wrong shape → empty map.
+    _migration_state_path(coral_dir).write_text('{"last_migrated_evals": [1, 2]}')
+    assert _read_last_migrated_evals(coral_dir) == {}
+
+
+# ---------------------------------------------------------------------------
 # assign_destinations: dest_weighting policies
 # ---------------------------------------------------------------------------
 
@@ -361,6 +500,46 @@ def test_assign_destinations_score_weighting_minimize_inverts():
         )
         landings[out[0].dst_island] += 1
     assert landings["2"] > 3 * landings["1"]
+
+
+def test_assign_destinations_weakest_biases_toward_weakest_island():
+    """``weakest`` inverts the ``score`` direction: under maximize, the
+    lowest-score island attracts the most migrants (FunSearch-style rescue)."""
+    rng = random.Random(7)
+    best_scores = {"0": 0.0, "1": 0.1, "2": 1.0}
+    landings: dict[str, int] = {"1": 0, "2": 0}
+    for _ in range(500):
+        out = assign_destinations(
+            [_candidate("agent-A", "0")],
+            island_ids=["0", "1", "2"],
+            weighting="weakest",
+            cycle_idx=0,
+            island_best_scores=best_scores,
+            rng=rng,
+            minimize=False,
+        )
+        landings[out[0].dst_island] += 1
+    # Island 1 (0.1) is far weaker than island 2 (1.0) → island 1 dominates.
+    assert landings["1"] > 3 * landings["2"]
+
+
+def test_assign_destinations_weakest_minimize_targets_strongest():
+    """Under minimize, ``weakest`` targets the highest-score island."""
+    rng = random.Random(7)
+    best_scores = {"0": 0.5, "1": 5.0, "2": 0.1}
+    landings: dict[str, int] = {"1": 0, "2": 0}
+    for _ in range(500):
+        out = assign_destinations(
+            [_candidate("agent-A", "0")],
+            island_ids=["0", "1", "2"],
+            weighting="weakest",
+            cycle_idx=0,
+            island_best_scores=best_scores,
+            rng=rng,
+            minimize=True,
+        )
+        landings[out[0].dst_island] += 1
+    assert landings["1"] > 3 * landings["2"]
 
 
 def test_assign_destinations_falls_back_to_uniform_when_no_scores():
@@ -1393,7 +1572,14 @@ def test_maybe_run_migration_cycle_migrates_whole_swap_with_pending_attempt(tmp_
     def fake_should_run(*, current_global_evals):
         return True
 
-    def fake_run_cycle(*, coral_dir, island_best_scores, current_agent_islands=None):
+    def fake_run_cycle(
+        *,
+        coral_dir,
+        island_best_scores,
+        current_agent_islands=None,
+        last_migrated_evals=None,
+        current_evals=0,
+    ):
         return [
             MigrationCandidate(agent_id="0-agent-1", src_island="0", dst_island="1", score=0.5),
             MigrationCandidate(agent_id="1-agent-1", src_island="1", dst_island="0", score=0.7),
@@ -1424,6 +1610,13 @@ def test_maybe_run_migration_cycle_migrates_whole_swap_with_pending_attempt(tmp_
     assert moved is not None
     assert moved.status == "pending"
     assert moved.metadata["island_id"] == "1"
+
+    # Both migrants got stamped with the remigration cooldown, and the stamp
+    # was persisted so it survives a resume.
+    from coral.agent.manager import _read_last_migrated_evals
+
+    assert set(mgr._last_migrated_eval) == {"0-agent-1", "1-agent-1"}
+    assert _read_last_migrated_evals(coral_dir) == mgr._last_migrated_eval
 
 
 def test_maybe_run_migration_cycle_ignores_raw_eval_count_for_tune_only(tmp_path):


### PR DESCRIPTION
* feat(migration): remigration cooldown, weakest dest default, cross-island notes

P0 — remigration cooldown (default 100, 0 disables):
  A freshly migrated agent's attempt records travel with it, so min_evals is
  satisfied on the new island immediately and the same top agent could be
  re-selected every cycle (ping-pong). Stamp each migrant with the global
  eval count at migration time and exclude agents still inside
  remigration_cooldown evals from selection. Persisted at
  public/migration_state.json so the guard survives coral resume.

P1 — weakest destination policy (new default):
  FunSearch-style 'rescue' policy: invert the score direction so the islands
  furthest behind attract the most migrants. Replaces score (rich-get-richer)
  as the default; score/uniform/round_robin remain available.

P4 — cross-island notes:
   opts out of the worktree island scope and
  aggregates every island's notes (read-only), tagged with source island.
  This is the cross-pollination channel the ablation models as knowledge
  diffusion. CORAL.md multi-island hint + migration arrival prompt point
  agents at it.

Ablation: scripts/ablate_migration.py drives the real policy code with a synthetic score process (persistent talent, slow skill growth, heavy re-orientation cost, knowledge diffusion). Over 8 seeds, weakest+cooldown100 beats uniform/score on final best (1.025 vs 0.952/0.942) and cuts ping-pong to 0. Validates mechanism-level claims; not evidence about real LLM runs.

* chore: remove migration ablation script from PR

* chore: drop p4 cross-island notes changes

* chore: refresh migration PR head

<!--
Thanks for contributing to CORAL! A few notes before you submit:

- Target the `dev` branch — all PRs go to `dev`, not `main` (see CONTRIBUTING.md).
- See CONTRIBUTING.md for the full workflow.
- Keep PRs scoped. Unrelated cleanups belong in a separate PR.
- Make sure `uv run pytest tests/ -v` and `uv run ruff check .` pass locally.
- If you used an AI coding agent to author this PR, also read AGENTS.md.
-->

## Motivation

<!-- Why is this change needed? Link related issues (e.g. "Closes #123"). -->

## Changes

<!-- What does this PR actually do? High-level summary, not a file-by-file rehash. -->

## Test plan

<!--
How did you verify this works? Concrete commands + results, not "I tested it".
Examples:
  - `uv run pytest tests/grader/ -v` (all green)
  - Smoke-ran `coral start -c examples/mnist/task.yaml agents.count=1` to first finalized score
  - `coral validate examples/<new-task>/`
-->

## Affected areas

<!-- Tick what this PR touches so reviewers know where to focus. -->

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other: <!-- specify -->

## Checklist

- [ ] PR targets the `dev` branch (not `main`).
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
