### PR TITLE
release: promote CORAL entity disambiguation to main

### DIFF
--- a/docs/app/(site)/page.tsx
+++ b/docs/app/(site)/page.tsx
@@ -1,28 +1,6 @@
 import Link from 'next/link';
 import { blogPosts } from '@/lib/blogs';
-import { DEFAULT_DESCRIPTION, SITE_ORIGIN } from '@/lib/metadata';
-
-const softwareApplicationJsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'SoftwareApplication',
-  name: 'CORAL',
-  applicationCategory: 'DeveloperApplication',
-  operatingSystem: 'Linux, macOS',
-  description: DEFAULT_DESCRIPTION,
-  url: SITE_ORIGIN,
-  codeRepository: 'https://github.com/Human-Agent-Society/CORAL',
-  license: 'https://www.apache.org/licenses/LICENSE-2.0',
-  softwareRequirements: 'Python 3.11 or later and Git',
-  offers: {
-    '@type': 'Offer',
-    price: '0',
-    priceCurrency: 'USD',
-  },
-  sameAs: [
-    'https://github.com/Human-Agent-Society/CORAL',
-    'https://arxiv.org/abs/2604.01658',
-  ],
-};
+import { CORAL_DEFINITION, softwareApplicationJsonLd } from '@/lib/metadata';
 
 const capabilities = [
   {
@@ -60,11 +38,10 @@ export default function HomePage() {
             Open infrastructure for autoresearch
           </p>
           <h1 className="max-w-4xl text-5xl font-semibold tracking-tight text-fd-foreground md:text-7xl">
-            Autonomous agents that experiment, learn, and evolve together.
+            Open-source autoresearch powered by autonomous coding agents.
           </h1>
           <p className="mt-7 max-w-2xl text-lg leading-8 text-fd-muted-foreground md:text-xl">
-            CORAL gives multi-agent organizations isolated workspaces, safe evaluation, and shared
-            memory so they can continuously improve solutions to open-ended problems.
+            {CORAL_DEFINITION}
           </p>
           <div className="mt-9 flex flex-wrap gap-3">
             <Link
@@ -72,6 +49,12 @@ export default function HomePage() {
               className="rounded-lg bg-fd-primary px-5 py-3 font-medium text-fd-primary-foreground transition-opacity hover:opacity-85"
             >
               Get started
+            </Link>
+            <Link
+              href="/docs/what-is-coral/"
+              className="rounded-lg border border-fd-border bg-fd-card px-5 py-3 font-medium text-fd-foreground transition-colors hover:bg-fd-accent"
+            >
+              What is CORAL?
             </Link>
             <Link
               href="https://github.com/Human-Agent-Society/CORAL"

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -10,7 +10,13 @@ import { getMDXComponents } from '@/components/mdx';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
-import { createPageMetadata } from '@/lib/metadata';
+import {
+  absoluteUrl,
+  CORAL_DEFINITION,
+  CORAL_DISAMBIGUATION,
+  createPageMetadata,
+  softwareApplicationJsonLd,
+} from '@/lib/metadata';
 
 interface PageProps {
   params: Promise<{ slug?: string[] }>;
@@ -26,6 +32,45 @@ interface MDXPageData {
   full?: boolean;
 }
 
+const coralIdentityJsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    softwareApplicationJsonLd,
+    {
+      '@type': 'AboutPage',
+      '@id': absoluteUrl('/docs/what-is-coral/#page'),
+      url: absoluteUrl('/docs/what-is-coral/'),
+      name: 'What Is CORAL? The Open-Source Autoresearch Framework',
+      description: CORAL_DEFINITION,
+      mainEntity: { '@id': softwareApplicationJsonLd['@id'] },
+    },
+    {
+      '@type': 'FAQPage',
+      '@id': absoluteUrl('/docs/what-is-coral/#faq'),
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is CORAL?',
+          acceptedAnswer: { '@type': 'Answer', text: CORAL_DEFINITION },
+        },
+        {
+          '@type': 'Question',
+          name: 'Is CORAL an AI agent?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Yes and no. Individual coding-agent processes running through CORAL can be called CORAL agents. The CORAL project itself is an autoresearch framework around those agents, not a single AI model.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Is CORAL related to Coral Protocol or CoralOS?',
+          acceptedAnswer: { '@type': 'Answer', text: CORAL_DISAMBIGUATION },
+        },
+      ],
+    },
+  ],
+};
+
 export default async function Page(props: PageProps) {
   const params = await props.params;
   const page = source.getPage(params.slug);
@@ -33,19 +78,28 @@ export default async function Page(props: PageProps) {
 
   const data = page.data as unknown as MDXPageData;
   const MDX = data.body;
+  const isCoralIdentityPage = page.url === '/docs/what-is-coral';
 
   return (
-    <DocsPage toc={data.toc} full={data.full} tableOfContent={{ single: false }}>
-      <DocsTitle>{data.title}</DocsTitle>
-      <DocsDescription>{data.description}</DocsDescription>
-      <DocsBody>
-        <MDX
-          components={getMDXComponents({
-            a: createRelativeLink(source, page),
-          })}
+    <>
+      {isCoralIdentityPage ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(coralIdentityJsonLd) }}
         />
-      </DocsBody>
-    </DocsPage>
+      ) : null}
+      <DocsPage toc={data.toc} full={data.full} tableOfContent={{ single: false }}>
+        <DocsTitle>{data.title}</DocsTitle>
+        <DocsDescription>{data.description}</DocsDescription>
+        <DocsBody>
+          <MDX
+            components={getMDXComponents({
+              a: createRelativeLink(source, page),
+            })}
+          />
+        </DocsBody>
+      </DocsPage>
+    </>
   );
 }
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     'autoresearch',
     'autonomous coding agents',
     'multi-agent systems',
-    'agent orchestration',
+    'coding agent infrastructure',
     'self-evolving agents',
     'Claude Code',
     'Codex',

--- a/docs/content/docs/concepts/architecture.mdx
+++ b/docs/content/docs/concepts/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: How CORAL orchestrates autonomous coding agents.
+description: How CORAL runs autonomous coding agents in isolated workspaces with grading and shared memory.
 ---
 
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -35,7 +35,7 @@ Each agent:
 - **Agents are the optimizers** — Claude Code, Codex, or OpenCode subprocesses working in git worktrees
 - **Shared state via `.coral/`** — attempts, notes, skills symlinked into each worktree
 - **Eval loop** — agents call `coral eval -m "..."` to stage, commit, and grade
-- **CLI orchestration** — `coral start/stop/status/eval/log` and more
+- **CLI coordination** — `coral start/stop/status/eval/log` and more
 - **Web dashboard** — `coral ui` for real-time monitoring
 
 ## Quick Links

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -2,6 +2,7 @@
   "title": "Documentation",
   "pages": [
     "index",
+    "what-is-coral",
     "getting-started",
     "concepts",
     "guides",

--- a/docs/content/docs/what-is-coral.mdx
+++ b/docs/content/docs/what-is-coral.mdx
@@ -1,0 +1,75 @@
+---
+title: What Is CORAL? The Open-Source Autoresearch Framework
+description: CORAL is an open-source autoresearch framework powered by autonomous coding agents, continuous grading, isolated Git worktrees, and shared memory.
+---
+
+**CORAL is an open-source autoresearch framework powered by autonomous coding agents.** It runs long-lived agents in isolated Git worktrees, continuously grades experiments, and shares knowledge through persistent memory.
+
+Give CORAL a codebase, an objective, and a grader. CORAL coordinates supported coding-agent runtimes as they propose changes, commit experiments, receive scores and feedback, and use discoveries from earlier attempts to guide the next search step.
+
+## Is CORAL an AI agent?
+
+Yes and no. A CORAL run is powered by autonomous coding agents, and each coding-agent process in that run can reasonably be called a **CORAL agent**. CORAL itself, however, is the framework around those agents—not a single model. It runs Claude Code, Codex, Cursor Agent, Kiro, and OpenCode in isolated workspaces and connects them with grading and shared memory.
+
+When this documentation uses the phrase **CORAL agent**, it means a coding-agent process running inside a CORAL-managed workspace—not a separate model named “Coral Agent.”
+
+## How CORAL works
+
+1. CORAL creates an isolated Git worktree for each agent.
+2. Each agent modifies the task codebase and commits an experiment.
+3. A task-specific grader evaluates the committed attempt and returns a score and feedback.
+4. Attempts, notes, and reusable skills persist in shared memory under `.coral/public/`.
+5. Agents continue the loop, building on useful results while exploring alternatives in parallel.
+
+This setup is designed for open-ended code search: kernel and algorithm optimization, benchmark solving, machine-learning experiments, scientific discovery, and other problems whose progress can be measured by deterministic tests or an LLM rubric grader.
+
+## Is CORAL related to Coral Protocol or CoralOS?
+
+No. **The CORAL autoresearch framework is not affiliated with Coral Protocol or CoralOS; those are separate projects.**
+
+The project described here is identified by all of the following:
+
+| Identity signal | Official value |
+| --- | --- |
+| Project | CORAL open-source autoresearch framework |
+| Canonical website | [coral.compounding-intelligence.ai](https://coral.compounding-intelligence.ai/) |
+| Source repository | [Human-Agent-Society/CORAL](https://github.com/Human-Agent-Society/CORAL) |
+| Research paper | [CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery](https://arxiv.org/abs/2604.01658) |
+| License | [Apache License 2.0](https://github.com/Human-Agent-Society/CORAL/blob/main/LICENSE) |
+
+## What makes CORAL different?
+
+- **Evaluation is part of the control loop.** Agents receive task-specific scores and feedback after every submitted experiment.
+- **Agents work in isolated repositories.** Git worktrees keep concurrent ideas separate and make every evaluated attempt reproducible.
+- **Memory persists across the organization.** Agents can share attempts, notes, and skills instead of repeatedly rediscovering the same information.
+- **The agent runtime is replaceable.** CORAL supplies workspaces, the grading loop, and shared state while supported coding agents supply the search behavior.
+- **Private evaluation stays private.** Hidden grader code and answer keys are isolated from the agents they evaluate.
+
+## Frequently asked questions
+
+### What is CORAL?
+
+CORAL is an open-source autoresearch framework powered by autonomous coding agents. It manages workspaces, evaluation, shared memory, and long-running experiment loops.
+
+### Is CORAL an AI agent?
+
+Yes and no. Individual coding-agent processes running through CORAL can be called CORAL agents. The CORAL project itself is the framework around those agents, not a single AI model.
+
+### Is CORAL related to Coral Protocol or CoralOS?
+
+No. The CORAL autoresearch framework, Coral Protocol, and CoralOS are separate projects.
+
+### Which agents does CORAL support?
+
+CORAL supports Claude Code, Codex, Cursor Agent, Kiro, and OpenCode. See [Agent Runtimes](/docs/guides/agent-runtimes) for configuration details.
+
+### Is CORAL open source?
+
+Yes. CORAL's source code is available on GitHub under the Apache License 2.0.
+
+## Start using CORAL
+
+- Follow the [installation guide](/docs/getting-started/installation).
+- Run your first task with the [quickstart](/docs/getting-started/quickstart).
+- Learn how the pieces connect in [Architecture](/docs/concepts/architecture).
+- Read the [COLM 2026 paper](https://arxiv.org/abs/2604.01658).

--- a/docs/lib/metadata.ts
+++ b/docs/lib/metadata.ts
@@ -3,14 +3,52 @@ import type { Metadata } from 'next';
 export const SITE_ORIGIN = 'https://coral.compounding-intelligence.ai';
 export const SITE_NAME = 'CORAL';
 export const DEFAULT_TITLE = 'CORAL: Open-Source Autoresearch Powered by Autonomous Coding Agents';
-export const DEFAULT_DESCRIPTION =
-  'Run Claude Code, Codex, Cursor, Kiro, and OpenCode as a self-improving multi-agent team with isolated worktrees, continuous grading, and shared memory.';
+export const CORAL_DEFINITION =
+  'CORAL is an open-source autoresearch framework powered by autonomous coding agents. It runs long-lived agents in isolated Git worktrees, continuously grades experiments, and shares knowledge through persistent memory.';
+export const CORAL_DISAMBIGUATION =
+  'CORAL is not affiliated with Coral Protocol or CoralOS; those are separate projects.';
+export const DEFAULT_DESCRIPTION = CORAL_DEFINITION;
+export const GITHUB_REPOSITORY_URL = 'https://github.com/Human-Agent-Society/CORAL';
+export const PAPER_URL = 'https://arxiv.org/abs/2604.01658';
 const SOCIAL_IMAGE_PATH = '/opengraph-image/';
 const SOCIAL_IMAGE_ALT = 'CORAL: open-source autoresearch powered by autonomous coding agents';
 
 export function absoluteUrl(path: string): string {
   return new URL(path, SITE_ORIGIN).toString();
 }
+
+export const softwareApplicationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  '@id': `${SITE_ORIGIN}/#software`,
+  name: 'CORAL',
+  alternateName: [
+    'CORAL autoresearch framework',
+    'CORAL autonomous coding agents framework',
+  ],
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Linux, macOS',
+  description: CORAL_DEFINITION,
+  disambiguatingDescription: CORAL_DISAMBIGUATION,
+  url: SITE_ORIGIN,
+  mainEntityOfPage: absoluteUrl('/docs/what-is-coral/'),
+  codeRepository: GITHUB_REPOSITORY_URL,
+  license: 'https://www.apache.org/licenses/LICENSE-2.0',
+  softwareRequirements: 'Python 3.11 or later and Git',
+  keywords: [
+    'autoresearch',
+    'autonomous coding agents',
+    'multi-agent systems',
+    'coding agent infrastructure',
+    'shared memory',
+  ],
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
+  sameAs: [GITHUB_REPOSITORY_URL, PAPER_URL],
+};
 
 export function createPageMetadata({
   title,

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -11,10 +11,11 @@ License: Apache-2.0
 
 - Use CORAL for iterative search over code when success can be measured by a programmatic metric or an LLM rubric grader.
 - Typical tasks include algorithm and kernel optimization, benchmark solving, scientific discovery, machine-learning experiments, and other open-ended code improvement problems.
-- CORAL is not a coding model. It orchestrates coding-agent runtimes, workspaces, evaluation, shared memory, and long-running experiments.
+- CORAL is not a coding model. It runs coding-agent processes and provides their workspaces, evaluation, shared memory, and long-running experiment loop.
 
 ## Start here
 
+- [What is CORAL?](https://coral.compounding-intelligence.ai/docs/what-is-coral/): Canonical project definition, identity, disambiguation, and frequently asked questions.
 - [Installation](https://coral.compounding-intelligence.ai/docs/getting-started/installation/): Install the `coral` CLI and its prerequisites.
 - [Quickstart](https://coral.compounding-intelligence.ai/docs/getting-started/quickstart/): Create, validate, and run a first task.
 - [Concepts](https://coral.compounding-intelligence.ai/docs/concepts/): Understand the architecture and evaluation loop.
@@ -50,3 +51,9 @@ License: Apache-2.0
 - [Sitemap](https://coral.compounding-intelligence.ai/sitemap.xml): Canonical index of the website and documentation.
 - [Latest release](https://github.com/Human-Agent-Society/CORAL/releases/latest): Current release and changelog.
 - [GitHub releases API](https://api.github.com/repos/Human-Agent-Society/CORAL/releases/latest): Machine-readable release metadata.
+
+## Disambiguation
+
+- CORAL is the open-source autoresearch framework maintained at `Human-Agent-Society/CORAL` and described in the paper "CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery."
+- CORAL is not affiliated with Coral Protocol or CoralOS; those are separate projects.
+- Individual coding-agent processes running through CORAL can be called CORAL agents. The CORAL project itself is the framework around those agents, not a single coding model.

--- a/docs/tests/site-routes.test.mjs
+++ b/docs/tests/site-routes.test.mjs
@@ -11,6 +11,7 @@ test('canonical pages stay on the same origin', async () => {
   const pages = [
     ['/', 'autonomous'],
     ['/docs/', 'Documentation'],
+    ['/docs/what-is-coral/', 'Open-Source Autoresearch Framework'],
     ['/blogs/', 'Blogs'],
     ['/blogs/evolve-like-coral/', 'Evolve Like Coral'],
   ];
@@ -26,6 +27,7 @@ test('public pages expose canonical and social metadata', async () => {
   const pages = [
     ['/', '/'],
     ['/docs/', '/docs/'],
+    ['/docs/what-is-coral/', '/docs/what-is-coral/'],
     ['/blogs/', '/blogs/'],
     ['/blogs/evolve-like-coral/', '/blogs/evolve-like-coral/'],
   ];
@@ -48,9 +50,23 @@ test('public pages expose canonical and social metadata', async () => {
 
 test('the homepage describes CORAL as a software application', async () => {
   const { body } = await get('/');
+  assert.match(body, /open-source autoresearch powered by autonomous coding agents/i);
   assert.match(body, /<script type="application\/ld\+json">/);
   assert.match(body, /"@type":"SoftwareApplication"/);
+  assert.match(body, /"alternateName":\["CORAL autoresearch framework"/);
+  assert.match(body, /"mainEntityOfPage":"https:\/\/coral\.compounding-intelligence\.ai\/docs\/what-is-coral\/"/);
   assert.match(body, /"codeRepository":"https:\/\/github\.com\/Human-Agent-Society\/CORAL"/);
+});
+
+test('the CORAL identity page provides explicit disambiguation and structured FAQs', async () => {
+  const { response, body } = await get('/docs/what-is-coral/');
+  assert.equal(response.status, 200);
+  assert.match(body, /CORAL is an open-source autoresearch framework powered by autonomous coding agents/i);
+  assert.match(body, /Yes and no\. Individual coding-agent processes running through CORAL/i);
+  assert.match(body, /not affiliated with Coral Protocol or CoralOS/i);
+  assert.match(body, /"@type":"AboutPage"/);
+  assert.match(body, /"@type":"FAQPage"/);
+  assert.match(body, /"name":"Is CORAL related to Coral Protocol or CoralOS\?"/);
 });
 
 test('robots and sitemap expose canonical site routes', async () => {
@@ -65,7 +81,13 @@ test('robots and sitemap expose canonical site routes', async () => {
   const sitemap = await get('/sitemap.xml');
   assert.equal(sitemap.response.status, 200);
   assert.match(sitemap.response.headers.get('content-type') ?? '', /application\/xml/);
-  for (const path of ['/', '/docs/', '/blogs/', '/blogs/evolve-like-coral/']) {
+  for (const path of [
+    '/',
+    '/docs/',
+    '/docs/what-is-coral/',
+    '/blogs/',
+    '/blogs/evolve-like-coral/',
+  ]) {
     assert.match(
       sitemap.body,
       new RegExp(`https://coral\\.compounding-intelligence\\.ai${path.replaceAll('/', '\\/')}`),
@@ -82,6 +104,7 @@ test('llms.txt provides canonical project and documentation entry points', async
   assert.match(body, /open-source autoresearch powered by autonomous coding agents/i);
   assert.match(body, /https:\/\/coral\.compounding-intelligence\.ai\/docs\/getting-started\/quickstart\//);
   assert.match(body, /https:\/\/github\.com\/Human-Agent-Society\/CORAL/);
+  assert.match(body, /not affiliated with Coral Protocol or CoralOS/i);
   assert.doesNotMatch(body, /uv tool install coral(?:\s|[`'"]|$)/);
 });
 


### PR DESCRIPTION
## Motivation

Promote the reviewed CORAL entity-definition and search-disambiguation improvements from `dev` to the production `main` branch.

This release contains #219 only. It gives search and answer engines a canonical definition of CORAL, distinguishes the project from similarly named products, and clarifies that individual processes can be called CORAL agents while CORAL itself is the surrounding autoresearch framework.

**Merge method:** Create a merge commit. Do not squash or rebase this `dev` to `main` promotion; preserving branch ancestry is required for future releases.

## Changes

- add the canonical `/docs/what-is-coral/` identity and disambiguation page
- align homepage copy and machine-readable project definitions
- add SoftwareApplication, AboutPage, and FAQPage structured data
- update navigation, sitemap discovery, and `llms.txt`
- replace vague orchestration wording with concrete descriptions of what CORAL runs and provides
- add route coverage for metadata, structured data, sitemap, and disambiguation content

## Test plan

Upstream PR #219 completed successfully:

- CI lint with Ruff (passed)
- CI tests on Python 3.11, 3.12, and 3.13 (passed)
- Vercel previews for `coral-docs` and `coral-web` (passed)
- `cd docs && node --test tests/blog-sync.test.mjs tests/canonical-links.test.mjs` (4 passed locally on #219)
- `cd docs && npm run build` (39 static pages generated locally on #219)
- `cd docs && SITE_URL=http://127.0.0.1:3017 npm run test:routes` (12 passed locally on #219)

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: release promotion from `dev` to `main`

## Checklist

- [x] This is the explicitly requested `dev` to `main` release promotion.
- [x] Title follows Conventional Commits.
- [ ] `uv run pytest tests/ -v` passes locally. (Not rerun locally for this ancestry-only promotion; upstream matrix passed.)
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass locally. (Not rerun locally; upstream CI lint passed.)
- [x] Added or updated tests under `tests/` for behavior changes in #219.
- [x] Updated documentation for the user-visible change.
- [x] No config field, CLI flag, hook, or runtime contract changed.
- [x] No new example task was added.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See `AGENTS.md`.

Authored with assistance from Codex. Human review of the promoted diff is required before merge.