### PR TITLE
perf(workspace): cache successful setup

### DIFF
--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -15,6 +16,34 @@ from coral.workspace.repo import (
 )
 
 logger = logging.getLogger(__name__)
+
+_SETUP_INPUT_FILES = (
+    "pyproject.toml",
+    "uv.lock",
+    "requirements.txt",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "bun.lock",
+    "Cargo.toml",
+    "Cargo.lock",
+    "go.mod",
+    "go.sum",
+)
+
+
+def _setup_inputs_fingerprint(worktree_path: Path) -> str:
+    """Hash common dependency manifests that workspace setup consumes."""
+    digest = hashlib.sha256()
+    for name in _SETUP_INPUT_FILES:
+        path = worktree_path / name
+        if path.is_file():
+            digest.update(name.encode())
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+    return digest.hexdigest()
 
 
 def create_agent_worktree(repo_path: Path, agent_id: str, agents_dir: Path) -> Path:
@@ -123,6 +152,7 @@ def setup_git_exclude(worktree_path: Path) -> None:
         ".coral_agent_id",
         ".coral_dir",
         ".coral_island",
+        ".coral_setup_state.json",
         "CLAUDE.md",
         "AGENTS.md",
         ".claude/",
@@ -721,21 +751,46 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
     Each worktree gets its own isolated ``.venv`` via UV_PROJECT_ENVIRONMENT
     to prevent concurrent agents from corrupting a shared venv.
 
-    Idempotent: if the worktree's ``.venv`` is already populated (the python
-    binary exists), skip both the setup commands and the coral reinstall.
-    Deps don't change mid-run, so re-running ``uv sync`` on every
-    interrupt-and-resume cycle is wasted work. To force a re-sync, delete the
-    ``.venv`` directory before resuming.
+    Idempotent: successful setup is recorded in a CORAL-managed state file and
+    skipped while the configured commands remain unchanged. This also covers
+    non-Python setup such as ``npm ci``, where no ``.venv`` is created. Older
+    worktrees with an existing venv but no state file are adopted without
+    rerunning setup.
     """
     if not setup_commands:
         return
 
-    # Force uv to create/use a venv inside this worktree, even if
-    # pyproject.toml is resolved from a parent directory.
     worktree_venv = worktree_path / ".venv"
     venv_python = worktree_venv / "bin" / "python"
-    if venv_python.exists():
+    setup_state_path = worktree_path / ".coral_setup_state.json"
+    inputs_fingerprint = _setup_inputs_fingerprint(worktree_path)
+    if setup_state_path.exists():
+        try:
+            state = json.loads(setup_state_path.read_text())
+            state_matches = (
+                state.get("version") == 1
+                and state.get("commands") == setup_commands
+                and state.get("inputs") == inputs_fingerprint
+            )
+            required_venv_exists = not state.get("created_venv", False) or venv_python.exists()
+            if state_matches and required_venv_exists:
+                logger.debug(f"Worktree setup already complete at {worktree_path}")
+                return
+        except (json.JSONDecodeError, OSError):
+            # A corrupt or unreadable marker must never suppress setup.
+            pass
+
+    # Force uv to create/use a venv inside this worktree, even if
+    # pyproject.toml is resolved from a parent directory.
+    if venv_python.exists() and not setup_state_path.exists():
         logger.debug(f"Worktree venv already populated at {worktree_venv}, skipping setup commands")
+        state = {
+            "version": 1,
+            "commands": setup_commands,
+            "inputs": inputs_fingerprint,
+            "created_venv": True,
+        }
+        setup_state_path.write_text(json.dumps(state, indent=2) + "\n")
         return
 
     env_override = {"UV_PROJECT_ENVIRONMENT": str(worktree_venv)}
@@ -759,3 +814,11 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
             )
             if result.returncode != 0:
                 logger.warning(f"Failed to install coral in worktree: {result.stderr.strip()}")
+
+    state = {
+        "version": 1,
+        "commands": setup_commands,
+        "inputs": _setup_inputs_fingerprint(worktree_path),
+        "created_venv": venv_python.exists(),
+    }
+    setup_state_path.write_text(json.dumps(state, indent=2) + "\n")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,5 +1,6 @@
 """Tests for workspace setup."""
 
+import json
 import os
 import subprocess
 import tempfile
@@ -126,6 +127,7 @@ def test_setup_git_exclude():
         assert "CLAUDE.md" in content
         assert ".claude/" in content
         assert ".coral_island" in content
+        assert ".coral_setup_state.json" in content
         # The tracked .gitignore is never touched
         assert not (worktree / ".gitignore").exists()
 
@@ -337,6 +339,69 @@ def test_setup_worktree_env_runs_when_venv_missing():
         setup_worktree_env(worktree, [f"touch {marker}"])
 
         assert marker.exists(), "Setup should have run on first launch"
+
+
+def test_setup_worktree_env_skips_repeated_non_python_setup():
+    """A successful setup is cached even when it does not create a venv."""
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        worktree = Path(d) / "worktree"
+        worktree.mkdir()
+        marker = worktree / "setup_runs.txt"
+        commands = [f"echo run >> {marker}"]
+
+        setup_worktree_env(worktree, commands)
+        setup_worktree_env(worktree, commands)
+
+        assert marker.read_text().splitlines() == ["run"]
+        state = json.loads((worktree / ".coral_setup_state.json").read_text())
+        assert state["version"] == 1
+        assert state["commands"] == commands
+        assert state["created_venv"] is False
+        assert isinstance(state["inputs"], str)
+
+
+def test_setup_worktree_env_reruns_when_commands_change():
+    """Changing workspace.setup invalidates the cached setup state."""
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        worktree = Path(d) / "worktree"
+        worktree.mkdir()
+        marker = worktree / "setup_runs.txt"
+
+        setup_worktree_env(worktree, [f"echo first >> {marker}"])
+        setup_worktree_env(worktree, [f"echo second >> {marker}"])
+
+        assert marker.read_text().splitlines() == ["first", "second"]
+
+
+def test_setup_worktree_env_reruns_when_dependency_manifest_changes():
+    """A checkout that changes a lockfile invalidates cached setup."""
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        worktree = Path(d) / "worktree"
+        worktree.mkdir()
+        marker = worktree / "setup_runs.txt"
+        commands = [f"echo run >> {marker}"]
+        (worktree / "package-lock.json").write_text('{"version": 1}')
+
+        setup_worktree_env(worktree, commands)
+        (worktree / "package-lock.json").write_text('{"version": 2}')
+        setup_worktree_env(worktree, commands)
+
+        assert marker.read_text().splitlines() == ["run", "run"]
+
+
+def test_setup_worktree_env_reruns_when_recorded_venv_was_removed():
+    """Deleting a venv still forces setup for commands that originally created it."""
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        worktree = Path(d) / "worktree"
+        worktree.mkdir()
+        marker = worktree / "setup_ran.marker"
+        commands = [f"touch {marker}"]
+        state = {"version": 1, "commands": commands, "created_venv": True}
+        (worktree / ".coral_setup_state.json").write_text(json.dumps(state))
+
+        setup_worktree_env(worktree, commands)
+
+        assert marker.exists(), "Setup should rerun after its recorded venv is removed"
 
 
 # --- apply_runtime_mounts tests ---


### PR DESCRIPTION
## Motivation

CORAL reruns `workspace.setup` on agent restarts unless a Python virtualenv happens to exist. This wastes time for non-Python setup such as `npm ci`, while a venv-only shortcut can also reuse stale dependencies after setup commands or dependency manifests change.

## Changes

- Persist successful setup state in an ignored `.coral_setup_state.json` marker.
- Cache both Python and non-Python setup commands.
- Invalidate the cache when setup commands or common dependency manifests change.
- Rerun setup when a previously recorded worktree venv has been removed.
- Adopt existing pre-marker worktree venvs without an unnecessary reinstall.

## Test plan

- `pytest tests/test_workspace.py -q` — 50 passed.
- `ruff check coral/workspace/worktree.py tests/test_workspace.py` — passed.
- `ruff format --check coral/workspace/worktree.py tests/test_workspace.py` — passed.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [x] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

*Authored with assistance from Codex. This draft is awaiting the submitting human's line-by-line review before it is marked ready.*
