### PR TITLE
ci: refresh main source guard after retargeting

### DIFF
--- a/.github/workflows/main-pr-source.yml
+++ b/.github/workflows/main-pr-source.yml
@@ -2,8 +2,7 @@ name: Main PR source guard
 
 on:
   pull_request_target:
-    branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions:
   contents: read
@@ -15,10 +14,16 @@ jobs:
     steps:
       - name: Verify pull request source
         env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
           BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
+          if [[ "$BASE_BRANCH" != "main" ]]; then
+            echo "Source guard does not apply to pull requests targeting $BASE_BRANCH."
+            exit 0
+          fi
+
           if [[ "$HEAD_REPOSITORY" != "$BASE_REPOSITORY" || "$HEAD_BRANCH" != "dev" ]]; then
             echo "::error::Pull requests to main must come from this repository's dev branch."
             echo "Received source: $HEAD_REPOSITORY:$HEAD_BRANCH"


### PR DESCRIPTION
## Motivation

The main-branch source guard leaves a stale failing check when a pull request is opened against `main` and then retargeted to `dev`. PR #221 reproduced this: rerunning the original workflow continued to use the original `pull_request_target` event context and failed even though the current base branch was `dev`.

## Changes

- Listen for `edited` pull request events so base-branch changes trigger a fresh guard run.
- Run the workflow for all pull request target branches, then exit successfully when the current base is not `main`.
- Preserve the existing rule that pull requests targeting `main` must come from this repository's `dev` branch.

## Test plan

- Parsed `.github/workflows/main-pr-source.yml` with Ruby `YAML.safe_load_file`.
- Executed the workflow shell body for three cases:
  - fork branch targeting `dev`: accepted as not applicable.
  - repository `dev` targeting `main`: accepted.
  - fork feature branch targeting `main`: rejected.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — passed (`130 files already formatted`).
- `uv run pytest tests/ -v` — 653 passed, 1 skipped, and 3 unrelated local failures. Two tmux tests fail because the mocked run does not create `.coral/public`; the versioning test reads the pre-existing local editable-install version `0.7.8` instead of the current `v0.7.13` tag. The unchanged `dev` commit is green in [GitHub CI](https://github.com/Human-Agent-Society/CORAL/actions/runs/30933686787).

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [x] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

Authored with assistance from Codex. The submitting human should review every changed line before marking this draft ready for review.
