### PR TITLE
feat(docs): add SEO discovery metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 <img src="assets/logo.png" alt="CORAL logo — multi-agent autonomous coding infrastructure" width="360">
 
-## Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.
+# CORAL: Open-Source Autoresearch for Autonomous Coding Agents
+
+**Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.**
 
 [![Paper](https://img.shields.io/badge/Paper-arXiv%3A2604.01658-B31B1B.svg?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.01658v1)
 [![Blog](https://img.shields.io/badge/Blog-CORAL-FF6B6B.svg?logo=hashnode&logoColor=white)](https://coral.compounding-intelligence.ai/blogs/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <img src="assets/logo.png" alt="CORAL logo — multi-agent autonomous coding infrastructure" width="360">
 
-# CORAL: Open-Source Autoresearch for Autonomous Coding Agents
+# CORAL: Open-Source Autoresearch Powered by Autonomous Coding Agents
 
 **Robust, lightweight infrastructure for multi-agent self-evolution, built for autoresearch.**
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -3,7 +3,9 @@
 
 <img src="assets/logo.png" alt="CORAL logo —— 多 Agent 自主编程基础设施" width="360">
 
-## **一键启动智能体群组，共享知识，无限进化**
+# CORAL：面向自主编程 Agent 的开源 Autoresearch 框架
+
+**一键启动智能体群组，共享知识，无限进化**
 
 <p>
   <img src="assets/mit_logo.png" alt="MIT" height="50">

--- a/README_CN.md
+++ b/README_CN.md
@@ -3,7 +3,7 @@
 
 <img src="assets/logo.png" alt="CORAL logo —— 多 Agent 自主编程基础设施" width="360">
 
-# CORAL：面向自主编程 Agent 的开源 Autoresearch 框架
+# CORAL：由自主编程 Agent 驱动的开源 Autoresearch 框架
 
 **一键启动智能体群组，共享知识，无限进化**
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,6 +4,40 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Evolve Like Coral: Towards Autonomous Multi-Agent Evolution</title>
+<meta name="description" content="How CORAL enables autonomous coding agents to run experiments, share knowledge, and improve solutions through multi-agent evolution.">
+<link rel="canonical" href="https://coral.compounding-intelligence.ai/blogs/evolve-like-coral/">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="CORAL">
+<meta property="og:title" content="Evolve Like Coral: Towards Autonomous Multi-Agent Evolution">
+<meta property="og:description" content="How CORAL enables autonomous coding agents to run experiments, share knowledge, and improve solutions through multi-agent evolution.">
+<meta property="og:url" content="https://coral.compounding-intelligence.ai/blogs/evolve-like-coral/">
+<meta property="og:image" content="https://coral.compounding-intelligence.ai/opengraph-image/">
+<meta property="article:published_time" content="2026-03-18">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Evolve Like Coral: Towards Autonomous Multi-Agent Evolution">
+<meta name="twitter:description" content="How CORAL enables autonomous coding agents to run experiments, share knowledge, and improve solutions through multi-agent evolution.">
+<meta name="twitter:image" content="https://coral.compounding-intelligence.ai/opengraph-image/">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Evolve Like Coral: Towards Autonomous Multi-Agent Evolution",
+  "description": "How CORAL enables autonomous coding agents to run experiments, share knowledge, and improve solutions through multi-agent evolution.",
+  "datePublished": "2026-03-18",
+  "dateModified": "2026-03-18",
+  "mainEntityOfPage": "https://coral.compounding-intelligence.ai/blogs/evolve-like-coral/",
+  "author": {
+    "@type": "Organization",
+    "name": "Human-Agent-Society",
+    "url": "https://github.com/Human-Agent-Society"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Human-Agent-Society",
+    "url": "https://github.com/Human-Agent-Society"
+  }
+}
+</script>
 <script>
 (function(){
   var saved=localStorage.getItem('theme');

--- a/docs/app/(site)/blogs/page.tsx
+++ b/docs/app/(site)/blogs/page.tsx
@@ -1,5 +1,15 @@
 import Link from 'next/link';
 import { blogPosts } from '@/lib/blogs';
+import { createPageMetadata } from '@/lib/metadata';
+
+const description =
+  'Research notes, results, and stories from building autonomous multi-agent systems with CORAL.';
+
+export const metadata = createPageMetadata({
+  title: 'Research and Autoresearch Blog',
+  description,
+  path: '/blogs/',
+});
 
 const dateFormatter = new Intl.DateTimeFormat('en', {
   dateStyle: 'long',
@@ -14,7 +24,7 @@ export default function BlogsPage() {
       </p>
       <h1 className="mt-3 text-4xl font-semibold text-fd-foreground md:text-6xl">Blogs</h1>
       <p className="mt-5 max-w-2xl text-lg leading-8 text-fd-muted-foreground">
-        Research notes, results, and stories from building autonomous multi-agent systems with CORAL.
+        {description}
       </p>
 
       <div className="mt-12 grid gap-5">

--- a/docs/app/(site)/page.tsx
+++ b/docs/app/(site)/page.tsx
@@ -1,5 +1,28 @@
 import Link from 'next/link';
 import { blogPosts } from '@/lib/blogs';
+import { DEFAULT_DESCRIPTION, SITE_ORIGIN } from '@/lib/metadata';
+
+const softwareApplicationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'CORAL',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Linux, macOS',
+  description: DEFAULT_DESCRIPTION,
+  url: SITE_ORIGIN,
+  codeRepository: 'https://github.com/Human-Agent-Society/CORAL',
+  license: 'https://www.apache.org/licenses/LICENSE-2.0',
+  softwareRequirements: 'Python 3.11 or later and Git',
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
+  sameAs: [
+    'https://github.com/Human-Agent-Society/CORAL',
+    'https://arxiv.org/abs/2604.01658',
+  ],
+};
 
 const capabilities = [
   {
@@ -27,6 +50,10 @@ export default function HomePage() {
 
   return (
     <div className="flex flex-1 flex-col">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationJsonLd) }}
+      />
       <section className="mx-auto grid w-full max-w-6xl gap-10 px-6 py-20 md:grid-cols-[1.35fr_0.65fr] md:py-28">
         <div className="flex flex-col items-start">
           <p className="mb-5 rounded-full border border-fd-border bg-fd-card px-3 py-1 text-sm font-medium text-fd-muted-foreground">

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -10,6 +10,7 @@ import { getMDXComponents } from '@/components/mdx';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { createPageMetadata } from '@/lib/metadata';
 
 interface PageProps {
   params: Promise<{ slug?: string[] }>;
@@ -56,9 +57,11 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
+  const data = page.data as unknown as MDXPageData;
 
-  return {
-    title: page.data.title,
-    description: page.data.description,
-  };
+  return createPageMetadata({
+    title: data.title,
+    description: data.description ?? 'Documentation for the CORAL autoresearch framework.',
+    path: page.url.endsWith('/') ? page.url : `${page.url}/`,
+  });
 }

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,15 +1,40 @@
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import { Analytics } from '@vercel/analytics/next';
+import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import {
+  createPageMetadata,
+  DEFAULT_DESCRIPTION,
+  DEFAULT_TITLE,
+  SITE_ORIGIN,
+} from '@/lib/metadata';
 import './global.css';
 
-export const metadata = {
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_ORIGIN),
+  ...createPageMetadata({
+    title: DEFAULT_TITLE,
+    description: DEFAULT_DESCRIPTION,
+    path: '/',
+  }),
   title: {
-    default: 'CORAL Documentation',
+    default: DEFAULT_TITLE,
     template: '%s | CORAL',
   },
-  description:
-    'An organization for autonomous AI agents — spawn agents, run experiments, share knowledge, and loop forever.',
+  applicationName: 'CORAL',
+  authors: [{ name: 'Human-Agent-Society', url: 'https://github.com/Human-Agent-Society' }],
+  creator: 'Human-Agent-Society',
+  publisher: 'Human-Agent-Society',
+  category: 'technology',
+  keywords: [
+    'autoresearch',
+    'autonomous coding agents',
+    'multi-agent systems',
+    'agent orchestration',
+    'self-evolving agents',
+    'Claude Code',
+    'Codex',
+  ],
 };
 
 export default function Layout({ children }: { children: ReactNode }) {

--- a/docs/app/opengraph-image.tsx
+++ b/docs/app/opengraph-image.tsx
@@ -1,0 +1,62 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'CORAL — open-source autoresearch for autonomous coding agents';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          alignItems: 'center',
+          background: '#111821',
+          color: '#edf2f7',
+          display: 'flex',
+          height: '100%',
+          justifyContent: 'center',
+          padding: '72px 88px',
+          width: '100%',
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', maxWidth: 1024 }}>
+          <div
+            style={{
+              color: '#9eacba',
+              display: 'flex',
+              fontSize: 28,
+              fontWeight: 600,
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+            }}
+          >
+            CORAL · Open-source autoresearch
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 68,
+              fontWeight: 700,
+              letterSpacing: '-0.035em',
+              lineHeight: 1.08,
+              marginTop: 28,
+            }}
+          >
+            Autonomous coding agents that experiment, learn, and evolve together.
+          </div>
+          <div
+            style={{
+              color: '#a9c7e8',
+              display: 'flex',
+              fontSize: 26,
+              marginTop: 36,
+            }}
+          >
+            Isolated worktrees · Continuous grading · Shared memory
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/docs/app/opengraph-image.tsx
+++ b/docs/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 
-export const alt = 'CORAL — open-source autoresearch for autonomous coding agents';
+export const alt = 'CORAL: open-source autoresearch powered by autonomous coding agents';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -42,7 +42,7 @@ export default function OpenGraphImage() {
               marginTop: 28,
             }}
           >
-            Autonomous coding agents that experiment, learn, and evolve together.
+            Open-source autoresearch powered by autonomous coding agents.
           </div>
           <div
             style={{

--- a/docs/app/robots.ts
+++ b/docs/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+import { absoluteUrl, SITE_ORIGIN } from '@/lib/metadata';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: absoluteUrl('/sitemap.xml'),
+    host: SITE_ORIGIN,
+  };
+}

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from 'next';
+import { source } from '@/lib/source';
+import { absoluteUrl } from '@/lib/metadata';
+
+function withTrailingSlash(path: string): string {
+  return path.endsWith('/') ? path : `${path}/`;
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const routes = new Set([
+    '/',
+    '/blogs/',
+    '/blogs/evolve-like-coral/',
+    ...source.getPages().map((page) => withTrailingSlash(page.url)),
+  ]);
+
+  return [...routes].map((path) => ({
+    url: absoluteUrl(path),
+    changeFrequency: path === '/' ? 'weekly' : 'monthly',
+    priority: path === '/' ? 1 : path === '/docs/' ? 0.9 : 0.7,
+  }));
+}

--- a/docs/lib/metadata.ts
+++ b/docs/lib/metadata.ts
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+
+export const SITE_ORIGIN = 'https://coral.compounding-intelligence.ai';
+export const SITE_NAME = 'CORAL';
+export const DEFAULT_TITLE = 'CORAL — Open-Source Autoresearch for Autonomous Coding Agents';
+export const DEFAULT_DESCRIPTION =
+  'Run Claude Code, Codex, Cursor, Kiro, and OpenCode as a self-improving multi-agent team with isolated worktrees, continuous grading, and shared memory.';
+const SOCIAL_IMAGE_PATH = '/opengraph-image/';
+const SOCIAL_IMAGE_ALT = 'CORAL — open-source autoresearch for autonomous coding agents';
+
+export function absoluteUrl(path: string): string {
+  return new URL(path, SITE_ORIGIN).toString();
+}
+
+export function createPageMetadata({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: string;
+}): Metadata {
+  const canonical = absoluteUrl(path);
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: 'website',
+      locale: 'en_US',
+      url: canonical,
+      siteName: SITE_NAME,
+      title,
+      description,
+      images: [
+        {
+          url: absoluteUrl(SOCIAL_IMAGE_PATH),
+          width: 1200,
+          height: 630,
+          alt: SOCIAL_IMAGE_ALT,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [{ url: absoluteUrl(SOCIAL_IMAGE_PATH), alt: SOCIAL_IMAGE_ALT }],
+    },
+  };
+}

--- a/docs/lib/metadata.ts
+++ b/docs/lib/metadata.ts
@@ -2,11 +2,11 @@ import type { Metadata } from 'next';
 
 export const SITE_ORIGIN = 'https://coral.compounding-intelligence.ai';
 export const SITE_NAME = 'CORAL';
-export const DEFAULT_TITLE = 'CORAL — Open-Source Autoresearch for Autonomous Coding Agents';
+export const DEFAULT_TITLE = 'CORAL: Open-Source Autoresearch Powered by Autonomous Coding Agents';
 export const DEFAULT_DESCRIPTION =
   'Run Claude Code, Codex, Cursor, Kiro, and OpenCode as a self-improving multi-agent team with isolated worktrees, continuous grading, and shared memory.';
 const SOCIAL_IMAGE_PATH = '/opengraph-image/';
-const SOCIAL_IMAGE_ALT = 'CORAL — open-source autoresearch for autonomous coding agents';
+const SOCIAL_IMAGE_ALT = 'CORAL: open-source autoresearch powered by autonomous coding agents';
 
 export function absoluteUrl(path: string): string {
   return new URL(path, SITE_ORIGIN).toString();

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,52 @@
+# CORAL
+
+> CORAL is open-source autoresearch powered by autonomous coding agents. Give it a codebase and a grader, and CORAL runs long-lived agents in isolated Git worktrees, grades every committed experiment, and shares attempts, notes, and skills through persistent memory.
+
+Canonical site: https://coral.compounding-intelligence.ai/
+Source: https://github.com/Human-Agent-Society/CORAL
+Paper: https://arxiv.org/abs/2604.01658
+License: Apache-2.0
+
+## When to use CORAL
+
+- Use CORAL for iterative search over code when success can be measured by a programmatic metric or an LLM rubric grader.
+- Typical tasks include algorithm and kernel optimization, benchmark solving, scientific discovery, machine-learning experiments, and other open-ended code improvement problems.
+- CORAL is not a coding model. It orchestrates coding-agent runtimes, workspaces, evaluation, shared memory, and long-running experiments.
+
+## Start here
+
+- [Installation](https://coral.compounding-intelligence.ai/docs/getting-started/installation/): Install the `coral` CLI and its prerequisites.
+- [Quickstart](https://coral.compounding-intelligence.ai/docs/getting-started/quickstart/): Create, validate, and run a first task.
+- [Concepts](https://coral.compounding-intelligence.ai/docs/concepts/): Understand the architecture and evaluation loop.
+- [Agent runtimes](https://coral.compounding-intelligence.ai/docs/guides/agent-runtimes/): Configure Claude Code, Codex, Cursor Agent, Kiro, or OpenCode.
+- [Build a grader](https://coral.compounding-intelligence.ai/docs/guides/custom-grader/): Package deterministic evaluation logic for a task.
+- [Multi-agent runs](https://coral.compounding-intelligence.ai/docs/guides/multi-agent/): Run agents in parallel with shared knowledge or isolated islands.
+- [Harness plugin](https://coral.compounding-intelligence.ai/docs/guides/plugin/): Author and operate CORAL tasks from Claude Code or Codex.
+
+## Core model
+
+- Agents are the optimizers. Each agent edits code in an isolated Git worktree and submits commits for evaluation.
+- A task-defined grader turns each committed attempt into a score and feedback. `grader.direction` determines whether higher or lower scores are better.
+- Shared state under `.coral/public/` carries attempts, notes, skills, heartbeat state, and checkpoints across agents.
+- Hidden grader code, answer keys, and grader environments stay under `.coral/private/` and are not visible to agents in isolated runs.
+- Multi-island runs can separate search populations and migrate selected agents between islands.
+
+## Installation
+
+- Preferred installer: `curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh`
+- Direct uv install: `uv tool install git+https://github.com/Human-Agent-Society/CORAL.git`
+- The unrelated package named `coral` on PyPI is not this project; install CORAL from the GitHub source above.
+
+## Research and examples
+
+- [COLM 2026 paper](https://arxiv.org/abs/2604.01658): CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery.
+- [Research article](https://coral.compounding-intelligence.ai/blogs/evolve-like-coral/): Architecture, experiments, comparisons, and multi-agent results.
+- [Example catalogue](https://coral.compounding-intelligence.ai/docs/examples/): Ready-to-run tasks across optimization, mathematics, systems, and machine learning.
+- [Example source](https://github.com/Human-Agent-Society/CORAL/tree/main/examples): Task configurations, seeds, and packaged graders.
+- [Kernel Builder result](https://github.com/Human-Agent-Society/CORAL/blob/main/demos/kernel_builder_1103.py): Published 1,103-cycle optimized kernel artifact.
+
+## Machine-readable resources
+
+- [Sitemap](https://coral.compounding-intelligence.ai/sitemap.xml): Canonical index of the website and documentation.
+- [Latest release](https://github.com/Human-Agent-Society/CORAL/releases/latest): Current release and changelog.
+- [GitHub releases API](https://api.github.com/repos/Human-Agent-Society/CORAL/releases/latest): Machine-readable release metadata.

--- a/docs/tests/canonical-links.test.mjs
+++ b/docs/tests/canonical-links.test.mjs
@@ -43,3 +43,21 @@ test('docs index links stay under the canonical docs prefix', async () => {
     assert.doesNotMatch(contents, new RegExp(`\\]\\(/${route}\\/`), route);
   }
 });
+
+test('public plugin instructions install CORAL from its source repository', async () => {
+  const installationFiles = [
+    'plugin/AGENTS.md',
+    'plugin/hooks/session-start.py',
+    'plugin/skills/coral-quickstart/SKILL.md',
+  ];
+
+  for (const relativePath of installationFiles) {
+    const contents = await readFile(resolve(root, relativePath), 'utf8');
+    assert.doesNotMatch(contents, /uv tool install coral(?:\s|[`'"]|$)/, relativePath);
+    assert.match(
+      contents,
+      /uv tool install git\+https:\/\/github\.com\/Human-Agent-Society\/CORAL\.git/,
+      relativePath,
+    );
+  }
+});

--- a/docs/tests/canonical-links.test.mjs
+++ b/docs/tests/canonical-links.test.mjs
@@ -9,6 +9,7 @@ const maintainedFiles = [
   'README_CN.md',
   'install.sh',
   'blog/index.html',
+  'docs/public/llms.txt',
   'docs/lib/layout.shared.tsx',
   'plugin/AGENTS.md',
   'plugin/hooks/session-start.py',

--- a/docs/tests/site-routes.test.mjs
+++ b/docs/tests/site-routes.test.mjs
@@ -74,6 +74,17 @@ test('robots and sitemap expose canonical site routes', async () => {
   }
 });
 
+test('llms.txt provides canonical project and documentation entry points', async () => {
+  const { response, body } = await get('/llms.txt');
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get('content-type') ?? '', /^text\/plain/);
+  assert.match(body, /^# CORAL$/m);
+  assert.match(body, /open-source autoresearch powered by autonomous coding agents/i);
+  assert.match(body, /https:\/\/coral\.compounding-intelligence\.ai\/docs\/getting-started\/quickstart\//);
+  assert.match(body, /https:\/\/github\.com\/Human-Agent-Society\/CORAL/);
+  assert.doesNotMatch(body, /uv tool install coral(?:\s|[`'"]|$)/);
+});
+
 test('the article serves an asset below its canonical prefix', async () => {
   const { response } = await get(
     '/blogs/evolve-like-coral/coral_logo.png',

--- a/docs/tests/site-routes.test.mjs
+++ b/docs/tests/site-routes.test.mjs
@@ -22,6 +22,58 @@ test('canonical pages stay on the same origin', async () => {
   }
 });
 
+test('public pages expose canonical and social metadata', async () => {
+  const pages = [
+    ['/', '/'],
+    ['/docs/', '/docs/'],
+    ['/blogs/', '/blogs/'],
+    ['/blogs/evolve-like-coral/', '/blogs/evolve-like-coral/'],
+  ];
+
+  for (const [path, canonicalPath] of pages) {
+    const { body } = await get(path);
+    const canonical = new URL(canonicalPath, 'https://coral.compounding-intelligence.ai');
+
+    assert.match(body, /<meta name="description" content="[^"]+"/, `${path} description`);
+    assert.match(
+      body,
+      new RegExp(`<link rel="canonical" href="${canonical.toString()}"`),
+      `${path} canonical`,
+    );
+    assert.match(body, /<meta property="og:title" content="[^"]+"/, `${path} Open Graph`);
+    assert.match(body, /<meta property="og:image" content="[^"]+"/, `${path} social image`);
+    assert.match(body, /<meta name="twitter:card" content="summary_large_image"/, `${path} Twitter`);
+  }
+});
+
+test('the homepage describes CORAL as a software application', async () => {
+  const { body } = await get('/');
+  assert.match(body, /<script type="application\/ld\+json">/);
+  assert.match(body, /"@type":"SoftwareApplication"/);
+  assert.match(body, /"codeRepository":"https:\/\/github\.com\/Human-Agent-Society\/CORAL"/);
+});
+
+test('robots and sitemap expose canonical site routes', async () => {
+  const robots = await get('/robots.txt');
+  assert.equal(robots.response.status, 200);
+  assert.match(robots.body, /Allow: \//);
+  assert.match(
+    robots.body,
+    /Sitemap: https:\/\/coral\.compounding-intelligence\.ai\/sitemap\.xml/,
+  );
+
+  const sitemap = await get('/sitemap.xml');
+  assert.equal(sitemap.response.status, 200);
+  assert.match(sitemap.response.headers.get('content-type') ?? '', /application\/xml/);
+  for (const path of ['/', '/docs/', '/blogs/', '/blogs/evolve-like-coral/']) {
+    assert.match(
+      sitemap.body,
+      new RegExp(`https://coral\\.compounding-intelligence\\.ai${path.replaceAll('/', '\\/')}`),
+      path,
+    );
+  }
+});
+
 test('the article serves an asset below its canonical prefix', async () => {
   const { response } = await get(
     '/blogs/evolve-like-coral/coral_logo.png',

--- a/plugin/AGENTS.md
+++ b/plugin/AGENTS.md
@@ -7,7 +7,7 @@ install the plugin but still want the agent to reach for CORAL.
 
 ## CORAL
 
-`coral` is a CLI for running autonomous coding agents against a grader and a leaderboard. If it's installed (`coral --help` succeeds), reach for it when the user wants to **author a task** or **run experiments**; otherwise install it (`uv tool install coral`).
+`coral` is a CLI for running autonomous coding agents against a grader and a leaderboard. If it's installed (`coral --help` succeeds), reach for it when the user wants to **author a task** or **run experiments**; otherwise install it (`uv tool install git+https://github.com/Human-Agent-Society/CORAL.git`).
 
 - **Author a task** (`task.yaml` + `seed/` + packaged grader): use the `creating-a-coral-task` skill. Scaffold with `coral init`, validate with `coral validate .`.
 - **Run / manage experiments**: use the `running-coral-experiments` skill. Drive `coral start / status / log / show / resume / stop`; pass per-run overrides as dotlist args (`agents.count=4`).

--- a/plugin/hooks/session-start.py
+++ b/plugin/hooks/session-start.py
@@ -61,7 +61,7 @@ def _missing_context() -> str:
         "```bash\n"
         "curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh\n"
         "# or, with uv:\n"
-        "uv tool install coral\n"
+        "uv tool install git+https://github.com/Human-Agent-Society/CORAL.git\n"
         "```\n\n"
         "Then the `creating-a-coral-task` and `running-coral-experiments` skills apply. "
         "Docs: https://coral.compounding-intelligence.ai/docs/\n"

--- a/plugin/skills/coral-quickstart/SKILL.md
+++ b/plugin/skills/coral-quickstart/SKILL.md
@@ -35,7 +35,8 @@ Two things you build (`seed/` + grader) and one thing you tune (how many agents,
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Human-Agent-Society/CORAL/main/install.sh | sh
-# or, if you have uv:  uv tool install coral
+# or, if you have uv:
+uv tool install git+https://github.com/Human-Agent-Society/CORAL.git
 coral --help      # verify
 ```
 


### PR DESCRIPTION
## Motivation

The public site currently presents the landing page as "CORAL Documentation" and does not expose a sitemap, robots policy, canonical URLs, or complete social previews. The static research article also lacks descriptive/search metadata. In addition, three public plugin surfaces recommend `uv tool install coral`, which resolves to an unrelated project on PyPI instead of this repository.

This change establishes the technical SEO baseline for search discovery and makes the direct-install fallback unambiguous.

## Changes

- Adds shared page metadata for the canonical site origin, search-focused titles/descriptions, canonical URLs, Open Graph, and Twitter cards.
- Adds a canonical `/llms.txt` with project positioning, use cases, installation provenance, core documentation, research artifacts, and machine-readable entry points.- Gives the English and Chinese READMEs one descriptive, search-focused H1 while retaining their existing taglines as supporting copy.- Generates a 1200×630 social preview image and applies it across landing, docs, blog listing, and article pages.
- Adds generated `robots.txt` and `sitemap.xml`; the sitemap enumerates every Fumadocs page plus the landing and blog routes.
- Adds `SoftwareApplication` structured data to the landing page and `Article` structured data to the research post.
- Updates the static article with canonical, description, social, and publication metadata.
- Replaces ambiguous `uv tool install coral` plugin guidance with the canonical GitHub install source.
- Extends site-route and maintained-link tests to cover metadata, crawler endpoints, structured data, social images, and install provenance.

## Test plan

- `cd docs && node --test tests/blog-sync.test.mjs tests/canonical-links.test.mjs` — 4 passed.
- `cd docs && npm run build` — production build completed; all 38 static pages generated.
- `cd docs && npm start`, then `npm run test:routes` — 11 passed.
- Manually rendered and inspected the generated 1200×630 Open Graph image.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — passed (130 files already formatted).
- `uv run pytest tests/ -v` — 653 passed, 1 skipped, 3 failed in untouched areas:
  - `tests/test_start_session_mode.py::test_local_from_users_own_tmux_stays_local`
  - `tests/test_start_session_mode.py::test_tmux_wrapper_restores_tmux`
  - `tests/test_versioning.py::test_distribution_version_is_based_on_latest_release_tag` (the local editable distribution reports `0.7.8.dev0`, older than tag `v0.7.13`)

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: public plugin install guidance

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally. See the three unrelated failures documented in the test plan.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [x] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description. No config, CLI, hook, or runtime contract changes.
- [ ] **New `examples/<task>/`**: not applicable; this PR does not add an example task.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

*Authored with assistance from Codex. Before merge, the submitting human must read every changed line and verify the design and test plan above.*



