### PR TITLE
fix: three cross-platform defects (process liveness, PATH separator, text encoding)

### DIFF
--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -36,7 +36,7 @@ def _extract_claude_code_session_id(log_path: Path) -> str | None:
     (system init, assistant messages, etc.) — scanning from the end.
     """
     try:
-        lines = log_path.read_text().strip().splitlines()
+        lines = log_path.read_text(encoding="utf-8").strip().splitlines()
         # First pass: look for a "result" line (most authoritative)
         for line in reversed(lines):
             line = line.strip()
@@ -149,7 +149,11 @@ class ClaudeCodeRuntime:
     ) -> AgentHandle:
         """Start a Claude Code agent in the given worktree."""
         agent_id_file = worktree_path / ".coral_agent_id"
-        agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
+        agent_id = (
+            agent_id_file.read_text(encoding="utf-8").strip()
+            if agent_id_file.exists()
+            else "unknown"
+        )
 
         if log_dir is None:
             log_dir = worktree_path / ".claude" / "logs"
@@ -233,7 +237,9 @@ class ClaudeCodeRuntime:
         # creds/session in the agent's home; returns Popen user=/group= kwargs.
         user_kwargs = apply_run_as_user(agent_env, run_as_user)
 
-        log_file = open(log_path, "w", buffering=1)  # line-buffered
+        log_file = open(
+            log_path, "w", buffering=1, encoding="utf-8", errors="replace"
+        )  # line-buffered
 
         # Open per-agent stderr capture under public/diagnostics/<agent_id>/agent.err
         # so stderr does not pollute the stream-json log. Falls back to STDOUT

--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -210,7 +211,7 @@ class ClaudeCodeRuntime:
         agent_env["VIRTUAL_ENV"] = worktree_venv
         # Prepend .venv/bin to PATH for non-login shells
         venv_bin = str(worktree_path / ".venv" / "bin")
-        agent_env["PATH"] = venv_bin + ":" + agent_env.get("PATH", "")
+        agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured
         if gateway_url:

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -174,7 +175,7 @@ class CodexRuntime:
         agent_env["VIRTUAL_ENV"] = worktree_venv
         # Prepend .venv/bin to PATH for non-login shells
         venv_bin = str(worktree_path / ".venv" / "bin")
-        agent_env["PATH"] = venv_bin + ":" + agent_env.get("PATH", "")
+        agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured
         if gateway_url:

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -42,7 +42,7 @@ def _extract_codex_session_id(log_path: Path) -> str | None:
     silently starting a fresh one.
     """
     try:
-        lines = log_path.read_text().strip().splitlines()
+        lines = log_path.read_text(encoding="utf-8").strip().splitlines()
         for line in reversed(lines):
             line = line.strip()
             if not line:
@@ -117,7 +117,11 @@ class CodexRuntime:
         Resume uses `codex exec resume <session_id> "prompt"`.
         """
         agent_id_file = worktree_path / ".coral_agent_id"
-        agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
+        agent_id = (
+            agent_id_file.read_text(encoding="utf-8").strip()
+            if agent_id_file.exists()
+            else "unknown"
+        )
 
         if log_dir is None:
             log_dir = worktree_path / ".codex" / "logs"
@@ -191,7 +195,7 @@ class CodexRuntime:
         # in the agent's home; returns Popen user=/group= kwargs.
         user_kwargs = apply_run_as_user(agent_env, run_as_user)
 
-        log_file = open(log_path, "w", buffering=1)
+        log_file = open(log_path, "w", buffering=1, encoding="utf-8", errors="replace")
 
         # Per-agent stderr capture under public/diagnostics/<agent_id>/agent.err.
         err_path: Path | None = None

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -203,7 +204,7 @@ class CursorAgentRuntime:
         agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
         agent_env["VIRTUAL_ENV"] = worktree_venv
         venv_bin = str(worktree_path / ".venv" / "bin")
-        agent_env["PATH"] = venv_bin + ":" + agent_env.get("PATH", "")
+        agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         apply_sandbox_env(agent_env, sandbox)
 

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -56,7 +56,7 @@ def _extract_cursor_session_id(log_path: Path) -> str | None:
     re-emit init), falling back to any line carrying a `session_id`.
     """
     try:
-        lines = log_path.read_text().strip().splitlines()
+        lines = log_path.read_text(encoding="utf-8").strip().splitlines()
         for line in reversed(lines):
             line = line.strip()
             if not line:
@@ -144,7 +144,11 @@ class CursorAgentRuntime:
         sandbox: AgentSandboxSpec | None = None,
     ) -> AgentHandle:
         agent_id_file = worktree_path / ".coral_agent_id"
-        agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
+        agent_id = (
+            agent_id_file.read_text(encoding="utf-8").strip()
+            if agent_id_file.exists()
+            else "unknown"
+        )
 
         if log_dir is None:
             log_dir = worktree_path / ".cursor" / "logs"
@@ -213,7 +217,7 @@ class CursorAgentRuntime:
         # its creds in the agent's home; returns Popen user=/group= kwargs.
         user_kwargs = apply_run_as_user(agent_env, run_as_user)
 
-        log_file = open(log_path, "w", buffering=1)
+        log_file = open(log_path, "w", buffering=1, encoding="utf-8", errors="replace")
 
         err_path: Path | None = None
         err_file: Any = None

--- a/coral/agent/builtin/kiro.py
+++ b/coral/agent/builtin/kiro.py
@@ -76,7 +76,11 @@ class KiroRuntime:
         sandbox: AgentSandboxSpec | None = None,
     ) -> AgentHandle:
         agent_id_file = worktree_path / ".coral_agent_id"
-        agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
+        agent_id = (
+            agent_id_file.read_text(encoding="utf-8").strip()
+            if agent_id_file.exists()
+            else "unknown"
+        )
 
         if log_dir is None:
             log_dir = worktree_path / ".kiro" / "logs"
@@ -113,7 +117,7 @@ class KiroRuntime:
         # its creds in the agent's home; returns Popen user=/group= kwargs.
         user_kwargs = apply_run_as_user(agent_env, run_as_user)
 
-        log_file = open(log_path, "w", buffering=1)
+        log_file = open(log_path, "w", buffering=1, encoding="utf-8", errors="replace")
 
         # Per-agent stderr capture under public/diagnostics/<agent_id>/agent.err.
         err_path: Path | None = None

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -152,7 +153,7 @@ class OpenCodeRuntime:
         agent_env["VIRTUAL_ENV"] = worktree_venv
         # Prepend .venv/bin to PATH for non-login shells
         venv_bin = str(worktree_path / ".venv" / "bin")
-        agent_env["PATH"] = venv_bin + ":" + agent_env.get("PATH", "")
+        agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured
         if gateway_url:

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -33,7 +33,7 @@ def _extract_opencode_session_id(log_path: Path) -> str | None:
     in events with a "session_id" or "sessionId" field.
     """
     try:
-        lines = log_path.read_text().strip().splitlines()
+        lines = log_path.read_text(encoding="utf-8").strip().splitlines()
         for line in reversed(lines):
             line = line.strip()
             if not line:
@@ -104,7 +104,11 @@ class OpenCodeRuntime:
     ) -> AgentHandle:
         """Start an OpenCode agent in the given worktree."""
         agent_id_file = worktree_path / ".coral_agent_id"
-        agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
+        agent_id = (
+            agent_id_file.read_text(encoding="utf-8").strip()
+            if agent_id_file.exists()
+            else "unknown"
+        )
 
         if log_dir is None:
             log_dir = worktree_path / ".opencode" / "logs"
@@ -169,7 +173,7 @@ class OpenCodeRuntime:
         # its creds in the agent's home; returns Popen user=/group= kwargs.
         user_kwargs = apply_run_as_user(agent_env, run_as_user)
 
-        log_file = open(log_path, "w", buffering=1)
+        log_file = open(log_path, "w", buffering=1, encoding="utf-8", errors="replace")
 
         # Per-agent stderr capture under public/diagnostics/<agent_id>/agent.err.
         err_path: Path | None = None

--- a/coral/agent/builtin/pi_agent.py
+++ b/coral/agent/builtin/pi_agent.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -167,7 +168,7 @@ class PiAgentRuntime:
         agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
         agent_env["VIRTUAL_ENV"] = worktree_venv
         venv_bin = str(worktree_path / ".venv" / "bin")
-        agent_env["PATH"] = venv_bin + ":" + agent_env.get("PATH", "")
+        agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         if gateway_url:
             agent_env["OPENAI_BASE_URL"] = gateway_url

--- a/coral/agent/builtin/pi_agent.py
+++ b/coral/agent/builtin/pi_agent.py
@@ -26,7 +26,7 @@ _PI_TOOLS = "read,bash,edit,write,grep,find,ls"
 def _extract_pi_session_id(log_path: Path) -> str | None:
     """Extract a Pi session ID from JSON output."""
     try:
-        lines = log_path.read_text().strip().splitlines()
+        lines = log_path.read_text(encoding="utf-8").strip().splitlines()
         for line in lines:
             line = line.strip()
             if not line:
@@ -118,7 +118,11 @@ class PiAgentRuntime:
     ) -> AgentHandle:
         """Start a Pi agent in the given worktree."""
         agent_id_file = worktree_path / ".coral_agent_id"
-        agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
+        agent_id = (
+            agent_id_file.read_text(encoding="utf-8").strip()
+            if agent_id_file.exists()
+            else "unknown"
+        )
 
         if log_dir is None:
             log_dir = worktree_path / ".pi" / "logs"
@@ -181,7 +185,7 @@ class PiAgentRuntime:
         # its creds in the agent's home; returns Popen user=/group= kwargs.
         user_kwargs = apply_run_as_user(agent_env, run_as_user)
 
-        log_file = open(log_path, "w", buffering=1)
+        log_file = open(log_path, "w", buffering=1, encoding="utf-8", errors="replace")
 
         err_path: Path | None = None
         err_file: Any = None

--- a/coral/agent/exit_classifier.py
+++ b/coral/agent/exit_classifier.py
@@ -70,7 +70,7 @@ def claude_code_log_has_session_error(log_path: Path) -> bool:
     the runtime classifier does not have to reach back into `manager.py`.
     """
     try:
-        content = log_path.read_text()
+        content = log_path.read_text(encoding="utf-8")
         return "No conversation found" in content
     except (OSError, UnicodeDecodeError):
         return False

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -312,7 +312,7 @@ class AgentManager:
         pid_file = self.paths.coral_dir / "public" / "grader_daemon.pid"
         if pid_file.exists():
             try:
-                stale_pid = int(pid_file.read_text().strip())
+                stale_pid = int(pid_file.read_text(encoding="utf-8").strip())
                 os.kill(stale_pid, signal.SIGTERM)
                 logger.info(f"Killed stale grader daemon PID {stale_pid}")
             except (ValueError, ProcessLookupError, PermissionError, OSError):
@@ -336,7 +336,7 @@ class AgentManager:
         self._grader_proc = proc
         self._grader_stop_event = stop_event
         try:
-            pid_file.write_text(str(proc.pid))
+            pid_file.write_text(str(proc.pid), encoding="utf-8")
         except OSError:
             pass
         logger.info(f"Grader daemon started (PID {proc.pid})")
@@ -690,7 +690,7 @@ class AgentManager:
             shared_dir=shared_dir_name,
             island_id=island_id,
         )
-        (worktree_path / instruction_file).write_text(coral_md)
+        (worktree_path / instruction_file).write_text(coral_md, encoding="utf-8")
 
         # OS-user isolation: chown agent-facing paths to the unprivileged user
         # and lock .coral/private/ to root, then run the agent subprocess as
@@ -962,7 +962,7 @@ class AgentManager:
             island_id: str | None = None
             if island_bc.exists():
                 try:
-                    island_id = island_bc.read_text().strip() or None
+                    island_id = island_bc.read_text(encoding="utf-8").strip() or None
                 except OSError:
                     island_id = None
             # Track it so subsequent restarts can use it
@@ -1023,7 +1023,7 @@ class AgentManager:
             if sid:
                 sessions[handle.agent_id] = sid
         sessions_file = self.paths.coral_dir / "public" / "sessions.json"
-        sessions_file.write_text(json.dumps(sessions, indent=2))
+        sessions_file.write_text(json.dumps(sessions, indent=2), encoding="utf-8")
         logger.info(f"Saved {len(sessions)} session ID(s) to sessions.json")
 
     def _load_saved_sessions(self) -> dict[str, str]:
@@ -1033,7 +1033,7 @@ class AgentManager:
         sessions_file = self.paths.coral_dir / "public" / "sessions.json"
         if sessions_file.exists():
             try:
-                return json.loads(sessions_file.read_text())
+                return json.loads(sessions_file.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"Failed to read sessions.json: {e}")
         return {}
@@ -1155,7 +1155,7 @@ class AgentManager:
             if path is None:
                 continue
             try:
-                data = json.loads(path.read_text())
+                data = json.loads(path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 # Transient read (e.g. mid-rename on some filesystems) — retry next tick.
                 continue
@@ -1187,7 +1187,7 @@ class AgentManager:
                 # When filtering, we have to read each candidate to inspect
                 # its agent_id field; cache the parse so we do not re-read.
                 try:
-                    data = json.loads(path.read_text())
+                    data = json.loads(path.read_text(encoding="utf-8"))
                 except (json.JSONDecodeError, OSError) as e:
                     logger.warning(f"Failed to read attempt {path}: {e}")
                     continue
@@ -1204,7 +1204,7 @@ class AgentManager:
             return newest_data
         if newest_path is not None:
             try:
-                return json.loads(newest_path.read_text())
+                return json.loads(newest_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"Failed to read attempt {newest_path}: {e}")
         return None
@@ -1220,7 +1220,7 @@ class AgentManager:
             counter_file = coral_dir / "public" / "eval_count"
         if counter_file.exists():
             try:
-                return int(counter_file.read_text().strip())
+                return int(counter_file.read_text(encoding="utf-8").strip())
             except ValueError:
                 pass
         return 0
@@ -2620,7 +2620,7 @@ class AgentManager:
             return
 
         pids = []
-        for line in agent_pids_file.read_text().strip().splitlines():
+        for line in agent_pids_file.read_text(encoding="utf-8").strip().splitlines():
             line = line.strip()
             if line:
                 pids.append(int(line))
@@ -2650,7 +2650,7 @@ class AgentManager:
     def _write_pid_file(self) -> None:
         if self.paths:
             pid_file = self.paths.coral_dir / "public" / "manager.pid"
-            pid_file.write_text(str(os.getpid()))
+            pid_file.write_text(str(os.getpid()), encoding="utf-8")
             # Also write agent PIDs so coral stop can kill them as fallback
             self._write_agent_pids()
 
@@ -2664,10 +2664,10 @@ class AgentManager:
                 if handle.process and handle.process.pid:
                     pids.append(str(handle.process.pid))
                     pid_map[handle.agent_id] = handle.process.pid
-            agent_pids_file.write_text("\n".join(pids))
+            agent_pids_file.write_text("\n".join(pids), encoding="utf-8")
             # Also write JSON mapping for the web UI to check process liveness
             pid_map_file = self.paths.coral_dir / "public" / "agent_pids.json"
-            pid_map_file.write_text(json.dumps(pid_map))
+            pid_map_file.write_text(json.dumps(pid_map), encoding="utf-8")
 
     def _atexit_cleanup(self) -> None:
         """Safety net: kill any surviving agent processes on interpreter exit."""
@@ -2810,7 +2810,7 @@ def _move_agent_files(
 def _attempt_file_belongs_to_agent(path: Path, agent_id: str) -> bool:
     """Return True when an attempt record file is owned by ``agent_id``."""
     try:
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8")
     except OSError:
         return False
     if path.suffix == ".jsonl":
@@ -2837,7 +2837,7 @@ def _stamp_attempt_file_island(path: Path, island_id: str) -> None:
     try:
         if path.suffix == ".jsonl":
             records = []
-            for line in path.read_text().splitlines():
+            for line in path.read_text(encoding="utf-8").splitlines():
                 if not line.strip():
                     continue
                 data = json.loads(line)
@@ -2847,16 +2847,18 @@ def _stamp_attempt_file_island(path: Path, island_id: str) -> None:
                 metadata["island_id"] = island_id
                 data["metadata"] = metadata
                 records.append(data)
-            path.write_text("".join(f"{json.dumps(record)}\n" for record in records))
+            path.write_text(
+                "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+            )
             return
 
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         metadata = data.get("metadata")
         if not isinstance(metadata, dict):
             metadata = {}
         metadata["island_id"] = island_id
         data["metadata"] = metadata
-        path.write_text(json.dumps(data, indent=2))
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
     except (json.JSONDecodeError, OSError, TypeError) as e:
         logger.warning("Failed to stamp migrated attempt %s with island %s: %s", path, island_id, e)
 
@@ -2963,7 +2965,7 @@ def _write_last_migrated_evals(coral_dir: Path, last_migrated: dict[str, int]) -
         prefix=".migration_state.", suffix=".tmp", dir=str(target.parent)
     )
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(payload)
         os.replace(tmp_path, target)
     except Exception:
@@ -2984,7 +2986,7 @@ def _read_last_migrated_evals(coral_dir: Path) -> dict[str, int]:
     """
     target = _migration_state_path(coral_dir)
     try:
-        with open(target) as f:
+        with open(target, encoding="utf-8") as f:
             raw = json.load(f)
     except (OSError, json.JSONDecodeError):
         return {}
@@ -3029,7 +3031,7 @@ def _write_arrival_note(coral_dir: Path, candidate: MigrationCandidate) -> None:
         f"`{candidate.src_island}` as island-local shared knowledge.\n"
     )
     fname = f"migration_{fname_ts}_{candidate.agent_id}.md"
-    (notes_dir / fname).write_text(body)
+    (notes_dir / fname).write_text(body, encoding="utf-8")
 
 
 def _reset_worktree_to_commit(worktree_path: Path, target_hash: str) -> None:

--- a/coral/agent/state.py
+++ b/coral/agent/state.py
@@ -115,7 +115,7 @@ def write_agent_state(coral_dir: str | Path, document: AgentStateDocument) -> Pa
 
     fd, tmp_path = tempfile.mkstemp(prefix=".agent_state.", suffix=".tmp", dir=str(target.parent))
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(payload)
         os.replace(tmp_path, target)
     except Exception:
@@ -139,7 +139,7 @@ def read_agent_state(coral_dir: str | Path) -> AgentStateDocument:
     if not target.exists():
         return AgentStateDocument()
     try:
-        with open(target) as f:
+        with open(target, encoding="utf-8") as f:
             raw = json.load(f)
     except (OSError, json.JSONDecodeError):
         return AgentStateDocument()

--- a/coral/agent/warmstart.py
+++ b/coral/agent/warmstart.py
@@ -18,7 +18,7 @@ _PROMPTS_DIR = Path(__file__).parent.parent / "hub" / "prompts"
 def _load_prompt(name: str) -> str:
     prompt_file = _PROMPTS_DIR / f"{name}.md"
     if prompt_file.exists():
-        return prompt_file.read_text()
+        return prompt_file.read_text(encoding="utf-8")
     return ""
 
 

--- a/coral/cli/_helpers.py
+++ b/coral/cli/_helpers.py
@@ -226,6 +226,75 @@ def in_coral_docker_session() -> bool:
     return os.environ.get("CORAL_IN_DOCKER") == "1"
 
 
+def _is_process_alive_windows(pid: int) -> bool:
+    """Windows backend for :func:`is_process_alive`.
+
+    Windows has no signal 0, so liveness has to be read off a process handle.
+    A handle stays valid after the process exits (until every reference is
+    closed), which is why the handle alone does not mean "running" — the
+    kernel object is *signalled* once the process terminates, so a zero
+    timeout wait separates a live process from an exited-but-unreaped one.
+    """
+    if sys.platform != "win32":  # pragma: no cover - narrows the type checker
+        return False
+
+    import ctypes
+    from ctypes import wintypes
+
+    error_access_denied = 5
+    synchronize = 0x00100000
+    wait_timeout = 0x00000102
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.OpenProcess(synchronize, False, pid)
+    if not handle:
+        # A running process owned by another user denies access; every other
+        # failure (notably ERROR_INVALID_PARAMETER for an unknown PID) is dead.
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        return kernel32.WaitForSingleObject(handle, 0) == wait_timeout
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def is_process_alive(pid: int) -> bool:
+    """Check whether a PID belongs to a running process, without signalling it.
+
+    Wraps the platform differences that ``os.kill(pid, 0)`` leaks to callers:
+
+    - POSIX raises ``ProcessLookupError`` for an unknown PID and
+      ``PermissionError`` for a live process owned by another user.
+    - Windows has no signal 0 at all, so ``os.kill(pid, 0)`` raises
+      ``OSError: [WinError 87] The parameter is incorrect`` for *every* PID,
+      live or not. Callers that only catch ``ProcessLookupError`` therefore
+      crash instead of reporting a stopped run.
+
+    Non-positive PIDs are rejected: ``os.kill`` treats 0 and negatives as
+    process-group selectors, so a truncated ``manager.pid`` would otherwise
+    probe the caller's own group and report a dead run as running.
+    """
+    if pid <= 0:
+        return False
+    if sys.platform == "win32":
+        return _is_process_alive_windows(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
 def is_docker_container_running(container_name: str, *, quiet: bool = False) -> bool:
     """Check if a Docker container is currently running."""
     cmd = docker_cmd_or_none() if quiet else docker_cmd()

--- a/coral/cli/_helpers.py
+++ b/coral/cli/_helpers.py
@@ -47,10 +47,10 @@ def save_tmux_session_name(save_dir: Path, session_name: str, *, owned: bool = T
                If False, coral is running inside a pre-existing session.
     """
     tmux_file = save_dir / ".coral_tmux_session"
-    tmux_file.write_text(session_name)
+    tmux_file.write_text(session_name, encoding="utf-8")
     owned_file = save_dir / ".coral_tmux_owned"
     if owned:
-        owned_file.write_text("1")
+        owned_file.write_text("1", encoding="utf-8")
     else:
         owned_file.unlink(missing_ok=True)
 
@@ -60,7 +60,7 @@ def find_tmux_session(coral_dir: Path) -> str | None:
     for search_dir in [coral_dir / "public", coral_dir.parent]:
         tmux_file = search_dir / ".coral_tmux_session"
         if tmux_file.exists():
-            session_name = tmux_file.read_text().strip()
+            session_name = tmux_file.read_text(encoding="utf-8").strip()
             if session_name:
                 result = subprocess.run(
                     ["tmux", "has-session", "-t", session_name],
@@ -86,7 +86,7 @@ def kill_tmux_session(coral_dir: Path) -> None:
     for search_dir in [coral_dir / "public", coral_dir.parent]:
         tmux_file = search_dir / ".coral_tmux_session"
         if tmux_file.exists():
-            session_name = tmux_file.read_text().strip()
+            session_name = tmux_file.read_text(encoding="utf-8").strip()
             owned = _is_tmux_owned(search_dir)
             if session_name and owned:
                 result = subprocess.run(
@@ -108,14 +108,14 @@ def kill_tmux_session(coral_dir: Path) -> None:
         import yaml
 
         try:
-            with open(config_file) as f:
+            with open(config_file, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f) or {}
             task_dir = cfg.get("_task_dir")
             if task_dir:
                 task_path = Path(task_dir)
                 tmux_file = task_path / ".coral_tmux_session"
                 if tmux_file.exists():
-                    session_name = tmux_file.read_text().strip()
+                    session_name = tmux_file.read_text(encoding="utf-8").strip()
                     owned = _is_tmux_owned(task_path)
                     if session_name and owned:
                         subprocess.run(
@@ -321,7 +321,7 @@ def is_docker_run_alive(coral_dir: Path, *, quiet: bool = False) -> bool:
     run_dir = coral_dir.resolve().parent
     marker = run_dir / ".coral_docker_container"
     if marker.exists():
-        name = marker.read_text().strip()
+        name = marker.read_text(encoding="utf-8").strip()
         if name:
             return is_docker_container_running(name, quiet=quiet)
     return False
@@ -330,7 +330,7 @@ def is_docker_run_alive(coral_dir: Path, *, quiet: bool = False) -> bool:
 def save_docker_container_name(save_dir: Path, container_name: str) -> None:
     """Save the Docker container name for coral stop to find."""
     marker = save_dir / ".coral_docker_container"
-    marker.write_text(container_name)
+    marker.write_text(container_name, encoding="utf-8")
 
 
 def docker_private_volume_name(host_run_dir: Path) -> str:
@@ -352,7 +352,7 @@ def kill_docker_container(coral_dir: Path) -> None:
     for search_dir in [coral_dir / "public", coral_dir.parent]:
         marker = search_dir / ".coral_docker_container"
         if marker.exists():
-            container_name = marker.read_text().strip()
+            container_name = marker.read_text(encoding="utf-8").strip()
             if container_name:
                 stopped = (
                     subprocess.run(
@@ -388,7 +388,7 @@ def kill_ui(coral_dir: Path) -> None:
         ui_url_file.unlink(missing_ok=True)
         return
     try:
-        pid = int(ui_pid_file.read_text().strip())
+        pid = int(ui_pid_file.read_text(encoding="utf-8").strip())
         os.kill(pid, signal.SIGKILL)
         print(f"Stopped dashboard (PID {pid}).")
     except (ProcessLookupError, ValueError):
@@ -404,7 +404,7 @@ def kill_orphaned_agents(agent_pids_file: Path) -> None:
     if not agent_pids_file.exists():
         return
     killed = 0
-    for line in agent_pids_file.read_text().strip().splitlines():
+    for line in agent_pids_file.read_text(encoding="utf-8").strip().splitlines():
         try:
             pid = int(line.strip())
             os.killpg(os.getpgid(pid), signal.SIGKILL)
@@ -420,7 +420,7 @@ def read_agent_id(start: str | Path | None = None) -> str:
     """Read agent ID from the nearest .coral_agent_id breadcrumb."""
     agent_id_file = find_breadcrumb_file(".coral_agent_id", start)
     if agent_id_file is not None:
-        return agent_id_file.read_text().strip()
+        return agent_id_file.read_text(encoding="utf-8").strip()
     return "unknown"
 
 
@@ -441,7 +441,7 @@ def read_direction(coral_dir: Path) -> str:
     if config_path.exists():
         import yaml
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
         return (config.get("grader") or {}).get("direction", "maximize")
     return "maximize"

--- a/coral/cli/author.py
+++ b/coral/cli/author.py
@@ -79,7 +79,8 @@ def cmd_init(args: argparse.Namespace) -> None:
         f"  runtime: claude_code         # claude_code | codex | cursor | kiro | opencode | 'pkg.module:Cls' for a custom runtime\n"
         f"\n"
         f"workspace:\n"
-        f'  repo_path: "./seed"          # relative to where you run `coral start`\n'
+        f'  repo_path: "./seed"          # relative to where you run `coral start`\n',
+        encoding="utf-8",
     )
 
     (task_path / "seed" / "solution.py").write_text(
@@ -89,7 +90,8 @@ def cmd_init(args: argparse.Namespace) -> None:
         "from stdout as the score. Replace with your real implementation.\n"
         '"""\n'
         "\n"
-        "print(0.0)\n"
+        "print(0.0)\n",
+        encoding="utf-8",
     )
 
     (task_path / "grader" / "pyproject.toml").write_text(
@@ -107,7 +109,8 @@ def cmd_init(args: argparse.Namespace) -> None:
         f'build-backend = "hatchling.build"\n'
         f"\n"
         f"[tool.hatch.build.targets.wheel]\n"
-        f'packages = ["src/{module_name}"]\n'
+        f'packages = ["src/{module_name}"]\n',
+        encoding="utf-8",
     )
 
     (grader_pkg_dir / "__init__.py").write_text(
@@ -115,7 +118,8 @@ def cmd_init(args: argparse.Namespace) -> None:
         f"\n"
         f"from .grader import Grader\n"
         f"\n"
-        f'__all__ = ["Grader"]\n'
+        f'__all__ = ["Grader"]\n',
+        encoding="utf-8",
     )
 
     (grader_pkg_dir / "grader.py").write_text(
@@ -144,7 +148,8 @@ def cmd_init(args: argparse.Namespace) -> None:
         f"        try:\n"
         f"            return float(result.stdout.strip())\n"
         f"        except ValueError:\n"
-        f'            return self.fail(f"Expected a single float on stdout, got: {{result.stdout[:80]!r}}")\n'
+        f'            return self.fail(f"Expected a single float on stdout, got: {{result.stdout[:80]!r}}")\n',
+        encoding="utf-8",
     )
 
     print(f"Created task at {task_path}/")

--- a/coral/cli/eval.py
+++ b/coral/cli/eval.py
@@ -70,7 +70,7 @@ def _read_attempt_file(attempts_file: Path):
     if not attempts_file.exists():
         return None
     try:
-        return Attempt.from_dict(_json.loads(attempts_file.read_text()))
+        return Attempt.from_dict(_json.loads(attempts_file.read_text(encoding="utf-8")))
     except (_json.JSONDecodeError, KeyError, OSError):
         return None
 

--- a/coral/cli/query.py
+++ b/coral/cli/query.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -12,6 +11,7 @@ from pathlib import Path
 from coral.cli._helpers import (
     find_coral_dir_and_island,
     is_docker_container_running,
+    is_process_alive,
     read_direction,
 )
 
@@ -381,10 +381,10 @@ def _collect_runs(results_dir: Path) -> list[dict]:
             elif pid_file.exists():
                 try:
                     manager_pid = int(pid_file.read_text().strip())
-                    os.kill(manager_pid, 0)
-                    status = "running"
-                except (ProcessLookupError, PermissionError, ValueError):
+                except ValueError:
                     status = "stopped"
+                else:
+                    status = "running" if is_process_alive(manager_pid) else "stopped"
 
             logs_dir = coral_dir / "public" / "logs"
             agent_names: set[str] = set()

--- a/coral/cli/query.py
+++ b/coral/cli/query.py
@@ -144,7 +144,7 @@ def cmd_show(args: argparse.Namespace) -> None:
         return
     attempt_file = candidates[0]
 
-    data = json.loads(attempt_file.read_text())
+    data = json.loads(attempt_file.read_text(encoding="utf-8"))
     print(f"Commit:  {data['commit_hash']}")
     print(f"Agent:   {data['agent_id']}")
     print(f"Title:   {data['title']}")
@@ -375,12 +375,12 @@ def _collect_runs(results_dir: Path) -> list[dict]:
             # container-internal and meaningless on the host.
             docker_marker = run_dir / ".coral_docker_container"
             if docker_marker.exists():
-                container_name = docker_marker.read_text().strip()
+                container_name = docker_marker.read_text(encoding="utf-8").strip()
                 if container_name and is_docker_container_running(container_name):
                     status = "running"
             elif pid_file.exists():
                 try:
-                    manager_pid = int(pid_file.read_text().strip())
+                    manager_pid = int(pid_file.read_text(encoding="utf-8").strip())
                 except ValueError:
                     status = "stopped"
                 else:
@@ -402,7 +402,7 @@ def _collect_runs(results_dir: Path) -> list[dict]:
                 try:
                     import yaml
 
-                    cfg = yaml.safe_load(config_file.read_text()) or {}
+                    cfg = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
                     agents_cfg = cfg.get("agents", {})
                     model = agents_cfg.get("model", "")
                     runtime = agents_cfg.get("runtime", "")
@@ -428,7 +428,7 @@ def _collect_runs(results_dir: Path) -> list[dict]:
                     continue
                 for af in attempts_dir.glob("*.json"):
                     try:
-                        adata = json.loads(af.read_text())
+                        adata = json.loads(af.read_text(encoding="utf-8"))
                         attempt_count += 1
                         # `budget_class` is a derived field on Attempt
                         # (from metadata), not a top-level JSON key — go

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -26,6 +26,7 @@ from coral.cli._helpers import (
     in_docker,
     in_tmux,
     is_docker_run_alive,
+    is_process_alive,
     kill_docker_container,
     kill_orphaned_agents,
     kill_tmux_session,
@@ -669,21 +670,12 @@ def cmd_resume(args: argparse.Namespace) -> None:
     pid_file = coral_dir / "public" / "manager.pid"
     if pid_file.exists():
         pid = int(pid_file.read_text().strip())
-        try:
-            os.kill(pid, 0)
+        if is_process_alive(pid):
             print(
                 f"Error: Manager already running (PID {pid}). Stop it first with 'coral stop'.",
                 file=sys.stderr,
             )
             sys.exit(1)
-        except PermissionError:
-            print(
-                f"Error: Manager already running (PID {pid}). Stop it first with 'coral stop'.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        except ProcessLookupError:
-            pass
 
     from coral.workspace import reconstruct_paths
 
@@ -775,9 +767,7 @@ def _stop_one(coral_dir: Path) -> None:
 
             for _ in range(10):
                 time.sleep(0.5)
-                try:
-                    os.kill(pid, 0)
-                except (ProcessLookupError, PermissionError):
+                if not is_process_alive(pid):
                     print("Manager stopped.")
                     return
             print("Manager didn't stop gracefully. Force killing...")
@@ -887,15 +877,9 @@ def cmd_status(args: argparse.Namespace) -> None:
     manager_alive = False
     if pid_file.exists():
         pid = int(pid_file.read_text().strip())
-        try:
-            os.kill(pid, 0)
+        if is_process_alive(pid):
             manager_alive = True
             print(f"Manager: RUNNING (PID {pid})")
-        except PermissionError:
-            manager_alive = True
-            print(f"Manager: RUNNING (PID {pid})")
-        except ProcessLookupError:
-            pass
 
     # Check if managed by a Docker container
     if not manager_alive and is_docker_run_alive(coral_dir):

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -356,8 +356,8 @@ def _start_in_docker(args: argparse.Namespace, config: CoralConfig) -> None:
     _run_docker_container(docker_cmd, container_name)
 
     save_docker_container_name(host_run_dir, container_name)
-    (host_run_dir / ".coral_host_repo_path").write_text(str(repo_path))
-    (host_run_dir / ".coral_host_config_dir").write_text(str(config_dir))
+    (host_run_dir / ".coral_host_repo_path").write_text(str(repo_path), encoding="utf-8")
+    (host_run_dir / ".coral_host_config_dir").write_text(str(config_dir), encoding="utf-8")
 
     # Create the "latest" symlink on the host
     latest_link = host_task_dir / "latest"
@@ -521,7 +521,7 @@ def cmd_start(args: argparse.Namespace) -> None:
     start_cmd = f"coral start -c {args.config}"
     if overrides:
         start_cmd += " " + " ".join(overrides)
-    (manager.paths.run_dir / "start_cmd.txt").write_text(start_cmd + "\n")
+    (manager.paths.run_dir / "start_cmd.txt").write_text(start_cmd + "\n", encoding="utf-8")
 
     print(f"\nRun directory: {manager.paths.run_dir}")
     print(f"Logs:          {manager.paths.coral_dir / 'public' / 'logs'}")
@@ -567,12 +567,12 @@ def _resume_in_docker(args: argparse.Namespace, config: CoralConfig, coral_dir: 
     config_dir_file = host_run_dir / ".coral_host_config_dir"
     repo_path_file = host_run_dir / ".coral_host_repo_path"
     config_dir = (
-        Path(config_dir_file.read_text().strip())
+        Path(config_dir_file.read_text(encoding="utf-8").strip())
         if config_dir_file.exists()
         else Path(config.task_dir or Path.cwd()).resolve()
     )
     repo_path = (
-        Path(repo_path_file.read_text().strip())
+        Path(repo_path_file.read_text(encoding="utf-8").strip())
         if repo_path_file.exists()
         else Path(config.workspace.repo_path).resolve()
     )
@@ -669,7 +669,7 @@ def cmd_resume(args: argparse.Namespace) -> None:
 
     pid_file = coral_dir / "public" / "manager.pid"
     if pid_file.exists():
-        pid = int(pid_file.read_text().strip())
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
         if is_process_alive(pid):
             print(
                 f"Error: Manager already running (PID {pid}). Stop it first with 'coral stop'.",
@@ -684,7 +684,7 @@ def cmd_resume(args: argparse.Namespace) -> None:
     # Restore task_dir so relative paths (e.g. gateway config) resolve correctly
     config_dir_file = coral_dir / "config_dir"
     if config_dir_file.exists():
-        config.task_dir = Path(config_dir_file.read_text().strip())
+        config.task_dir = Path(config_dir_file.read_text(encoding="utf-8").strip())
 
     latest_link = paths.task_dir / "latest"
     if latest_link.is_symlink():
@@ -759,7 +759,7 @@ def _stop_one(coral_dir: Path) -> None:
             kill_orphaned_agents(agent_pids_file)
             return
 
-        pid = int(pid_file.read_text().strip())
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
         try:
             os.kill(pid, signal.SIGTERM)
             print(f"Sent SIGTERM to manager (PID {pid}).")
@@ -799,7 +799,7 @@ def _current_agent_islands(run_dir: Path) -> dict[str, str]:
         if not island_file.exists():
             continue
         try:
-            island_id = island_file.read_text().strip()
+            island_id = island_file.read_text(encoding="utf-8").strip()
         except OSError:
             continue
         if island_id:
@@ -876,7 +876,7 @@ def cmd_status(args: argparse.Namespace) -> None:
     pid_file = coral_dir / "public" / "manager.pid"
     manager_alive = False
     if pid_file.exists():
-        pid = int(pid_file.read_text().strip())
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
         if is_process_alive(pid):
             manager_alive = True
             print(f"Manager: RUNNING (PID {pid})")
@@ -885,7 +885,11 @@ def cmd_status(args: argparse.Namespace) -> None:
     if not manager_alive and is_docker_run_alive(coral_dir):
         manager_alive = True
         docker_marker = run_dir / ".coral_docker_container"
-        container_name = docker_marker.read_text().strip() if docker_marker.exists() else "unknown"
+        container_name = (
+            docker_marker.read_text(encoding="utf-8").strip()
+            if docker_marker.exists()
+            else "unknown"
+        )
         print(f"Manager: RUNNING (Docker container {container_name})")
 
     if not manager_alive:

--- a/coral/cli/ui.py
+++ b/coral/cli/ui.py
@@ -166,11 +166,13 @@ def start_ui_background(
 
     if pid_file.exists():
         try:
-            existing_pid = int(pid_file.read_text().strip())
+            existing_pid = int(pid_file.read_text(encoding="utf-8").strip())
         except (OSError, ValueError):
             existing_pid = 0
         if is_process_alive(existing_pid):
-            existing_url = url_file.read_text().strip() if url_file.exists() else "dashboard"
+            existing_url = (
+                url_file.read_text(encoding="utf-8").strip() if url_file.exists() else "dashboard"
+            )
             print(f"Dashboard already running: {existing_url}")
             if existing_url.startswith("http"):
                 webbrowser.open(existing_url)
@@ -209,7 +211,7 @@ def start_ui_background(
         "--no-open",
     ]
     log_path = public_dir / "ui.log"
-    with log_path.open("a") as log_file:
+    with log_path.open("a", encoding="utf-8") as log_file:
         process = subprocess.Popen(
             command,
             cwd=results_dir.parent,
@@ -218,8 +220,8 @@ def start_ui_background(
             start_new_session=True,
         )
 
-    pid_file.write_text(str(process.pid))
-    url_file.write_text(url + "\n")
+    pid_file.write_text(str(process.pid), encoding="utf-8")
+    url_file.write_text(url + "\n", encoding="utf-8")
 
     print(f"Dashboard:     {url}")
     webbrowser.open(url)
@@ -260,8 +262,8 @@ def cmd_ui(args: argparse.Namespace) -> None:
     url_file = coral_dir / "public" / "ui.url"
 
     pid_file.parent.mkdir(parents=True, exist_ok=True)
-    pid_file.write_text(str(os.getpid()))
-    url_file.write_text(url + "\n")
+    pid_file.write_text(str(os.getpid()), encoding="utf-8")
+    url_file.write_text(url + "\n", encoding="utf-8")
 
     if not args.no_open:
         webbrowser.open(url)

--- a/coral/cli/ui.py
+++ b/coral/cli/ui.py
@@ -11,7 +11,7 @@ import sys
 import webbrowser
 from pathlib import Path
 
-from coral.cli._helpers import find_coral_dir
+from coral.cli._helpers import find_coral_dir, is_process_alive
 
 DEFAULT_UI_PORT = 8420
 UI_PORT_SEARCH_LIMIT = 20
@@ -167,15 +167,16 @@ def start_ui_background(
     if pid_file.exists():
         try:
             existing_pid = int(pid_file.read_text().strip())
-            os.kill(existing_pid, 0)
+        except (OSError, ValueError):
+            existing_pid = 0
+        if is_process_alive(existing_pid):
             existing_url = url_file.read_text().strip() if url_file.exists() else "dashboard"
             print(f"Dashboard already running: {existing_url}")
             if existing_url.startswith("http"):
                 webbrowser.open(existing_url)
             return
-        except (OSError, ValueError):
-            pid_file.unlink(missing_ok=True)
-            url_file.unlink(missing_ok=True)
+        pid_file.unlink(missing_ok=True)
+        url_file.unlink(missing_ok=True)
 
     if not _port_available(host, port):
         fallback_port = _find_available_port(host, port + 1)

--- a/coral/config.py
+++ b/coral/config.py
@@ -451,7 +451,7 @@ class CoralConfig:
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> CoralConfig:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         return cls.from_dict(data, base_dir=Path(path).parent)
 
@@ -491,7 +491,7 @@ class CoralConfig:
         return container
 
     def to_yaml(self, path: str | Path) -> None:
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump(self.to_dict(), f, default_flow_style=False, sort_keys=False)
 
     @classmethod
@@ -628,7 +628,7 @@ def _load_preset(ref: Any, base_dir: Path | None) -> dict[str, Any]:
     if not isinstance(ref, str) or not ref.strip():
         raise ValueError(f"preset must be a non-empty string, got {ref!r}")
     path = _resolve_preset_path(ref.strip(), base_dir)
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         loaded = yaml.safe_load(f) or {}
     if not isinstance(loaded, dict):
         raise ValueError(f"Preset {path} must contain a YAML mapping, got {type(loaded).__name__}")

--- a/coral/gateway/config.py
+++ b/coral/gateway/config.py
@@ -120,7 +120,7 @@ def generate_default_litellm_config(path: Path, model: str = "sonnet") -> Path:
     }
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 
     logger.info(f"Generated default LiteLLM config at {path}")

--- a/coral/gateway/middleware.py
+++ b/coral/gateway/middleware.py
@@ -97,7 +97,7 @@ class CoralGatewayMiddleware:
     def _log_entry(self, entry: dict[str, Any]) -> None:
         """Append a JSONL entry to the log file."""
         try:
-            with open(self._log_path, "a") as f:
+            with open(self._log_path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(entry, default=str) + "\n")
         except Exception as e:
             logger.warning(f"Failed to write gateway log: {e}")

--- a/coral/grader/daemon.py
+++ b/coral/grader/daemon.py
@@ -232,7 +232,7 @@ def _attempt_island_id(attempt: Attempt) -> str | None:
 
 def _read_attempt_file(path: Path) -> Attempt | None:
     try:
-        return Attempt.from_dict(json.loads(path.read_text()))
+        return Attempt.from_dict(json.loads(path.read_text(encoding="utf-8")))
     except (json.JSONDecodeError, KeyError, OSError, TypeError):
         return None
 
@@ -559,7 +559,7 @@ def _find_pending(coral_dir: Path) -> list[Attempt]:
             continue
         for p in sorted(d.glob("*.json")):
             try:
-                data = json.loads(p.read_text())
+                data = json.loads(p.read_text(encoding="utf-8"))
                 a = Attempt.from_dict(data)
             except Exception:
                 continue
@@ -663,7 +663,7 @@ def _drain_pending(
             for fut in as_completed(futures):
                 if heartbeat_file is not None:
                     try:
-                        heartbeat_file.write_text(datetime.now(UTC).isoformat())
+                        heartbeat_file.write_text(datetime.now(UTC).isoformat(), encoding="utf-8")
                     except OSError:
                         pass
                 result = fut.result()
@@ -722,7 +722,7 @@ def run_daemon(coral_dir: str | Path, stop_event: Any = None) -> None:
     )
     started_at = datetime.now(UTC).isoformat()
     heartbeat_file = coral_dir / "public" / "grader_daemon_heartbeat"
-    heartbeat_file.write_text(started_at)
+    heartbeat_file.write_text(started_at, encoding="utf-8")
 
     def _should_stop() -> bool:
         return bool(stop_event and stop_event.is_set())
@@ -737,7 +737,7 @@ def run_daemon(coral_dir: str | Path, stop_event: Any = None) -> None:
         if not pending:
             # Idle heartbeat so supervisors can tell the daemon is alive.
             try:
-                heartbeat_file.write_text(datetime.now(UTC).isoformat())
+                heartbeat_file.write_text(datetime.now(UTC).isoformat(), encoding="utf-8")
             except OSError:
                 pass
             time.sleep(_POLL_INTERVAL_SEC)

--- a/coral/hooks/post_commit.py
+++ b/coral/hooks/post_commit.py
@@ -197,7 +197,7 @@ def submit_eval(
         parent_attempt_file = island_root(coral_dir, island_id) / "attempts" / f"{parent_hash}.json"
         if parent_attempt_file.exists():
             try:
-                parent_data = json.loads(parent_attempt_file.read_text())
+                parent_data = json.loads(parent_attempt_file.read_text(encoding="utf-8"))
                 parent_shared_state_hash = parent_data.get("shared_state_hash")
             except (json.JSONDecodeError, OSError):
                 pass

--- a/coral/hub/attempts.py
+++ b/coral/hub/attempts.py
@@ -33,7 +33,7 @@ def _write_attempt_json(path: Path, attempt: Attempt) -> None:
         dir=path.parent,
     )
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(payload)
             f.flush()
             os.fsync(f.fileno())
@@ -68,7 +68,7 @@ def read_attempt(
     if not path.exists():
         return None
     try:
-        return Attempt.from_dict(json.loads(path.read_text()))
+        return Attempt.from_dict(json.loads(path.read_text(encoding="utf-8")))
     except (json.JSONDecodeError, KeyError, OSError):
         return None
 
@@ -84,7 +84,7 @@ def set_user_best(coral_dir: str | Path, commit_hash: str) -> Attempt | None:
             continue
         for path in sorted(attempts_dir.glob("*.json")):
             try:
-                attempt = Attempt.from_dict(json.loads(path.read_text()))
+                attempt = Attempt.from_dict(json.loads(path.read_text(encoding="utf-8")))
             except (json.JSONDecodeError, KeyError, OSError):
                 continue
             is_target = attempt.commit_hash == commit_hash
@@ -126,7 +126,7 @@ def archive_attempts(
             if not path.exists():
                 continue
             try:
-                attempt = Attempt.from_dict(json.loads(path.read_text()))
+                attempt = Attempt.from_dict(json.loads(path.read_text(encoding="utf-8")))
             except (json.JSONDecodeError, KeyError, OSError):
                 continue
             attempt.metadata["archived"] = True
@@ -161,12 +161,12 @@ def increment_eval_count(coral_dir: str | Path, island_id: str | int | None = No
         count = 0
         if p.exists():
             try:
-                count = int(p.read_text().strip())
+                count = int(p.read_text(encoding="utf-8").strip())
             except ValueError:
                 pass
         count += 1
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(str(count))
+        p.write_text(str(count), encoding="utf-8")
         return count
 
     global_path = _global_eval_count_path(coral_dir)
@@ -191,7 +191,7 @@ def read_eval_count(coral_dir: str | Path, island_id: str | int | None = None) -
     if not path.exists():
         return 0
     try:
-        return int(path.read_text().strip())
+        return int(path.read_text(encoding="utf-8").strip())
     except ValueError:
         return 0
 
@@ -206,7 +206,7 @@ def read_attempts(coral_dir: str | Path, island_id: str | int | None = None) -> 
     attempts = []
     for f in sorted(d.glob("*.json")):
         try:
-            data = json.loads(f.read_text())
+            data = json.loads(f.read_text(encoding="utf-8"))
             attempts.append(Attempt.from_dict(data))
         except (json.JSONDecodeError, KeyError):
             continue

--- a/coral/hub/auto_stop.py
+++ b/coral/hub/auto_stop.py
@@ -27,7 +27,7 @@ def write_auto_stop(coral_dir: str | Path, payload: dict[str, Any]) -> Path:
         dir=path.parent,
     )
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(text)
             f.flush()
             os.fsync(f.fileno())
@@ -47,7 +47,7 @@ def read_auto_stop(coral_dir: str | Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
     return data if isinstance(data, dict) else None

--- a/coral/hub/checkpoint.py
+++ b/coral/hub/checkpoint.py
@@ -47,7 +47,7 @@ def init_checkpoint_repo(coral_dir: str, island_id: str | int | None = None) -> 
             check=True,
         )
         gitignore = root / ".gitignore"
-        gitignore.write_text("coral.lock\n")
+        gitignore.write_text("coral.lock\n", encoding="utf-8")
         subprocess.run(
             ["git", "add", "-A"],
             cwd=str(root),
@@ -84,7 +84,7 @@ def checkpoint(
     lock_path = root / ".git" / "coral.lock"
     try:
         lock_path.touch(exist_ok=True)
-        with open(lock_path) as lock_fd:
+        with open(lock_path, encoding="utf-8") as lock_fd:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
 
             subprocess.run(

--- a/coral/hub/heartbeat.py
+++ b/coral/hub/heartbeat.py
@@ -26,7 +26,7 @@ def _load_prompt(name: str) -> str:
     """Load a prompt template from the prompts directory."""
     prompt_file = _PROMPTS_DIR / f"{name}.md"
     if prompt_file.exists():
-        return prompt_file.read_text()
+        return prompt_file.read_text(encoding="utf-8")
     return ""
 
 
@@ -84,7 +84,7 @@ def _read_actions(path: Path) -> list[dict]:
     if not path.exists():
         return []
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         return data.get("actions", [])
     except (json.JSONDecodeError, OSError) as e:
         logger.warning(f"Failed to read heartbeat config {path.name}: {e}")

--- a/coral/hub/notes.py
+++ b/coral/hub/notes.py
@@ -210,7 +210,7 @@ def _parse_legacy_entries(text: str) -> list[dict[str, Any]]:
 
 def _parse_note_file(path: Path) -> dict[str, Any]:
     """Parse a single note .md file into an entry dict."""
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     meta, body = _parse_frontmatter(text)
 
     # Title: prefer a body `# heading`, then a frontmatter `title:`, then the
@@ -271,7 +271,7 @@ def _parse_raw_source_file(path: Path) -> dict[str, Any]:
     into the shared ``date`` / ``creator`` slots the dashboard already renders.
     """
     entry = _parse_note_file(path)
-    meta, _ = _parse_frontmatter(path.read_text())
+    meta, _ = _parse_frontmatter(path.read_text(encoding="utf-8"))
 
     url = _first_present(meta, ("source_url", "url"))
     if url:
@@ -302,12 +302,12 @@ def _collect_from_dir(directory: Path) -> list[dict[str, Any]]:
         entries = [_parse_note_file(f) for f in md_files]
         legacy = directory / "notes.md"
         if legacy.exists() and legacy.stat().st_size > 0:
-            entries.extend(_parse_legacy_entries(legacy.read_text()))
+            entries.extend(_parse_legacy_entries(legacy.read_text(encoding="utf-8")))
         return entries
 
     legacy = directory / "notes.md"
     if legacy.exists() and legacy.stat().st_size > 0:
-        return _parse_legacy_entries(legacy.read_text())
+        return _parse_legacy_entries(legacy.read_text(encoding="utf-8"))
 
     return []
 
@@ -508,7 +508,7 @@ def notes_by(
     matched: list[Path] = []
     for md_file in _iter_user_note_files(notes_dir):
         try:
-            text = md_file.read_text()
+            text = md_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
         meta, _ = _parse_frontmatter(text)
@@ -533,7 +533,7 @@ def notes_unattributed(
     missing: list[Path] = []
     for md_file in _iter_user_note_files(notes_dir):
         try:
-            text = md_file.read_text()
+            text = md_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
         meta, _ = _parse_frontmatter(text)

--- a/coral/hub/skills.py
+++ b/coral/hub/skills.py
@@ -70,7 +70,7 @@ def _list_skills_single(coral_dir: Path, island_id: str | int | None) -> list[di
         if not skill_md.exists():
             continue
 
-        text = skill_md.read_text()
+        text = skill_md.read_text(encoding="utf-8")
         meta, body = _parse_frontmatter(text)
 
         results.append(
@@ -102,7 +102,7 @@ def read_skill(skill_dir: str | Path) -> dict[str, Any]:
     skill_dir = Path(skill_dir)
     skill_md = skill_dir / "SKILL.md"
 
-    content = skill_md.read_text() if skill_md.exists() else ""
+    content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else ""
     meta, body = _parse_frontmatter(content)
 
     files = []
@@ -158,7 +158,7 @@ def skills_by(
         if not skill_md.exists():
             continue
         try:
-            text = skill_md.read_text()
+            text = skill_md.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
         meta, _ = _parse_frontmatter(text)

--- a/coral/hub/steering.py
+++ b/coral/hub/steering.py
@@ -88,7 +88,7 @@ def read_pending(coral_dir: str | Path) -> list[SteeringAction]:
     actions: list[SteeringAction] = []
     for path in sorted(_steering_dir(coral_dir).glob("*.json")):
         try:
-            action = SteeringAction.from_dict(json.loads(path.read_text()))
+            action = SteeringAction.from_dict(json.loads(path.read_text(encoding="utf-8")))
         except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError):
             continue
         if action.applied_at is None:
@@ -103,7 +103,7 @@ def mark_applied(coral_dir: str | Path, action_id: str) -> bool:
     if not path.exists():
         return False
     try:
-        action = SteeringAction.from_dict(json.loads(path.read_text()))
+        action = SteeringAction.from_dict(json.loads(path.read_text(encoding="utf-8")))
     except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError):
         return False
     action.applied_at = _now()
@@ -126,7 +126,7 @@ def _now() -> str:
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     fd, tmp_path = tempfile.mkstemp(prefix=f".{path.stem}.", suffix=".tmp", dir=path.parent)
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2)
             f.write("\n")
             f.flush()

--- a/coral/sandbox/srt.py
+++ b/coral/sandbox/srt.py
@@ -112,7 +112,7 @@ class SrtSandbox:
         settings_dir = ctx.coral_dir / "private" / "sandbox"
         settings_dir.mkdir(parents=True, exist_ok=True)
         settings_path = settings_dir / f"{ctx.agent_id}.json"
-        settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+        settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
 
         try:
             _SRT_TMPDIR.mkdir(exist_ok=True)
@@ -224,7 +224,7 @@ def _runtime_home_paths(shared_dir_name: str) -> list[str]:
 def _worktree_island(worktree: Path) -> str | None:
     """Read a worktree's island membership from its .coral_island breadcrumb."""
     try:
-        return (worktree / ".coral_island").read_text().strip() or None
+        return (worktree / ".coral_island").read_text(encoding="utf-8").strip() or None
     except OSError:
         return None
 

--- a/coral/template/coral_md.py
+++ b/coral/template/coral_md.py
@@ -27,7 +27,7 @@ def generate_coral_md(
         island_id: Agent's island in multi-island mode (formats a provenance hint)
     """
     template_path = _SINGLE_TEMPLATE_PATH if single_agent else _TEMPLATE_PATH
-    template = template_path.read_text()
+    template = template_path.read_text(encoding="utf-8")
 
     # Build optional sections
     tips_section = ""

--- a/coral/template/skills/skill-creator/eval-viewer/generate_review.py
+++ b/coral/template/skills/skill-creator/eval-viewer/generate_review.py
@@ -114,7 +114,7 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
     for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
         if candidate.exists():
             try:
-                metadata = json.loads(candidate.read_text())
+                metadata = json.loads(candidate.read_text(encoding="utf-8"))
                 prompt = metadata.get("prompt", "")
                 eval_id = metadata.get("eval_id")
             except (json.JSONDecodeError, OSError):
@@ -127,7 +127,7 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
         for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
             if candidate.exists():
                 try:
-                    text = candidate.read_text()
+                    text = candidate.read_text(encoding="utf-8")
                     match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
                     if match:
                         prompt = match.group(1).strip()
@@ -154,7 +154,7 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
     for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
         if candidate.exists():
             try:
-                grading = json.loads(candidate.read_text())
+                grading = json.loads(candidate.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 pass
             if grading:
@@ -176,7 +176,7 @@ def embed_file(path: Path) -> dict:
 
     if ext in TEXT_EXTENSIONS:
         try:
-            content = path.read_text(errors="replace")
+            content = path.read_text(errors="replace", encoding="utf-8")
         except OSError:
             content = "(Error reading file)"
         return {
@@ -245,7 +245,7 @@ def load_previous_iteration(workspace: Path) -> dict[str, dict]:
     feedback_path = workspace / "feedback.json"
     if feedback_path.exists():
         try:
-            data = json.loads(feedback_path.read_text())
+            data = json.loads(feedback_path.read_text(encoding="utf-8"))
             feedback_map = {
                 r["run_id"]: r["feedback"]
                 for r in data.get("reviews", [])
@@ -278,7 +278,7 @@ def generate_html(
 ) -> str:
     """Generate the complete standalone HTML page with embedded data."""
     template_path = Path(__file__).parent / "viewer.html"
-    template = template_path.read_text()
+    template = template_path.read_text(encoding="utf-8")
 
     # Build previous_feedback and previous_outputs maps for the template
     previous_feedback: dict[str, str] = {}
@@ -363,7 +363,7 @@ class ReviewHandler(BaseHTTPRequestHandler):
             benchmark = None
             if self.benchmark_path and self.benchmark_path.exists():
                 try:
-                    benchmark = json.loads(self.benchmark_path.read_text())
+                    benchmark = json.loads(self.benchmark_path.read_text(encoding="utf-8"))
                 except (json.JSONDecodeError, OSError):
                     pass
             html = generate_html(runs, self.skill_name, self.previous, benchmark)
@@ -393,7 +393,7 @@ class ReviewHandler(BaseHTTPRequestHandler):
                 data = json.loads(body)
                 if not isinstance(data, dict) or "reviews" not in data:
                     raise ValueError("Expected JSON object with 'reviews' key")
-                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
                 resp = b'{"ok":true}'
                 self.send_response(200)
             except (json.JSONDecodeError, OSError, ValueError) as e:
@@ -458,14 +458,14 @@ def main() -> None:
     benchmark = None
     if benchmark_path and benchmark_path.exists():
         try:
-            benchmark = json.loads(benchmark_path.read_text())
+            benchmark = json.loads(benchmark_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
 
     if args.static:
         html = generate_html(runs, skill_name, previous, benchmark)
         args.static.parent.mkdir(parents=True, exist_ok=True)
-        args.static.write_text(html)
+        args.static.write_text(html, encoding="utf-8")
         print(f"\n  Static viewer written to: {args.static}\n")
         sys.exit(0)
 

--- a/coral/user_agents.py
+++ b/coral/user_agents.py
@@ -114,7 +114,7 @@ def load_store(path: Path | None = None) -> BindingStore:
     path = path or user_config_path()
     if not path.exists():
         return BindingStore(path=path)
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     if not isinstance(data, dict):
         raise ValueError(f"{path}: top-level content must be a mapping")
@@ -136,7 +136,7 @@ def save_store(store: BindingStore, path: Path | None = None) -> Path:
     if store.default:
         out["default"] = store.default
     out["agents"] = {name: b.to_dict() for name, b in store.bindings.items()}
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.dump(out, f, default_flow_style=False, sort_keys=True)
     return path
 

--- a/coral/web/api.py
+++ b/coral/web/api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any
 
@@ -11,7 +10,7 @@ import yaml
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from coral.cli._helpers import is_docker_run_alive
+from coral.cli._helpers import is_docker_run_alive, is_process_alive
 
 
 def _coral_dir(request: Request) -> Path:
@@ -23,10 +22,10 @@ def _run_is_alive(coral_dir: Path) -> bool:
     if pid_file.exists():
         try:
             pid = int(pid_file.read_text().strip())
-            os.kill(pid, 0)
+        except (OSError, ValueError):
+            pid = 0
+        if is_process_alive(pid):
             return True
-        except (ProcessLookupError, PermissionError, ValueError):
-            pass
     return is_docker_run_alive(coral_dir, quiet=True)
 
 
@@ -561,10 +560,10 @@ async def get_status(request: Request) -> JSONResponse:
     if pid_file.exists():
         try:
             manager_pid = int(pid_file.read_text().strip())
-            os.kill(manager_pid, 0)
-            manager_alive = True
-        except (ProcessLookupError, PermissionError, ValueError):
-            pass
+        except (OSError, ValueError):
+            manager_pid = None
+        if manager_pid is not None:
+            manager_alive = is_process_alive(manager_pid)
     is_docker = not manager_alive and is_docker_run_alive(coral_dir, quiet=True)
     if is_docker:
         manager_alive = True
@@ -605,13 +604,9 @@ async def get_status(request: Request) -> JSONResponse:
         if pids_file.exists():
             try:
                 for line in pids_file.read_text().strip().splitlines():
-                    pid = int(line.strip())
-                    try:
-                        os.kill(pid, 0)
+                    if is_process_alive(int(line.strip())):
                         any_agent_alive = True
                         break
-                    except (ProcessLookupError, PermissionError):
-                        pass
             except (ValueError, OSError):
                 pass
 
@@ -628,11 +623,7 @@ async def get_status(request: Request) -> JSONResponse:
         agent_pid = agent_pid_map.get(agent_id)
         if agent_pid:
             # Direct PID check — most reliable
-            try:
-                os.kill(agent_pid, 0)
-                status = "active"
-            except (ProcessLookupError, PermissionError):
-                status = "stopped"
+            status = "active" if is_process_alive(agent_pid) else "stopped"
         elif any_agent_alive or is_docker:
             # Container or agent.pids says something is running but no per-agent mapping
             status = "active" if age < 300 else "idle"

--- a/coral/web/api.py
+++ b/coral/web/api.py
@@ -21,7 +21,7 @@ def _run_is_alive(coral_dir: Path) -> bool:
     pid_file = coral_dir / "public" / "manager.pid"
     if pid_file.exists():
         try:
-            pid = int(pid_file.read_text().strip())
+            pid = int(pid_file.read_text(encoding="utf-8").strip())
         except (OSError, ValueError):
             pid = 0
         if is_process_alive(pid):
@@ -35,7 +35,7 @@ async def get_config(request: Request) -> JSONResponse:
     if not config_path.exists():
         return JSONResponse({"error": "config.yaml not found"}, status_code=404)
 
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         config = yaml.safe_load(f)
     return JSONResponse(config)
 
@@ -81,14 +81,14 @@ async def get_attempt_detail(request: Request) -> JSONResponse:
     for view_root in all_view_roots(coral_dir):
         candidate = view_root / "attempts" / f"{commit_hash}.json"
         if candidate.exists():
-            return JSONResponse(json.loads(candidate.read_text()))
+            return JSONResponse(json.loads(candidate.read_text(encoding="utf-8")))
 
     # Prefix match — ambiguous across islands → 404 rather than guessing.
     matches: list[Path] = []
     for view_root in all_view_roots(coral_dir):
         matches.extend((view_root / "attempts").glob(f"{commit_hash}*.json"))
     if len(matches) == 1:
-        return JSONResponse(json.loads(matches[0].read_text()))
+        return JSONResponse(json.loads(matches[0].read_text(encoding="utf-8")))
     return JSONResponse({"error": "attempt not found"}, status_code=404)
 
 
@@ -338,7 +338,7 @@ def _direction(request: Request) -> str:
     """Read grader direction from config. Returns 'maximize' or 'minimize'."""
     config_path = _coral_dir(request) / "config.yaml"
     if config_path.exists():
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
         return (config.get("grader") or {}).get("direction", "maximize")
     return "maximize"
@@ -559,7 +559,7 @@ async def get_status(request: Request) -> JSONResponse:
     manager_pid = None
     if pid_file.exists():
         try:
-            manager_pid = int(pid_file.read_text().strip())
+            manager_pid = int(pid_file.read_text(encoding="utf-8").strip())
         except (OSError, ValueError):
             manager_pid = None
         if manager_pid is not None:
@@ -593,7 +593,7 @@ async def get_status(request: Request) -> JSONResponse:
     pid_map_file = coral_dir / "public" / "agent_pids.json"
     if not is_docker and pid_map_file.exists():
         try:
-            agent_pid_map = json.loads(pid_map_file.read_text())
+            agent_pid_map = json.loads(pid_map_file.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -603,7 +603,7 @@ async def get_status(request: Request) -> JSONResponse:
         pids_file = coral_dir / "public" / "agent.pids"
         if pids_file.exists():
             try:
-                for line in pids_file.read_text().strip().splitlines():
+                for line in pids_file.read_text(encoding="utf-8").strip().splitlines():
                     if is_process_alive(int(line.strip())):
                         any_agent_alive = True
                         break

--- a/coral/workspace/breadcrumbs.py
+++ b/coral/workspace/breadcrumbs.py
@@ -26,7 +26,7 @@ def find_coral_breadcrumb(start: str | Path | None = None) -> tuple[Path, Path] 
         breadcrumb = cur / ".coral_dir"
         if breadcrumb.exists():
             try:
-                coral_dir = Path(breadcrumb.read_text().strip()).resolve()
+                coral_dir = Path(breadcrumb.read_text(encoding="utf-8").strip()).resolve()
             except (OSError, ValueError):
                 coral_dir = None
             if coral_dir is not None and coral_dir.is_dir():
@@ -42,7 +42,7 @@ def read_island_breadcrumb(coral_dir: Path, breadcrumb_dir: Path) -> str | None:
     if not island_file.exists():
         return None
     try:
-        island_id = island_file.read_text().strip()
+        island_id = island_file.read_text(encoding="utf-8").strip()
     except OSError:
         return None
     if island_id and (coral_dir / "islands" / island_id).is_dir():

--- a/coral/workspace/grader_env.py
+++ b/coral/workspace/grader_env.py
@@ -68,7 +68,7 @@ def _coral_install_origin() -> dict:
             "git+https://github.com/Human-Agent-Society/CORAL.git` or "
             "`git clone ... && uv sync`."
         )
-    return json.loads(direct_url.read_text())
+    return json.loads(direct_url.read_text(encoding="utf-8"))
 
 
 def _coral_install_command(origin: dict) -> str:

--- a/coral/workspace/project.py
+++ b/coral/workspace/project.py
@@ -167,12 +167,12 @@ def seed_agent_role(
         return dst
 
     if source is None:
-        template = _ROLE_TEMPLATE_PATH.read_text()
+        template = _ROLE_TEMPLATE_PATH.read_text(encoding="utf-8")
         rendered = template.format(
             agent_id=agent_id,
             created_at=datetime.now().isoformat(),
         )
-        dst.write_text(rendered)
+        dst.write_text(rendered, encoding="utf-8")
         return dst
 
     src = Path(source).expanduser()
@@ -271,7 +271,7 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
     config.to_yaml(coral_dir / "config.yaml")
 
     # Save config_dir so resume can restore task_dir for relative path resolution
-    (coral_dir / "config_dir").write_text(str(effective_config_dir))
+    (coral_dir / "config_dir").write_text(str(effective_config_dir), encoding="utf-8")
 
     # Create/update "latest" symlink at task_dir/latest -> this run directory
     latest_link = task_dir / "latest"

--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -136,19 +136,19 @@ def setup_git_exclude(worktree_path: Path) -> None:
     # Preserve existing entries
     existing = set()
     if exclude_path.exists():
-        existing = set(exclude_path.read_text().splitlines())
+        existing = set(exclude_path.read_text(encoding="utf-8").splitlines())
 
     missing = entries - existing
     if missing:
         exclude_path.parent.mkdir(parents=True, exist_ok=True)
-        with exclude_path.open("a") as f:
+        with exclude_path.open("a", encoding="utf-8") as f:
             for entry in sorted(missing):
                 f.write(f"{entry}\n")
 
 
 def write_agent_id(worktree_path: Path, agent_id: str) -> None:
     """Write .coral_agent_id file in the worktree."""
-    (worktree_path / ".coral_agent_id").write_text(agent_id)
+    (worktree_path / ".coral_agent_id").write_text(agent_id, encoding="utf-8")
 
 
 def write_coral_dir(worktree_path: Path, coral_dir: Path) -> None:
@@ -157,14 +157,14 @@ def write_coral_dir(worktree_path: Path, coral_dir: Path) -> None:
     Hooks and graders read this file to locate shared state (attempts, config,
     private grader data) without needing a symlink in the worktree.
     """
-    (worktree_path / ".coral_dir").write_text(str(coral_dir.resolve()))
+    (worktree_path / ".coral_dir").write_text(str(coral_dir.resolve()), encoding="utf-8")
 
 
 def get_coral_dir(worktree_path: Path) -> Path | None:
     """Read the shared .coral directory path from the .coral_dir breadcrumb file."""
     ref_file = worktree_path / ".coral_dir"
     if ref_file.exists():
-        return Path(ref_file.read_text().strip())
+        return Path(ref_file.read_text(encoding="utf-8").strip())
     return None
 
 
@@ -181,7 +181,7 @@ def grader_source_dir(coral_dir: Path) -> Path | None:
     cfg_file = coral_dir / "config_dir"
     if not cfg_file.exists():
         return None
-    grader = Path(cfg_file.read_text().strip()) / "grader"
+    grader = Path(cfg_file.read_text(encoding="utf-8").strip()) / "grader"
     return grader if grader.is_dir() else None
 
 
@@ -264,7 +264,7 @@ def setup_shared_state(
     # callers (no island_id) deliberately do NOT get this file — its absence
     # is how downstream code (submit_eval, monitor_loop) distinguishes modes.
     if island_id is not None:
-        (worktree_path / ".coral_island").write_text(str(island_id))
+        (worktree_path / ".coral_island").write_text(str(island_id), encoding="utf-8")
 
 
 # Items inside the shared dir that are agent-facing symlinks into the
@@ -346,7 +346,7 @@ def repoint_shared_state(
         except (ValueError, OSError):
             dst.symlink_to(src.resolve())
 
-    (worktree_path / ".coral_island").write_text(str(new_island_id))
+    (worktree_path / ".coral_island").write_text(str(new_island_id), encoding="utf-8")
 
 
 def apply_runtime_mounts(
@@ -528,7 +528,7 @@ def setup_claude_settings(
 
     settings_path = claude_dir / "settings.local.json"
     # Always overwrite — each agent needs its own copy
-    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
 
 
 def setup_opencode_settings(
@@ -609,7 +609,7 @@ def setup_opencode_settings(
         }
 
     settings_path = opencode_dir / "opencode.json"
-    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
 
 
 def setup_codex_settings(
@@ -654,7 +654,7 @@ def setup_codex_settings(
     config_toml = "\n".join(lines) + "\n"
 
     settings_path = codex_dir / "config.toml"
-    settings_path.write_text(config_toml)
+    settings_path.write_text(config_toml, encoding="utf-8")
 
 
 def setup_cursor_settings(
@@ -706,7 +706,7 @@ def setup_cursor_settings(
         "\n" + "\n".join(body_lines) + "\n"
     )
 
-    (rules_dir / "coral.mdc").write_text(rules_md)
+    (rules_dir / "coral.mdc").write_text(rules_md, encoding="utf-8")
 
 
 def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:

--- a/tests/test_process_liveness.py
+++ b/tests/test_process_liveness.py
@@ -1,0 +1,80 @@
+"""Tests for the cross-platform PID liveness probe."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from coral.cli._helpers import is_process_alive
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="exercises the POSIX os.kill branch"
+)
+
+
+def test_current_process_is_alive() -> None:
+    assert is_process_alive(os.getpid())
+
+
+def test_exited_process_is_not_alive() -> None:
+    """A process that has exited is dead on both platforms.
+
+    On Windows the kernel object outlives the process while a handle is still
+    open, so this also covers the "handle exists" case that would otherwise be
+    misreported as running.
+    """
+    process = subprocess.Popen([sys.executable, "-c", ""])
+    process.wait()
+
+    assert not is_process_alive(process.pid)
+
+
+@pytest.mark.parametrize("pid", [0, -1, -12345])
+def test_non_positive_pids_are_never_alive(pid: int) -> None:
+    """``os.kill`` reads 0 and negatives as process groups, not processes.
+
+    A truncated or corrupt ``manager.pid`` must not make the caller's own
+    process group look like a running manager.
+    """
+    assert not is_process_alive(pid)
+
+
+@posix_only
+def test_invalid_parameter_oserror_is_reported_dead(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows raises WinError 87 from ``os.kill`` instead of ProcessLookupError.
+
+    Regression test for `coral status` crashing: the bare OSError escaped call
+    sites that only caught ProcessLookupError.
+    """
+
+    def raise_invalid_parameter(pid: int, sig: int) -> None:
+        raise OSError(22, "The parameter is incorrect", None, 87)
+
+    monkeypatch.setattr(os, "kill", raise_invalid_parameter)
+
+    assert not is_process_alive(4321)
+
+
+@posix_only
+def test_permission_error_means_alive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A process owned by another user exists, so it counts as running."""
+
+    def raise_permission_error(pid: int, sig: int) -> None:
+        raise PermissionError("Operation not permitted")
+
+    monkeypatch.setattr(os, "kill", raise_permission_error)
+
+    assert is_process_alive(4321)
+
+
+@posix_only
+def test_process_lookup_error_means_dead(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_lookup_error(pid: int, sig: int) -> None:
+        raise ProcessLookupError("No such process")
+
+    monkeypatch.setattr(os, "kill", raise_lookup_error)
+
+    assert not is_process_alive(4321)


### PR DESCRIPTION
## Summary

Three independent portability defects, one commit each. All three are plain correctness fixes — behaviour on Linux and macOS is unchanged — but each one is an unconditional crash on Windows.

I hit them while trying to run CORAL on Windows 11. This PR does **not** claim Windows support (see *Not in scope* below); it removes three POSIX-only assumptions that are wrong on their own terms.

---

### 1. `os.kill(pid, 0)` is not a portable liveness probe

**Problem.** Signal 0 does not exist on Windows. `os.kill(pid, 0)` there raises `OSError: [WinError 87] The parameter is incorrect` for *every* PID, whether the process is alive or not. The call sites only caught `ProcessLookupError` and `PermissionError`, so the bare `OSError` escaped.

**Trigger.** Any command that reads `manager.pid`, `ui.pid` or `agent.pids`:

```
$ coral status
Traceback (most recent call last):
  File "coral/cli/start.py", line 891, in cmd_status
    os.kill(pid, 0)
OSError: [WinError 87] The parameter is incorrect
```

Same for `coral runs`, `coral start` (resume path), `coral ui`, and the dashboard's `GET /api/status`.

**Fix.** Add `is_process_alive()` to `coral.cli._helpers`, alongside the existing `is_docker_run_alive()` liveness helper, and route all seven probes through it:

- POSIX keeps `os.kill(pid, 0)`: `ProcessLookupError` → dead, `PermissionError` (live process owned by another user) → alive. This preserves today's behaviour exactly.
- Windows opens a `SYNCHRONIZE` handle and waits on it with a zero timeout. A handle stays valid after the process exits, so the *wait result*, not the handle, decides liveness. `ERROR_ACCESS_DENIED` → alive.
- Non-positive PIDs return `False`. `os.kill` reads `0` and negatives as process-group selectors, so a truncated `manager.pid` would otherwise probe the caller's own group and report a dead run as running.

The refactor also removes a latent bug in `coral stop`: its shutdown poll treated `PermissionError` as "the manager stopped", which is the opposite of what that error means.

### 2. PATH entries joined with a hardcoded `":"`

**Problem.** Every built-in runtime prepends the worktree venv to the agent's PATH with `venv_bin + ":" + agent_env.get("PATH", "")`. Windows uses `";"`.

**Trigger.** Launching any agent on Windows. The prepended entry fuses with the inherited PATH into one unparsable string, so the venv is not found *and* every previously reachable executable disappears from the agent's PATH. The agent process dies immediately after launch.

**Fix.** Use `os.pathsep` in `claude_code.py`, `codex.py`, `cursor_agent.py`, `opencode.py` and `pi_agent.py`. It is `":"` on POSIX, so nothing changes there.

### 3. Text file I/O uses the locale encoding

**Problem.** `open()`, `Path.read_text()` and `Path.write_text()` fall back to the locale encoding when none is given. CORAL's own state is UTF-8 — JSON, YAML, JSONL attempt logs, agent transcripts, skill/note markdown — so on any machine whose locale is not UTF-8, the same file is written and read under two different codecs.

**Trigger.** A Chinese Windows install (cp936) is enough. Reading a warm-start transcript, an agent log, `config.yaml` or a bundled skill file that contains any character outside cp936 raises `UnicodeDecodeError` and takes down the command; writing silently mangles non-ASCII content. `coral/agent/warmstart.py` is the easiest one to reach, since agent transcripts routinely contain non-ASCII. The same applies to any non-UTF-8 POSIX locale.

**Fix.** Pass `encoding="utf-8"` explicitly at every text I/O site under `coral/` (163 call sites, mechanical). Binary-mode calls are untouched. Agent stdout log files also get `errors="replace"`, matching how `open_agent_stderr_for_log_dir()` already opens the stderr log, so a stray byte from an agent CLI cannot kill the writer thread.

---

## Verification

- `ruff check .` and `ruff format --check .` clean.
- New `tests/test_process_liveness.py` covers the helper: a live process, an exited process (the case a raw handle check would misreport on Windows), non-positive PIDs, and — on POSIX — the three `os.kill` error mappings, including a regression test for the `WinError 87` `OSError` that used to escape.
- Full suite run on Windows 11 / Python 3.11 before and after the change: identical results (`612 passed`, the same 49 pre-existing failures, the same 4 skips). Those 49 failures are unrelated POSIX assumptions in the test environment (symlinks, tmux, `chmod`, `/bin/sh`) and are untouched by this PR.
- The liveness helper's Windows path was exercised on a real Windows host; the POSIX path was exercised both natively and through mocked `os.kill` errors.

## Not in scope

Two hard Windows blockers remain and are deliberately left alone, since fixing them means real design decisions rather than portability cleanups: `coral/hub/checkpoint.py` imports `fcntl` and `coral/workspace/user_isolation.py` imports `pwd`, both at module level. No Windows-only shim is added anywhere in this PR.
