### PR TITLE
fix: proper heartbeat config options parsing

### DIFF
--- a/coral/config.py
+++ b/coral/config.py
@@ -690,6 +690,7 @@ def _preprocess(data: dict[str, Any]) -> dict[str, Any]:
                 "is_global": h.get("global", False),
                 "trigger": h.get("trigger", "interval"),
                 "prompt": h.get("prompt", ""),
+                "options": h.get("options", {}),
             }
             for h in heartbeat_raw
         ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -192,6 +192,32 @@ def test_heartbeat_global_flag_roundtrip():
     assert d["agents"]["heartbeat"][0]["global"] is True
 
 
+def test_heartbeat_plateau_options_survive_preprocess():
+    """Per-action `options` from task.yaml must reach HeartbeatAction.options.
+    """
+    from coral.agent.heartbeat import parse_options
+
+    data = {
+        "task": {"name": "t", "description": "d"},
+        "agents": {
+            "heartbeat": [
+                {
+                    "name": "pivot",
+                    "every": 3,
+                    "trigger": "plateau",
+                    "options": {"epsilon": 0.005},
+                },
+            ]
+        },
+    }
+    config = CoralConfig.from_dict(data)
+    action = next(h for h in config.agents.heartbeat if h.name == "pivot")
+    assert action.options == {"epsilon": 0.005}
+
+    # And it must survive the validation/parse step the runner actually uses.
+    assert parse_options(action.trigger, action.options).epsilon == 0.005
+
+
 def test_run_config_defaults():
     config = CoralConfig(
         task=TaskConfig(name="t", description="d"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,8 +193,7 @@ def test_heartbeat_global_flag_roundtrip():
 
 
 def test_heartbeat_plateau_options_survive_preprocess():
-    """Per-action `options` from task.yaml must reach HeartbeatAction.options.
-    """
+    """Per-action `options` from task.yaml must reach HeartbeatAction.options."""
     from coral.agent.heartbeat import parse_options
 
     data = {


### PR DESCRIPTION
<!--
Thanks for contributing to CORAL! A few notes before you submit:

- Target the `dev` branch — all PRs go to `dev`, not `main` (see CONTRIBUTING.md).
- See CONTRIBUTING.md for the full workflow.
- Keep PRs scoped. Unrelated cleanups belong in a separate PR.
- Make sure `uv run pytest tests/ -v` and `uv run ruff check .` pass locally.
- If you used an AI coding agent to author this PR, also read AGENTS.md.
-->

## Motivation

Fixed a bug in the options section in the user-specific heartbeats

## Changes

Fixed a bug in the options section in the user-specific heartbeats

## Test plan

<!--
How did you verify this works? Concrete commands + results, not "I tested it".
Examples:
  - `uv run pytest tests/grader/ -v` (all green)
  - Smoke-ran `coral start -c examples/mnist/task.yaml agents.count=1` to first finalized score
  - `coral validate examples/<new-task>/`
-->

## Affected areas

<!-- Tick what this PR touches so reviewers know where to focus. -->

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: <!-- specify -->

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
