### PR TITLE
ci: require dev as source for main PRs

### DIFF
--- a/.github/workflows/main-pr-source.yml
+++ b/.github/workflows/main-pr-source.yml
@@ -1,0 +1,28 @@
+name: Main PR source guard
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  require-dev-source:
+    name: Require dev source for main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify pull request source
+        env:
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$HEAD_REPOSITORY" != "$BASE_REPOSITORY" || "$HEAD_BRANCH" != "dev" ]]; then
+            echo "::error::Pull requests to main must come from this repository's dev branch."
+            echo "Received source: $HEAD_REPOSITORY:$HEAD_BRANCH"
+            exit 1
+          fi
+
+          echo "Accepted source: $HEAD_REPOSITORY:$HEAD_BRANCH"


### PR DESCRIPTION
## Motivation

The repository should accept pull requests to `main` only from its own `dev` branch. GitHub rulesets cannot directly constrain a pull request head branch, so this bootstrap PR adds a metadata-only required check that enforces the policy.

This PR is the one-time bootstrap exception: the guard must exist on the base branch before it can evaluate subsequent pull requests. After this merges, the `Require dev source for main` check will be added to the active `main` ruleset.

## Changes

- Add a `pull_request_target` workflow for PRs targeting `main`.
- Require both `head.repo.full_name` to match the base repository and `head.ref` to equal `dev`.
- Grant only read-only contents permission and never checkout or execute code from the PR branch.

## Test plan

- Parsed `.github/workflows/main-pr-source.yml` with Ruby YAML.
- Simulated the shell predicate: `Human-Agent-Society/CORAL:dev` passes.
- Simulated a same-repository feature branch: it fails.
- After merge, verify the check on a temporary non-`dev` PR before making it required in the `main` ruleset.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [x] CI / tooling / packaging
- [x] Other: repository branch policy

## Checklist

- [ ] PR targets the `dev` branch (not `main`). This is the one-time bootstrap required to install a `main` base-branch guard.
- [x] Title follows Conventional Commits.
- [ ] `uv run pytest tests/ -v` passes locally. No Python/runtime code changed; GitHub CI runs the suite.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass. No Python files changed.
- [ ] Added or updated tests under `tests/` for any behavior change. The workflow predicate is validated as described above.
- [ ] Updated docs for any user-visible or contract change. Not applicable to runtime behavior.
- [x] If this changes a config field, CLI flag, hook, or runtime contract — no migration is required.
- [ ] New example task: not applicable.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See `AGENTS.md`.

Authored with assistance from Codex. The human author must review the workflow before marking the final checklist item.