### PR TITLE
docs: showcase contributor affiliations in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@
 
 ## Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
 
+<p><strong>Built by researchers and engineers from</strong></p>
+
+<p>
+  <img src="https://img.shields.io/badge/MIT-A31F34?style=for-the-badge" alt="MIT">
+  <img src="https://img.shields.io/badge/NUS-E87722?style=for-the-badge" alt="NUS">
+  <img src="https://img.shields.io/badge/Stanford-8C1515?style=for-the-badge" alt="Stanford University">
+  <img src="https://img.shields.io/badge/MiniMax-111111?style=for-the-badge" alt="MiniMax">
+  <img src="https://img.shields.io/badge/Meta_Superintelligence_Labs-0668E1?style=for-the-badge" alt="Meta Superintelligence Labs">
+</p>
+
+**Open source. Independent. [Everyone is welcome to contribute and become a maintainer.](#contributing)**
+
+<sub>Affiliations identify individual contributors and do not imply institutional endorsement.</sub>
+
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,13 +5,19 @@
 
 ## **一键启动智能体群组，共享知识，无限进化**
 
+<p><strong>由来自以下机构的研究者与工程师共同建设</strong></p>
+
 <p>
-  <img src="assets/mit_logo.png" alt="MIT" height="50">
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  <img src="assets/nus.png" alt="NUS" height="50">
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  <img src="assets/stanford.png" alt="Stanford" height="50">
+  <img src="https://img.shields.io/badge/MIT-A31F34?style=for-the-badge" alt="MIT">
+  <img src="https://img.shields.io/badge/NUS-E87722?style=for-the-badge" alt="NUS">
+  <img src="https://img.shields.io/badge/Stanford-8C1515?style=for-the-badge" alt="Stanford University">
+  <img src="https://img.shields.io/badge/MiniMax-111111?style=for-the-badge" alt="MiniMax">
+  <img src="https://img.shields.io/badge/Meta_Superintelligence_Labs-0668E1?style=for-the-badge" alt="Meta Superintelligence Labs">
 </p>
+
+**开源、独立。[欢迎每个人参与贡献并成为维护者。](#参与贡献)**
+
+<sub>机构信息仅用于说明贡献者的个人背景，不代表相关机构的官方背书。</sub>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)


### PR DESCRIPTION
## Motivation

Make the backgrounds of current contributors visible near the README hero while keeping CORAL explicitly open to contributors and future maintainers from every community. Previously, the Chinese README showed only three academic affiliations and the English README showed none.

## Changes

- Add a consistent badge row for MIT, NUS, Stanford, MiniMax, and Meta Superintelligence Labs to both READMEs.
- Pair the affiliation showcase with a prominent invitation for everyone to contribute and become a maintainer.
- Clarify that contributors participate independently and that affiliations do not imply institutional endorsement.
- Replace the Chinese README’s three-logo strip so both languages present the same community message.

Authored with assistance from Codex. Human review of every changed line is still required before merge.

## Test plan

- `git diff --check` (passed)
- Verified all five Shields.io badge URLs return HTTP 200.
- Rendered both READMEs through GitHub’s GFM API and inspected the hero markup and contribution anchors.
- Full Python tests and Ruff checks were not run because this is a README-only change.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: root English and Chinese READMEs

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).