### PR TITLE
fix(codex): resume thread after heartbeat

### DIFF
--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -33,10 +33,12 @@ _CODEX_RUNTIME_OPTION_KEYS = {
 
 
 def _extract_codex_session_id(log_path: Path) -> str | None:
-    """Extract session_id from a Codex JSONL log.
+    """Extract the resumable thread ID from a Codex JSONL log.
 
-    Codex exec --json emits JSONL events. Session IDs appear in events
-    with a "session_id" field, typically in the final summary event.
+    Older Codex versions emitted ``session_id`` while current versions emit a
+    ``thread.started`` event with ``thread_id``. Accept both formats so a
+    heartbeat interrupt can resume the existing conversation instead of
+    silently starting a fresh one.
     """
     try:
         lines = log_path.read_text().strip().splitlines()
@@ -46,8 +48,12 @@ def _extract_codex_session_id(log_path: Path) -> str | None:
                 continue
             try:
                 data = json.loads(line)
+                if not isinstance(data, dict):
+                    continue
                 sid = data.get("session_id")
-                if sid:
+                if not sid and data.get("type") == "thread.started":
+                    sid = data.get("thread_id")
+                if isinstance(sid, str) and sid:
                     return sid
             except json.JSONDecodeError:
                 continue

--- a/tests/test_manager_reliability.py
+++ b/tests/test_manager_reliability.py
@@ -122,6 +122,30 @@ def test_codex_classify_exit_uses_uptime_fallback(tmp_path: Path) -> None:
     assert runtime.classify_exit(log, exit_code=0, uptime_seconds=5.0) == "no_result"
 
 
+def test_codex_extracts_current_thread_started_id(tmp_path: Path) -> None:
+    log = tmp_path / "agent.log"
+    log.write_text(
+        '{"type":"thread.started","thread_id":"019fbea9-d7c0-7870-9606-cf1100d303e8"}\n'
+        '{"type":"turn.started"}\n'
+    )
+
+    assert CodexRuntime().extract_session_id(log) == "019fbea9-d7c0-7870-9606-cf1100d303e8"
+
+
+def test_codex_extracts_legacy_session_id(tmp_path: Path) -> None:
+    log = tmp_path / "agent.log"
+    log.write_text('{"type":"result","session_id":"legacy-session"}\n')
+
+    assert CodexRuntime().extract_session_id(log) == "legacy-session"
+
+
+def test_codex_ignores_unrelated_thread_id(tmp_path: Path) -> None:
+    log = tmp_path / "agent.log"
+    log.write_text('{"type":"item.completed","thread_id":"not-a-session"}\n')
+
+    assert CodexRuntime().extract_session_id(log) is None
+
+
 def test_kiro_classify_exit_uses_uptime_fallback(tmp_path: Path) -> None:
     log = tmp_path / "agent.log"
     log.write_text("plain text output\n")


### PR DESCRIPTION
## Motivation

Current Codex CLI versions identify resumable sessions with a `thread.started` event and `thread_id`. CORAL only recognized the legacy `session_id` field, so a heartbeat interrupt could fail to recover the active Codex thread and silently start a fresh conversation.

## Changes

- Recognize `thread_id` specifically on `thread.started` events.
- Preserve compatibility with legacy `session_id` log entries.
- Ignore unrelated `thread_id` fields from other event types.
- Add regression coverage for current, legacy, and unrelated event formats.

## Test plan

- `pytest tests/test_manager_reliability.py -q` — 36 passed.
- `ruff check coral/agent/builtin/codex.py tests/test_manager_reliability.py` — passed.
- `ruff format --check coral/agent/builtin/codex.py tests/test_manager_reliability.py` — passed.

## Affected areas

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

*Authored with assistance from Codex. This draft is awaiting the submitting human's line-by-line review before it is marked ready.*
