### PR TITLE
fix: resolve virtualenv executable paths cross-platform

### DIFF
--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -25,6 +24,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -214,7 +214,7 @@ class ClaudeCodeRuntime:
         # Set VIRTUAL_ENV so login shells (which reset PATH) can restore it
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        # Prepend .venv/bin to PATH for non-login shells
+        # Prepend the venv executable dir (bin or Scripts) to PATH for non-login shells
         venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 

--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -214,7 +215,7 @@ class ClaudeCodeRuntime:
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
         # Prepend .venv/bin to PATH for non-login shells
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -22,6 +21,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -178,7 +178,7 @@ class CodexRuntime:
         # Set VIRTUAL_ENV so login shells (which reset PATH) can restore it
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        # Prepend .venv/bin to PATH for non-login shells
+        # Prepend the venv executable dir (bin or Scripts) to PATH for non-login shells
         venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -178,7 +179,7 @@ class CodexRuntime:
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
         # Prepend .venv/bin to PATH for non-login shells
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -207,7 +208,7 @@ class CursorAgentRuntime:
         worktree_venv = str(worktree_path / ".venv")
         agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         apply_sandbox_env(agent_env, sandbox)

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -34,6 +33,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -156,7 +157,7 @@ class OpenCodeRuntime:
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
         # Prepend .venv/bin to PATH for non-login shells
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -22,6 +21,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -156,7 +156,7 @@ class OpenCodeRuntime:
         # Set VIRTUAL_ENV so login shells (which reset PATH) can restore it
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        # Prepend .venv/bin to PATH for non-login shells
+        # Prepend the venv executable dir (bin or Scripts) to PATH for non-login shells
         venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 

--- a/coral/agent/builtin/pi_agent.py
+++ b/coral/agent/builtin/pi_agent.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -171,7 +172,7 @@ class PiAgentRuntime:
         worktree_venv = str(worktree_path / ".venv")
         agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         if gateway_url:

--- a/coral/agent/builtin/pi_agent.py
+++ b/coral/agent/builtin/pi_agent.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from coral.venv_paths import venv_bin_dir
 import subprocess
 import sys
 import threading
@@ -17,6 +16,7 @@ from typing import Any
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
 from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -11,6 +11,8 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+from coral.venv_paths import venv_python as resolve_venv_python
+
 from coral.agent.state import read_agent_state
 from coral.cli._helpers import (
     docker_cmd,
@@ -57,9 +59,9 @@ def _resolved_python() -> str:
     # Look for a local .venv relative to the coral package
     coral_pkg = Path(__file__).resolve().parent.parent.parent
     for venv_name in (".venv", "venv"):
-        venv_python = coral_pkg / venv_name / "bin" / "python"
-        if venv_python.exists():
-            return str(venv_python)
+        candidate = resolve_venv_python(coral_pkg / venv_name)
+        if candidate.exists():
+            return str(candidate)
 
     # Fallback: current interpreter (absolute, but don't resolve symlinks)
     return os.path.abspath(sys.executable)

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -11,8 +11,6 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from coral.venv_paths import venv_python as resolve_venv_python
-
 from coral.agent.state import read_agent_state
 from coral.cli._helpers import (
     docker_cmd,
@@ -41,6 +39,7 @@ from coral.cli._helpers import (
 )
 from coral.config import CoralConfig
 from coral.hub.auto_stop import read_auto_stop
+from coral.venv_paths import venv_python as resolve_venv_python
 from coral.workspace.project import slugify
 
 

--- a/coral/venv_paths.py
+++ b/coral/venv_paths.py
@@ -1,0 +1,28 @@
+"""Platform-aware virtualenv path helpers (POSIX bin/ vs Windows Scripts/)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def venv_bin_dir_name(*, windows: bool | None = None) -> str:
+    """Directory under a venv root that holds executables."""
+    if windows is None:
+        windows = sys.platform == "win32"
+    return "Scripts" if windows else "bin"
+
+
+def venv_python_name(*, windows: bool | None = None) -> str:
+    """Interpreter filename inside the venv bin directory."""
+    if windows is None:
+        windows = sys.platform == "win32"
+    return "python.exe" if windows else "python"
+
+
+def venv_bin_dir(venv_root: Path | str, *, windows: bool | None = None) -> Path:
+    return Path(venv_root) / venv_bin_dir_name(windows=windows)
+
+
+def venv_python(venv_root: Path | str, *, windows: bool | None = None) -> Path:
+    return venv_bin_dir(venv_root, windows=windows) / venv_python_name(windows=windows)

--- a/coral/workspace/grader_env.py
+++ b/coral/workspace/grader_env.py
@@ -31,6 +31,8 @@ import subprocess
 import sys
 import sysconfig
 from pathlib import Path
+
+from coral.venv_paths import venv_python
 from urllib.parse import urlparse
 
 from coral.config import GraderConfig
@@ -104,7 +106,7 @@ def grader_venv_path(coral_dir: Path) -> Path:
 
 def grader_python_path(coral_dir: Path) -> Path:
     """Path to the Python interpreter inside the grader venv."""
-    return grader_venv_path(coral_dir) / "bin" / "python"
+    return venv_python(grader_venv_path(coral_dir))
 
 
 def setup_grader_env(

--- a/coral/workspace/grader_env.py
+++ b/coral/workspace/grader_env.py
@@ -31,11 +31,10 @@ import subprocess
 import sys
 import sysconfig
 from pathlib import Path
-
-from coral.venv_paths import venv_python
 from urllib.parse import urlparse
 
 from coral.config import GraderConfig
+from coral.venv_paths import venv_python
 from coral.workspace.repo import _clean_env, run_setup_commands
 
 logger = logging.getLogger(__name__)

--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from coral.venv_paths import venv_python as resolve_venv_python
 import shutil
 import subprocess
 from pathlib import Path
@@ -733,7 +734,7 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
     # Force uv to create/use a venv inside this worktree, even if
     # pyproject.toml is resolved from a parent directory.
     worktree_venv = worktree_path / ".venv"
-    venv_python = worktree_venv / "bin" / "python"
+    venv_python = resolve_venv_python(worktree_venv)
     if venv_python.exists():
         logger.debug(f"Worktree venv already populated at {worktree_venv}, skipping setup commands")
         return
@@ -743,7 +744,7 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
 
     # Install coral into the worktree's venv so agents can use
     # ``uv run coral eval`` and graders can ``from coral.grader import ...``.
-    venv_python = worktree_venv / "bin" / "python"
+    venv_python = resolve_venv_python(worktree_venv)
     if venv_python.exists() and shutil.which("uv"):
         coral_root = Path(__file__).resolve().parent.parent.parent
         if (coral_root / "pyproject.toml").exists():

--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 import logging
 import os
-from coral.venv_paths import venv_python as resolve_venv_python
 import shutil
 import subprocess
 from pathlib import Path
 
+from coral.venv_paths import venv_python as resolve_venv_python
 from coral.workspace.repo import (
     _clean_env,
     run_setup_commands,

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -15,6 +15,7 @@ from coral.grader.protocol import GraderInterface
 from coral.grader.subprocess_grader import SubprocessGrader
 from coral.grader.task_grader import DEFAULT_TUNE_DESCRIPTION, TaskGrader
 from coral.types import ScoreBundle, Task
+from coral.venv_paths import venv_python as resolve_venv_python
 
 # --- Harbor grader schema tests (swebench-verified, terminal-bench) ----------
 #
@@ -344,7 +345,7 @@ def test_loader_passes_grader_config_and_args():
     """GraderConfig (incl. args) from task.yaml must reach the loaded grader."""
     with tempfile.TemporaryDirectory() as tmpdir:
         coral_dir = Path(tmpdir)
-        venv_python = coral_dir / "private" / "grader_venv" / "bin" / "python"
+        venv_python = resolve_venv_python(coral_dir / "private" / "grader_venv")
         venv_python.parent.mkdir(parents=True)
         venv_python.touch()
 
@@ -382,7 +383,7 @@ def test_loader_returns_subprocess_grader_for_entrypoint():
     with tempfile.TemporaryDirectory() as tmpdir:
         coral_dir = Path(tmpdir)
         # Pretend the grader venv exists.
-        venv_python = coral_dir / "private" / "grader_venv" / "bin" / "python"
+        venv_python = resolve_venv_python(coral_dir / "private" / "grader_venv")
         venv_python.parent.mkdir(parents=True)
         venv_python.touch()
 

--- a/tests/test_venv_paths.py
+++ b/tests/test_venv_paths.py
@@ -2,7 +2,12 @@
 
 from pathlib import Path
 
-from coral.venv_paths import venv_bin_dir, venv_bin_dir_name, venv_python, venv_python_name
+from coral.venv_paths import (
+    venv_bin_dir,
+    venv_bin_dir_name,
+    venv_python,
+    venv_python_name,
+)
 
 
 def test_posix_layout():

--- a/tests/test_venv_paths.py
+++ b/tests/test_venv_paths.py
@@ -1,0 +1,21 @@
+"""Platform venv path helpers (#228)."""
+
+from pathlib import Path
+
+from coral.venv_paths import venv_bin_dir, venv_bin_dir_name, venv_python, venv_python_name
+
+
+def test_posix_layout():
+    assert venv_bin_dir_name(windows=False) == "bin"
+    assert venv_python_name(windows=False) == "python"
+    root = Path("/tmp/proj/.venv")
+    assert venv_bin_dir(root, windows=False) == root / "bin"
+    assert venv_python(root, windows=False) == root / "bin" / "python"
+
+
+def test_windows_layout():
+    assert venv_bin_dir_name(windows=True) == "Scripts"
+    assert venv_python_name(windows=True) == "python.exe"
+    root = Path(r"C:\proj\.venv")
+    assert venv_bin_dir(root, windows=True) == root / "Scripts"
+    assert venv_python(root, windows=True) == root / "Scripts" / "python.exe"


### PR DESCRIPTION
## Summary
Follow-up to #226: CORAL still hard-coded POSIX `.venv/bin` / `bin/python` for agent PATH, worktree setup, grader, and CLI discovery.

## Changes
- Add `coral.venv_paths` helpers (`bin` vs `Scripts`, `python` vs `python.exe`).
- Wire helpers through agent builtins, `setup_worktree_env`, `grader_python_path`, and `_resolved_python`.
- Unit tests for POSIX and Windows layouts independent of host OS.

Closes #228