### PR TITLE
feat(cli): add status filtering to coral notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ coral log                                         # Top 20 by score
 coral log -n 5 --recent                           # Sort by time
 coral log --search "kernel" --agent agent-1       # Full-text + filter
 coral show <hash> [--diff]                        # Attempt details (file summary or full diff)
-coral notes [--search KW] [--read N] [--history]  # Browse / read / show checkpoint history
+coral notes [--status STATUS] [--search KW] [-n N] [--read N] [--history]  # Browse / filter / read / show checkpoint history
 coral skills [--read NAME]                        # List or read a shared skill
 coral runs [--all] [--task NAME]                  # Active runs (or all)
 

--- a/coral/cli/__init__.py
+++ b/coral/cli/__init__.py
@@ -95,6 +95,14 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--run", help="Run ID (defaults to latest)")
 
 
+def _non_empty_status(value: str) -> str:
+    """Validate and normalize a status supplied on the command line."""
+    normalized = value.strip()
+    if not normalized:
+        raise argparse.ArgumentTypeError("status must be a non-empty string")
+    return normalized
+
+
 def main() -> None:
     from coral import __version__
 
@@ -324,11 +332,18 @@ Run 'coral <command> --help' for details on any command."""
             "  coral notes                   List all notes\n"
             "  coral notes -n 5              Last 5 notes\n"
             "  coral notes --search 'idea'   Search notes\n"
+            "  coral notes --status confirmed  Filter by note status\n"
             "  coral notes --read 3          Read note #3"
         ),
         formatter_class=_CommandHelpFormatter,
     )
     p_notes.add_argument("--search", "-s", help="Search notes by keyword")
+    p_notes.add_argument(
+        "--status",
+        metavar="STATUS",
+        type=_non_empty_status,
+        help="Filter by frontmatter status (e.g. confirmed, refuted, untested)",
+    )
     p_notes.add_argument("-n", "--recent", type=int, help="Show N most recent")
     p_notes.add_argument("--read", "-r", help="Read a specific note by number or name")
     p_notes.add_argument(

--- a/coral/cli/query.py
+++ b/coral/cli/query.py
@@ -199,6 +199,7 @@ def cmd_notes(args: argparse.Namespace) -> None:
         getattr(args, "task", None),
         getattr(args, "run", None),
     )
+    status = getattr(args, "status", None)
 
     if getattr(args, "history", False):
         from coral.hub.checkpoint import checkpoint_history
@@ -230,18 +231,28 @@ def cmd_notes(args: argparse.Namespace) -> None:
         except ValueError:
             print(read_all_notes(str(coral_dir), island_id=island_id))
     elif args.search:
-        results = search_notes(str(coral_dir), args.search, island_id=island_id)
+        results = search_notes(
+            str(coral_dir),
+            args.search,
+            island_id=island_id,
+            status=status,
+        )
         if results:
             print(f"Notes matching '{args.search}':")
             print(format_notes_list(results))
         else:
             print(f"No notes matching '{args.search}'.")
     elif args.recent:
-        entries = get_recent_notes(str(coral_dir), n=args.recent, island_id=island_id)
+        entries = get_recent_notes(
+            str(coral_dir),
+            n=args.recent,
+            island_id=island_id,
+            status=status,
+        )
         print(f"Recent notes ({len(entries)}):")
         print(format_notes_list(entries))
     else:
-        entries = list_notes(str(coral_dir), island_id=island_id)
+        entries = list_notes(str(coral_dir), island_id=island_id, status=status)
         print(f"Notes ({len(entries)}):")
         print(format_notes_list(entries))
 

--- a/coral/hub/notes.py
+++ b/coral/hub/notes.py
@@ -330,11 +330,28 @@ def _sort_key(entry: dict[str, Any]) -> datetime:
     return datetime.min.replace(tzinfo=UTC)
 
 
+def _filter_notes_by_status(
+    entries: list[dict[str, Any]],
+    status: str | None,
+) -> list[dict[str, Any]]:
+    """Return entries whose parsed status matches the requested value."""
+    if status is None:
+        return entries
+
+    expected = status.strip().casefold()
+    return [
+        entry
+        for entry in entries
+        if "status" in entry and str(entry["status"]).strip().casefold() == expected
+    ]
+
+
 def list_notes(
     coral_dir: str | Path,
     island_id: str | int | None = None,
     *,
     include_raw: bool = False,
+    status: str | None = None,
 ) -> list[dict[str, Any]]:
     """List all note entries from the notes directory.
 
@@ -348,12 +365,17 @@ def list_notes(
     (category ``"raw"``) for read-only display. It defaults to False so
     agent-facing consumers (``coral notes``, search, recent-note summaries)
     keep seeing only authored notes; only the dashboard opts in.
+
+    ``status`` filters on the parsed frontmatter value after trimming
+    surrounding whitespace and normalizing case. Notes without a status are
+    excluded only when this filter is active.
     """
     coral_dir = Path(coral_dir)
     if island_id is not None or not (coral_dir / "islands").exists():
-        return _list_notes_single(coral_dir, island_id, include_raw=include_raw)
+        entries = _list_notes_single(coral_dir, island_id, include_raw=include_raw)
+        return _filter_notes_by_status(entries, status)
 
-    entries: list[dict[str, Any]] = []
+    entries = []
     for view_root in all_view_roots(coral_dir):
         sub = _list_notes_single(
             coral_dir, island_id=view_root.name, clean=False, include_raw=include_raw
@@ -363,7 +385,7 @@ def list_notes(
         entries.extend(sub)
     entries.sort(key=_sort_key)
     _clean_note_entries(entries)
-    return entries
+    return _filter_notes_by_status(entries, status)
 
 
 def _list_notes_single(
@@ -425,11 +447,13 @@ def search_notes(
     coral_dir: str | Path,
     query: str,
     island_id: str | int | None = None,
+    *,
+    status: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Search notes by keyword (case-insensitive) in title and body."""
+    """Search notes by keyword and optional status."""
     query_lower = query.lower()
     results = []
-    for entry in list_notes(coral_dir, island_id=island_id):
+    for entry in list_notes(coral_dir, island_id=island_id, status=status):
         full_text = f"{entry['title']} {entry['body']}".lower()
         if query_lower in full_text:
             results.append(entry)
@@ -440,9 +464,11 @@ def get_recent_notes(
     coral_dir: str | Path,
     n: int = 5,
     island_id: str | int | None = None,
+    *,
+    status: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Return the last N notes (most recent last in file = most recent last)."""
-    entries = list_notes(coral_dir, island_id=island_id)
+    """Filter notes, then return the last N matches."""
+    entries = list_notes(coral_dir, island_id=island_id, status=status)
     return entries[-n:] if len(entries) > n else entries
 
 

--- a/docs/content/docs/api/hub.mdx
+++ b/docs/content/docs/api/hub.mdx
@@ -80,10 +80,10 @@ Notes are Markdown files with YAML frontmatter stored in `.coral/public/notes/`.
 
 | Function | Description |
 |----------|-------------|
-| `list_notes(coral_dir)` | List all notes (returns metadata dicts) |
+| `list_notes(coral_dir, island_id=None, *, include_raw=False, status=None)` | List notes, optionally filtered by frontmatter status |
 | `read_note(coral_dir, index)` | Read a specific note by 1-based index |
-| `search_notes(coral_dir, query)` | Search notes by keyword |
-| `get_recent_notes(coral_dir, n=5)` | Most recent N notes |
+| `search_notes(coral_dir, query, island_id=None, *, status=None)` | Search notes by keyword and optional status |
+| `get_recent_notes(coral_dir, n=5, island_id=None, *, status=None)` | Most recent N notes after optional status filtering |
 | `read_all_notes(coral_dir)` | Concatenated content of all notes |
 | `format_notes_list(entries)` | Format note entries for terminal display |
 

--- a/docs/content/docs/cli/reference.mdx
+++ b/docs/content/docs/cli/reference.mdx
@@ -262,14 +262,22 @@ coral notes [options]
 | Flag | Description |
 |------|-------------|
 | `-s, --search QUERY` | Search notes by keyword |
+| `--status STATUS` | Filter by frontmatter status (case-insensitive; surrounding whitespace ignored) |
 | `-n, --recent N` | Show N most recent |
 | `-r, --read ID` | Read a specific note by number or name |
 
 ```bash
 coral notes                    # List all
 coral notes --search "idea"    # Search
+coral notes --status confirmed # Documented: confirmed, refuted, untested; custom values accepted
+coral notes --status refuted --search "tiling"
+coral notes --status untested -n 5
 coral notes --read 3           # Read note #3
 ```
+
+`--status` accepts any non-empty value so new status vocabulary can be used without
+requiring a CLI release. Notes without structured frontmatter or without a `status`
+field are excluded only while this filter is active.
 
 ### `coral skills`
 

--- a/tests/test_cli_notes.py
+++ b/tests/test_cli_notes.py
@@ -1,0 +1,267 @@
+"""Tests for ``coral notes`` status filtering (issue #200)."""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from coral.cli import query as query_module
+from coral.cli.query import cmd_notes
+from coral.hub.notes import get_recent_notes, list_notes, search_notes
+
+
+def _write_note(
+    coral_dir: Path,
+    name: str,
+    status: str | None,
+    *,
+    created: str = "2026-08-07",
+) -> None:
+    notes_dir = coral_dir / "public" / "notes"
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    frontmatter = ["---", "creator: agent-1", f"created: {created}"]
+    if status is not None:
+        frontmatter.append(f'status: "{status}"')
+    frontmatter.extend(["---", "", f"# {name}", "", f"{name} body"])
+    (notes_dir / f"{name}.md").write_text("\n".join(frontmatter), encoding="utf-8")
+
+
+def _run_cmd_notes(
+    coral_dir: Path,
+    monkeypatch,
+    capsys,
+    **overrides: object,
+) -> str:
+    monkeypatch.setattr(
+        query_module,
+        "find_coral_dir_and_island",
+        lambda task=None, run=None: (coral_dir, None),
+    )
+    options: dict[str, object] = {
+        "history": False,
+        "diff": None,
+        "read": None,
+        "search": None,
+        "recent": None,
+        "status": None,
+        "task": None,
+        "run": None,
+    }
+    options.update(overrides)
+    cmd_notes(argparse.Namespace(**options))
+    return capsys.readouterr().out
+
+
+def test_list_notes_filters_status_case_insensitively_and_ignores_whitespace(
+    tmp_path: Path,
+) -> None:
+    _write_note(tmp_path, "lower", "confirmed")
+    _write_note(tmp_path, "mixed", " Confirmed ")
+    _write_note(tmp_path, "prefixed", "confirmed-extra")
+    _write_note(tmp_path, "refuted", "refuted")
+    _write_note(tmp_path, "missing", None)
+
+    entries = list_notes(tmp_path, status=" CONFIRMED ")
+
+    assert [entry["title"] for entry in entries] == ["lower", "mixed"]
+
+
+def test_search_notes_composes_with_status_filter(tmp_path: Path) -> None:
+    _write_note(tmp_path, "confirmed-tiling", "confirmed")
+    _write_note(tmp_path, "refuted-tiling", "refuted")
+    _write_note(tmp_path, "confirmed-kernel", "confirmed")
+
+    entries = search_notes(tmp_path, "tiling", status="confirmed")
+
+    assert [entry["title"] for entry in entries] == ["confirmed-tiling"]
+
+
+def test_list_notes_accepts_future_status_values(tmp_path: Path) -> None:
+    _write_note(tmp_path, "future-note", "needs-review")
+    _write_note(tmp_path, "confirmed-note", "confirmed")
+    _write_note(tmp_path, "legacy-note", None)
+
+    entries = list_notes(tmp_path, status="needs-review")
+
+    assert [entry["title"] for entry in entries] == ["future-note"]
+
+
+def test_notes_cli_accepts_future_status_values(tmp_path: Path) -> None:
+    coral_dir = tmp_path / "coral"
+    worktree = tmp_path / "worktree"
+    _write_note(coral_dir, "future-note", "needs-review")
+    _write_note(coral_dir, "confirmed-note", "confirmed")
+    worktree.mkdir()
+    (worktree / ".coral_dir").write_text(str(coral_dir), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "coral.cli", "notes", "--status", "needs-review"],
+        cwd=worktree,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "future-note" in result.stdout
+    assert "confirmed-note" not in result.stdout
+
+
+def test_recent_notes_filters_before_returning_latest_count(tmp_path: Path) -> None:
+    _write_note(tmp_path, "confirmed-old", "confirmed", created="2026-08-01")
+    _write_note(tmp_path, "confirmed-middle", "confirmed", created="2026-08-02")
+    _write_note(tmp_path, "confirmed-new", "confirmed", created="2026-08-03")
+    _write_note(tmp_path, "refuted-later", "refuted", created="2026-08-04")
+    _write_note(tmp_path, "untested-latest", "untested", created="2026-08-05")
+
+    entries = get_recent_notes(tmp_path, n=2, status="confirmed")
+
+    assert [entry["title"] for entry in entries] == ["confirmed-middle", "confirmed-new"]
+
+
+def test_cmd_notes_applies_status_to_normal_list(tmp_path, monkeypatch, capsys) -> None:
+    _write_note(tmp_path, "confirmed-note", "confirmed")
+    _write_note(tmp_path, "refuted-note", "refuted")
+    _write_note(tmp_path, "legacy-note", None)
+
+    out = _run_cmd_notes(tmp_path, monkeypatch, capsys, status="confirmed")
+
+    assert "confirmed-note" in out
+    assert "refuted-note" not in out
+    assert "legacy-note" not in out
+
+
+def test_cmd_notes_composes_status_with_search(tmp_path, monkeypatch, capsys) -> None:
+    _write_note(tmp_path, "confirmed-tiling", "confirmed")
+    _write_note(tmp_path, "refuted-tiling", "refuted")
+    _write_note(tmp_path, "confirmed-kernel", "confirmed")
+
+    out = _run_cmd_notes(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        search="tiling",
+        status="confirmed",
+    )
+
+    assert "confirmed-tiling" in out
+    assert "refuted-tiling" not in out
+    assert "confirmed-kernel" not in out
+
+
+def test_cmd_notes_recent_filters_before_returning_latest_count(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    _write_note(tmp_path, "confirmed-old", "confirmed", created="2026-08-01")
+    _write_note(tmp_path, "confirmed-middle", "confirmed", created="2026-08-02")
+    _write_note(tmp_path, "confirmed-new", "confirmed", created="2026-08-03")
+    _write_note(tmp_path, "refuted-later", "refuted", created="2026-08-04")
+    _write_note(tmp_path, "untested-latest", "untested", created="2026-08-05")
+
+    out = _run_cmd_notes(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        recent=2,
+        status="confirmed",
+    )
+
+    assert "confirmed-old" not in out
+    assert "confirmed-middle" in out
+    assert "confirmed-new" in out
+    assert "refuted-later" not in out
+    assert "untested-latest" not in out
+
+
+def test_cmd_notes_without_status_preserves_existing_list(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    _write_note(tmp_path, "confirmed-note", "confirmed")
+    _write_note(tmp_path, "refuted-note", "refuted")
+    _write_note(tmp_path, "legacy-note", None)
+
+    out = _run_cmd_notes(tmp_path, monkeypatch, capsys)
+
+    assert out.startswith("Notes (3):\n")
+    assert "confirmed-note" in out
+    assert "refuted-note" in out
+    assert "legacy-note" in out
+    assert out.index("confirmed-note") < out.index("legacy-note") < out.index("refuted-note")
+
+
+def test_cmd_notes_without_status_preserves_existing_search(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    _write_note(tmp_path, "confirmed-tiling", "confirmed")
+    _write_note(tmp_path, "refuted-tiling", "refuted")
+
+    out = _run_cmd_notes(tmp_path, monkeypatch, capsys, search="tiling")
+
+    assert out.startswith("Notes matching 'tiling':\n")
+    assert "confirmed-tiling" in out
+    assert "refuted-tiling" in out
+    assert out.index("confirmed-tiling") < out.index("refuted-tiling")
+
+
+def test_cmd_notes_without_status_preserves_existing_recent(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    _write_note(tmp_path, "confirmed-old", "confirmed", created="2026-08-01")
+    _write_note(tmp_path, "refuted-middle", "refuted", created="2026-08-02")
+    _write_note(tmp_path, "legacy-new", None, created="2026-08-03")
+
+    out = _run_cmd_notes(tmp_path, monkeypatch, capsys, recent=2)
+
+    assert out.startswith("Recent notes (2):\n")
+    assert "confirmed-old" not in out
+    assert "refuted-middle" in out
+    assert "legacy-new" in out
+    assert out.index("refuted-middle") < out.index("legacy-new")
+
+
+def test_cmd_notes_read_ignores_status_filter(tmp_path, monkeypatch, capsys) -> None:
+    _write_note(tmp_path, "confirmed-note", "confirmed", created="2026-08-01")
+    _write_note(tmp_path, "refuted-note", "refuted", created="2026-08-02")
+
+    out = _run_cmd_notes(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        read="1",
+        status="refuted",
+    )
+
+    assert "# confirmed-note" in out
+    assert "# refuted-note" not in out
+
+
+def test_notes_help_documents_status_option() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "coral.cli", "notes", "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--status STATUS" in result.stdout
+
+
+def test_notes_rejects_blank_status() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "coral.cli", "notes", "--status", "   "],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "status must be a non-empty string" in result.stderr


### PR DESCRIPTION
## Motivation

Closes #200.

CORAL already parses structured note `status` frontmatter, but `coral notes` had no way to select notes by that field. Users had to inspect all notes manually, and `--search` / `--recent` could not be narrowed to a status.

## Changes

- Add `coral notes --status STATUS` with whitespace trimming and non-empty input validation.
- Match parsed frontmatter status exactly after trimming and case normalization.
- Accept custom and future status values instead of restricting the CLI to a fixed vocabulary.
- Apply the filter to list, search, and recent-note flows; recent notes are filtered before selecting the latest N matches.
- Preserve existing no-filter output and leave read, checkpoint history, and checkpoint diff behavior unchanged.
- Document the CLI flag and Hub API signatures.
- Add regression coverage for exact matching, missing status, custom values through the real CLI parser, search/recent composition, no-filter compatibility, and read behavior.

## User and developer impact

Users can now query confirmed, refuted, untested, or project-specific note statuses directly. The new Hub API arguments are optional keyword-only parameters, so existing callers remain compatible. No migration is required.

## Test plan

- [x] `.venv/bin/pytest -q tests/test_cli_notes.py` — 14 passed.
- [x] `.venv/bin/pytest -q tests/test_cli_notes.py tests/test_hub.py tests/test_islands.py` — 60 passed.
- [x] `.venv/bin/ruff check .` — passed.
- [x] `.venv/bin/ruff format --check .` — 132 files already formatted.
- [x] `git diff --check` — passed.
- [ ] Full `.venv/bin/pytest -q` — 677 passed, 1 skipped, 1 failed. The only failure is `tests/test_versioning.py::test_distribution_version_is_based_on_latest_release_tag`: tag `v0.7.15` is not an ancestor of the current `dev` baseline (`0b6a8e7`). The same ancestry check fails on the unmodified baseline, so it is unrelated to this change.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [x] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [x] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [ ] Full test suite passes locally; see the unrelated baseline failure documented above.
- [x] Ruff lint and format checks pass.
- [x] Added tests under `tests/` for the behavior change.
- [x] Updated documentation for the new CLI/API surface.
- [x] The flag and API parameters are additive and require no migration.
- [x] AI-assisted changes received a complete human-guided review before publication.
