### PR TITLE
docs: showcase contributor affiliations in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
   <a href="https://www.stanford.edu/"><img src="assets/stanford.png" alt="Stanford University" height="58"></a>
 </p>
 
-**Open source. Independent. [Everyone is welcome to contribute and become a maintainer.](#contributing)**
-
 <sub>Affiliations identify individual contributors and do not imply institutional endorsement.</sub>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 <p><strong>Built by researchers and engineers from</strong></p>
 
 <p>
-  <img src="https://img.shields.io/badge/MIT-A31F34?style=for-the-badge" alt="MIT">
-  <img src="https://img.shields.io/badge/NUS-E87722?style=for-the-badge" alt="NUS">
-  <img src="https://img.shields.io/badge/Stanford-8C1515?style=for-the-badge" alt="Stanford University">
-  <img src="https://img.shields.io/badge/MiniMax-111111?style=for-the-badge" alt="MiniMax">
-  <img src="https://img.shields.io/badge/Meta_Superintelligence_Labs-0668E1?style=for-the-badge" alt="Meta Superintelligence Labs">
+  <a href="https://www.mit.edu/"><img src="assets/mit_logo.png" alt="MIT" height="48"></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://www.nus.edu.sg/"><img src="assets/nus.png" alt="National University of Singapore" height="52"></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://www.stanford.edu/"><img src="assets/stanford.png" alt="Stanford University" height="58"></a>
 </p>
 
 **Open source. Independent. [Everyone is welcome to contribute and become a maintainer.](#contributing)**

--- a/README.md
+++ b/README.md
@@ -5,15 +5,7 @@
 
 ## Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
 
-<p><strong>Built by researchers from</strong></p>
-
-<p>
-  <a href="https://www.mit.edu/"><img src="assets/mit_logo.png" alt="MIT" height="48"></a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://www.nus.edu.sg/"><img src="assets/nus.png" alt="National University of Singapore" height="52"></a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://www.stanford.edu/"><img src="assets/stanford.png" alt="Stanford University" height="58"></a>
-</p>
+<p><strong>Built by researchers affiliated with MIT, NUS, Stanford, and McGill.</strong></p>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
 
-<p><strong>Built by researchers and engineers from</strong></p>
+<p><strong>Contributors are affiliated with</strong></p>
 
 <p>
   <a href="https://www.mit.edu/"><img src="assets/mit_logo.png" alt="MIT" height="48"></a>
@@ -14,8 +14,6 @@
   &nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://www.stanford.edu/"><img src="assets/stanford.png" alt="Stanford University" height="58"></a>
 </p>
-
-<sub>Affiliations identify individual contributors and do not imply institutional endorsement.</sub>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
 
-<p><strong>Contributors are affiliated with</strong></p>
+<p><strong>Built by researchers from</strong></p>
 
 <p>
   <a href="https://www.mit.edu/"><img src="assets/mit_logo.png" alt="MIT" height="48"></a>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@
 
 ## Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
 
+<p><strong>Built by researchers and engineers from</strong></p>
+
+<p>
+  <img src="https://img.shields.io/badge/MIT-A31F34?style=for-the-badge" alt="MIT">
+  <img src="https://img.shields.io/badge/NUS-E87722?style=for-the-badge" alt="NUS">
+  <img src="https://img.shields.io/badge/Stanford-8C1515?style=for-the-badge" alt="Stanford University">
+  <img src="https://img.shields.io/badge/MiniMax-111111?style=for-the-badge" alt="MiniMax">
+  <img src="https://img.shields.io/badge/Meta_Superintelligence_Labs-0668E1?style=for-the-badge" alt="Meta Superintelligence Labs">
+</p>
+
+**Open source. Independent. [Everyone is welcome to contribute and become a maintainer.](#contributing)**
+
+<sub>Affiliations identify individual contributors and do not imply institutional endorsement.</sub>
+
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,7 +5,7 @@
 
 ## **一键启动智能体群组，共享知识，无限进化**
 
-<p><strong>由来自以下机构的研究者与工程师共同建设</strong></p>
+<p><strong>贡献者来自</strong></p>
 
 <p>
   <a href="https://www.mit.edu/"><img src="assets/mit_logo.png" alt="MIT" height="48"></a>
@@ -14,8 +14,6 @@
   &nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://www.stanford.edu/"><img src="assets/stanford.png" alt="斯坦福大学" height="58"></a>
 </p>
-
-<sub>机构信息仅用于说明贡献者的个人背景，不代表相关机构的官方背书。</sub>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -8,11 +8,11 @@
 <p><strong>由来自以下机构的研究者与工程师共同建设</strong></p>
 
 <p>
-  <img src="https://img.shields.io/badge/MIT-A31F34?style=for-the-badge" alt="MIT">
-  <img src="https://img.shields.io/badge/NUS-E87722?style=for-the-badge" alt="NUS">
-  <img src="https://img.shields.io/badge/Stanford-8C1515?style=for-the-badge" alt="Stanford University">
-  <img src="https://img.shields.io/badge/MiniMax-111111?style=for-the-badge" alt="MiniMax">
-  <img src="https://img.shields.io/badge/Meta_Superintelligence_Labs-0668E1?style=for-the-badge" alt="Meta Superintelligence Labs">
+  <a href="https://www.mit.edu/"><img src="assets/mit_logo.png" alt="MIT" height="48"></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://www.nus.edu.sg/"><img src="assets/nus.png" alt="新加坡国立大学" height="52"></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://www.stanford.edu/"><img src="assets/stanford.png" alt="斯坦福大学" height="58"></a>
 </p>
 
 **开源、独立。[欢迎每个人参与贡献并成为维护者。](#参与贡献)**

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,7 +5,7 @@
 
 ## **一键启动智能体群组，共享知识，无限进化**
 
-<p><strong>贡献者来自</strong></p>
+<p><strong>由来自以下机构的研究者共同建设</strong></p>
 
 <p>
   <a href="https://www.mit.edu/"><img src="assets/mit_logo.png" alt="MIT" height="48"></a>

--- a/README_CN.md
+++ b/README_CN.md
@@ -15,8 +15,6 @@
   <a href="https://www.stanford.edu/"><img src="assets/stanford.png" alt="斯坦福大学" height="58"></a>
 </p>
 
-**开源、独立。[欢迎每个人参与贡献并成为维护者。](#参与贡献)**
-
 <sub>机构信息仅用于说明贡献者的个人背景，不代表相关机构的官方背书。</sub>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,15 +5,7 @@
 
 ## **一键启动智能体群组，共享知识，无限进化**
 
-<p><strong>由来自以下机构的研究者共同建设</strong></p>
-
-<p>
-  <a href="https://www.mit.edu/"><img src="assets/mit_logo.png" alt="MIT" height="48"></a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://www.nus.edu.sg/"><img src="assets/nus.png" alt="新加坡国立大学" height="52"></a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://www.stanford.edu/"><img src="assets/stanford.png" alt="斯坦福大学" height="58"></a>
-</p>
+<p><strong>由来自 MIT、NUS、Stanford 和 McGill 的研究者共同建设。</strong></p>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,13 +5,19 @@
 
 ## **一键启动智能体群组，共享知识，无限进化**
 
+<p><strong>由来自以下机构的研究者与工程师共同建设</strong></p>
+
 <p>
-  <img src="assets/mit_logo.png" alt="MIT" height="50">
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  <img src="assets/nus.png" alt="NUS" height="50">
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  <img src="assets/stanford.png" alt="Stanford" height="50">
+  <img src="https://img.shields.io/badge/MIT-A31F34?style=for-the-badge" alt="MIT">
+  <img src="https://img.shields.io/badge/NUS-E87722?style=for-the-badge" alt="NUS">
+  <img src="https://img.shields.io/badge/Stanford-8C1515?style=for-the-badge" alt="Stanford University">
+  <img src="https://img.shields.io/badge/MiniMax-111111?style=for-the-badge" alt="MiniMax">
+  <img src="https://img.shields.io/badge/Meta_Superintelligence_Labs-0668E1?style=for-the-badge" alt="Meta Superintelligence Labs">
 </p>
+
+**开源、独立。[欢迎每个人参与贡献并成为维护者。](#参与贡献)**
+
+<sub>机构信息仅用于说明贡献者的个人背景，不代表相关机构的官方背书。</sub>
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)


### PR DESCRIPTION
## Motivation

Make the academic backgrounds of current contributors visible near the README hero and keep the English and Chinese presentations aligned. Previously, the Chinese README showed these affiliations but the English README did not.

## Changes

- Add a plain-text affiliation line for researchers from MIT, NUS, Stanford, and McGill to both READMEs.

Authored with assistance from Codex. Human review of every changed line is still required before merge.

## Test plan

- `git diff --check` (passed)
- Rendered both READMEs through GitHub’s GFM API and inspected the affiliation text.
- Confirmed that the affiliation block contains no institutional logo assets or outbound links.
- Full Python tests and Ruff checks were not run locally because this is a README-only change; CI passed lint and tests on Python 3.11–3.13 for earlier revisions and is rerunning for the updated commit.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: root English and Chinese READMEs

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass locally.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).


