### PR TITLE
feat(grader): persist score breakdowns in attempts

### DIFF
--- a/coral/grader/daemon.py
+++ b/coral/grader/daemon.py
@@ -452,6 +452,11 @@ def _grade_one(
             score = bundle.aggregated
             feedback = _build_feedback(bundle)
             metadata = dict(getattr(bundle, "metadata", None) or {})
+            # Score breakdowns are daemon-owned evaluation output. Preserve them
+            # separately from arbitrary grader metadata so downstream consumers
+            # can inspect the aggregate's component scores without changing
+            # selection behavior.
+            metadata["scores"] = {name: score.to_dict() for name, score in bundle.scores.items()}
             grader_completed = True
         finally:
             _remove_worktree(repo_dir, checkout_path)

--- a/coral/types.py
+++ b/coral/types.py
@@ -151,7 +151,12 @@ def get_budget_class(metadata: dict[str, Any] | None) -> str:
 
 @dataclass
 class Attempt:
-    """Record of a single optimization attempt by an agent."""
+    """Record of a single optimization attempt by an agent.
+
+    Successful grader finalization stores the serialized ``ScoreBundle.scores``
+    mapping in ``metadata["scores"]``. This daemon-owned breakdown supplements
+    the aggregate ``score``; it does not affect selection behavior.
+    """
 
     commit_hash: str
     agent_id: str

--- a/tests/test_grader_daemon.py
+++ b/tests/test_grader_daemon.py
@@ -173,6 +173,9 @@ def test_process_pending_once_grades_pending():
             assert finalized[0].score == 0.42
             assert finalized[0].status == "improved"
             assert finalized[0].commit_hash == pending.commit_hash
+            assert finalized[0].metadata["scores"] == {
+                "eval": {"value": 0.42, "name": "eval", "explanation": None, "metadata": {}}
+            }
 
             # No more pending after the drain.
             assert _find_pending(repo / ".coral") == []
@@ -220,6 +223,51 @@ def test_process_pending_once_preserves_submission_fields():
             assert final.agent_id == "agent-1"
             assert final.timestamp == original_ts  # daemon doesn't restamp
             assert final.parent_hash == pending.parent_hash
+        finally:
+            sys.path.pop(0)
+
+
+def test_grader_persists_score_breakdown_in_attempt_metadata():
+    """Finalized attempts retain daemon-owned serialized ScoreBundle scores."""
+    with tempfile.TemporaryDirectory() as d:
+        repo = _init_repo_and_coral(Path(d))
+        _write_grader(
+            repo,
+            "from coral.grader.task_grader import TaskGrader\n"
+            "from coral.types import Score, ScoreBundle\n"
+            "class Grader(TaskGrader):\n"
+            "    def evaluate(self):\n"
+            "        return ScoreBundle(\n"
+            "            scores={\n"
+            "                'quality': Score(value=0.9, name='quality', explanation='good', metadata={'source': 'test'}),\n"
+            "                'cost': Score(value=0.2, name='cost'),\n"
+            "            },\n"
+            "            aggregated=0.8,\n"
+            "            metadata={'grader_key': 'grader_value', 'scores': {'incorrect': 'value'}},\n"
+            "        )\n",
+        )
+        sys.path.insert(0, str(repo))
+        try:
+            (repo / "main.py").write_text("print('v2')\n")
+            pending = submit_eval(
+                message="Persist breakdown", agent_id="agent-1", workdir=str(repo), wait=False
+            )
+
+            process_pending_once(repo / ".coral")
+
+            finalized = read_attempt(repo / ".coral", pending.commit_hash)
+            assert finalized is not None
+            assert finalized.score == 0.8
+            assert finalized.metadata["grader_key"] == "grader_value"
+            assert finalized.metadata["scores"] == {
+                "quality": {
+                    "value": 0.9,
+                    "name": "quality",
+                    "explanation": "good",
+                    "metadata": {"source": "test"},
+                },
+                "cost": {"value": 0.2, "name": "cost", "explanation": None, "metadata": {}},
+            }
         finally:
             sys.path.pop(0)
 
@@ -476,6 +524,7 @@ def test_grader_marks_grader_error_on_exception():
             assert final.budget_class == "grader_error", (
                 "Grader exceptions should be classified as grader_error, not real attempts."
             )
+            assert "scores" not in final.metadata
         finally:
             sys.path.pop(0)
 
@@ -873,6 +922,7 @@ def test_grade_one_finalizes_migrated_pending_attempt_in_current_island(tmp_path
     assert current.score == 0.9
     assert current.metadata["island_id"] == "1"
     assert current.metadata["grader_key"] == "grader_value"
+    assert current.metadata["scores"] == {}
     assert read_eval_count(coral_dir, island_id="0") == 0
     assert read_eval_count(coral_dir, island_id="1") == 1
     assert read_eval_count(coral_dir) == 1


### PR DESCRIPTION
## Motivation
The grader daemon currently persists the aggregate attempt score but drops the per-dimension score breakdown from `ScoreBundle.scores`. This makes downstream analysis and debugging less informative.

Closes #199

## Changes
- Persist serialized per-dimension `ScoreBundle.scores` in successful attempt metadata under `metadata["scores"]`.
- Preserve existing grader metadata while making the daemon-owned score breakdown authoritative if a grader metadata payload uses the same key.
- Document the resulting `Attempt.metadata` contract and cover scalar, multi-dimension, error, and migration paths.

## Test plan
- `uv run --extra dev pytest tests/test_grader_daemon.py -q` — 31 passed
- `uv run --extra dev ruff check coral/types.py coral/grader/daemon.py tests/test_grader_daemon.py`
- `uv run --extra dev ruff format --check coral/types.py coral/grader/daemon.py tests/test_grader_daemon.py`
- `git diff --check`

## Affected areas
- [x] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: `Attempt` metadata contract and tests

## Checklist
- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [ ] `uv run pytest tests/ -v` passes locally. (Focused daemon suite run; full suite not run.)
- [x] `ruff check` and `ruff format --check` pass for changed files.
- [x] Added or updated tests under `tests/` for the behavior change.
- [x] Updated the relevant data-contract documentation.
- [x] **AI-assisted PR**: Authored with assistance from Codex. I read every changed line, ran the tests above locally, and verified the behavior described in the test plan.