### PR TITLE
fix(grader): respect private score visibility

### DIFF
--- a/coral/grader/daemon.py
+++ b/coral/grader/daemon.py
@@ -437,6 +437,7 @@ def _grade_one(
     status = "crashed"
     feedback = ""
     metadata: dict = {}
+    public_scores: dict[str, dict[str, Any]] | None = None
     grader_completed = False
 
     try:
@@ -452,11 +453,8 @@ def _grade_one(
             score = bundle.aggregated
             feedback = _build_feedback(bundle)
             metadata = dict(getattr(bundle, "metadata", None) or {})
-            # Score breakdowns are daemon-owned evaluation output. Preserve them
-            # separately from arbitrary grader metadata so downstream consumers
-            # can inspect the aggregate's component scores without changing
-            # selection behavior.
-            metadata["scores"] = {name: score.to_dict() for name, score in bundle.scores.items()}
+            if getattr(bundle, "is_public", True):
+                public_scores = {name: score.to_dict() for name, score in bundle.scores.items()}
             grader_completed = True
         finally:
             _remove_worktree(repo_dir, checkout_path)
@@ -504,6 +502,13 @@ def _grade_one(
     # then stamp the final budget_class (always wins over any pending value).
     for k, v in (base_attempt.metadata or {}).items():
         metadata.setdefault(k, v)
+    if grader_completed:
+        # Score breakdowns are daemon-owned. Apply their visibility after the
+        # merge so neither grader nor pending metadata can publish private data.
+        if public_scores is None:
+            metadata.pop("scores", None)
+        else:
+            metadata["scores"] = public_scores
     if final_island_id is not None:
         metadata["island_id"] = final_island_id
     metadata["budget_class"] = budget_class

--- a/coral/types.py
+++ b/coral/types.py
@@ -153,9 +153,10 @@ def get_budget_class(metadata: dict[str, Any] | None) -> str:
 class Attempt:
     """Record of a single optimization attempt by an agent.
 
-    Successful grader finalization stores the serialized ``ScoreBundle.scores``
-    mapping in ``metadata["scores"]``. This daemon-owned breakdown supplements
-    the aggregate ``score``; it does not affect selection behavior.
+    Successful public grader finalization stores the serialized
+    ``ScoreBundle.scores`` mapping in ``metadata["scores"]``. This daemon-owned
+    breakdown is omitted when ``ScoreBundle.is_public`` is false. It supplements
+    the aggregate ``score`` and does not affect selection behavior.
     """
 
     commit_hash: str

--- a/docs/content/docs/api/types.mdx
+++ b/docs/content/docs/api/types.mdx
@@ -100,7 +100,7 @@ bundle = ScoreBundle(
 |-------|------|-------------|
 | `scores` | `dict[str, Score]` | Named scores |
 | `aggregated` | `float \| None` | Overall score |
-| `is_public` | `bool` | Whether scores are visible to agents (default: True) |
+| `is_public` | `bool` | Whether the per-score breakdown is stored in agent-visible attempt metadata (default: True). The aggregate score and feedback remain visible. |
 
 ### Methods
 
@@ -150,6 +150,7 @@ attempt = Attempt(
 | Key | Type | Description |
 |-----|------|-------------|
 | `budget_class` | `str` | `"real"`, `"tune"`, or `"grader_error"`; controls leaderboard and heartbeat accounting |
+| `scores` | `dict[str, dict]` | Serialized `ScoreBundle.scores` for a successful public bundle; omitted when `is_public` is false |
 | `user_best` | `bool` | Set to `true` when the operator marks this attempt as best in the dashboard |
 
 ### Methods

--- a/plugin/skills/creating-a-coral-task/references/grader-api.md
+++ b/plugin/skills/creating-a-coral-task/references/grader-api.md
@@ -59,12 +59,16 @@ class Score:
 class ScoreBundle:
     scores: dict[str, Score]        # name -> Score
     aggregated: float | None = None # the single number used for ranking + plateau detection
-    is_public: bool = True          # False hides the score from the agent
+    is_public: bool = True          # False omits the per-score breakdown from public attempts
     feedback: str | None = None     # message the agent reads
     metadata: dict = field(default_factory=dict)
 ```
 
 `aggregated` is what the leaderboard sorts on and what plateau/heartbeat logic watches. With `self.score(x)` it's just `x`. For multiple metrics you set it explicitly — see the multi-metric pattern in [cookbook.md](cookbook.md).
+
+When `is_public` is true, the daemon serializes `scores` into the finalized
+attempt's public metadata. Setting it to false omits that breakdown; the
+aggregate score and grader feedback remain visible to the agent.
 
 ## Mental model
 

--- a/tests/test_grader_daemon.py
+++ b/tests/test_grader_daemon.py
@@ -272,6 +272,48 @@ def test_grader_persists_score_breakdown_in_attempt_metadata():
             sys.path.pop(0)
 
 
+def test_private_grader_omits_score_breakdown_from_attempt_metadata():
+    """Private bundles suppress daemon-, grader-, and pending-provided scores."""
+    with tempfile.TemporaryDirectory() as d:
+        repo = _init_repo_and_coral(Path(d))
+        _write_grader(
+            repo,
+            "from coral.grader.task_grader import TaskGrader\n"
+            "from coral.types import Score, ScoreBundle\n"
+            "class Grader(TaskGrader):\n"
+            "    def evaluate(self):\n"
+            "        return ScoreBundle(\n"
+            "            scores={\n"
+            "                'hidden': Score(value=0.4, name='hidden', explanation='secret', metadata={'case': 'private'}),\n"
+            "            },\n"
+            "            aggregated=0.4,\n"
+            "            is_public=False,\n"
+            "            metadata={'grader_key': 'grader_value', 'scores': {'grader': 'leak'}},\n"
+            "        )\n",
+        )
+        sys.path.insert(0, str(repo))
+        try:
+            (repo / "main.py").write_text("print('v2')\n")
+            pending = submit_eval(
+                message="Keep breakdown private",
+                agent_id="agent-1",
+                workdir=str(repo),
+                wait=False,
+            )
+            pending.metadata["scores"] = {"pending": "leak"}
+            write_attempt(repo / ".coral", pending)
+
+            process_pending_once(repo / ".coral")
+
+            finalized = read_attempt(repo / ".coral", pending.commit_hash)
+            assert finalized is not None
+            assert finalized.score == 0.4
+            assert finalized.metadata["grader_key"] == "grader_value"
+            assert "scores" not in finalized.metadata
+        finally:
+            sys.path.pop(0)
+
+
 def test_process_pending_multiple_in_submission_order():
     """Pending attempts are graded in submission (timestamp) order."""
     with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
## Motivation

PR #201 made per-dimension score breakdowns available in finalized attempt metadata, but persisted them even when `ScoreBundle.is_public` was false. Since attempts are agent-visible, private metric values and score metadata could leak through the new field.

Closes #202.

## Changes

- Apply the daemon-owned `metadata["scores"]` value only after grader and pending metadata are merged.
- Persist the serialized breakdown for public bundles, while removing the reserved key for private bundles so metadata collisions cannot bypass visibility.
- Preserve the existing aggregate score, feedback, selection, grader-error, and migration behavior.
- Document that `is_public` controls the per-score attempt-metadata breakdown; aggregate score and feedback remain visible.

Migration is automatic: existing public bundles retain the #201 behavior, old attempts remain readable, and private bundles stop emitting `metadata["scores"]` on their next finalized attempt.

## Test plan

- `uv run --no-sync pytest tests/test_grader_daemon.py -q` — 32 passed.
- `uv run --no-sync pytest tests/ -q` — 642 passed, 1 skipped, 2 failed. Both failures are pre-existing `tests/test_start_session_mode.py` tmux tests and reproduce unchanged on `origin/dev` with `FileNotFoundError` for `.coral/public/.coral_tmux_session`.
- `uv run --no-sync ruff check .` — passed.
- `uv run --no-sync ruff format --check .` — 127 files already formatted.
- `git diff --check origin/dev...HEAD` — passed.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [x] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: `Attempt.metadata` visibility contract and task-authoring skill reference

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally. (Two unrelated failures reproduce on `origin/dev`; see test plan.)
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [x] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

*Authored with assistance from Codex. This draft intentionally leaves the human-review checklist item unchecked until the maintainer has read every changed line.*
