### PR TITLE
release: promote runtime and heartbeat fixes to main

### DIFF
--- a/coral/agent/builtin/claude_code.py
+++ b/coral/agent/builtin/claude_code.py
@@ -24,6 +24,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -213,8 +214,8 @@ class ClaudeCodeRuntime:
         # Set VIRTUAL_ENV so login shells (which reset PATH) can restore it
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        # Prepend .venv/bin to PATH for non-login shells
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        # Prepend the venv executable dir (bin or Scripts) to PATH for non-login shells
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured

--- a/coral/agent/builtin/codex.py
+++ b/coral/agent/builtin/codex.py
@@ -21,6 +21,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -177,8 +178,8 @@ class CodexRuntime:
         # Set VIRTUAL_ENV so login shells (which reset PATH) can restore it
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        # Prepend .venv/bin to PATH for non-login shells
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        # Prepend the venv executable dir (bin or Scripts) to PATH for non-login shells
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured

--- a/coral/agent/builtin/cursor_agent.py
+++ b/coral/agent/builtin/cursor_agent.py
@@ -33,6 +33,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -207,7 +208,7 @@ class CursorAgentRuntime:
         worktree_venv = str(worktree_path / ".venv")
         agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         apply_sandbox_env(agent_env, sandbox)

--- a/coral/agent/builtin/opencode.py
+++ b/coral/agent/builtin/opencode.py
@@ -21,6 +21,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -155,8 +156,8 @@ class OpenCodeRuntime:
         # Set VIRTUAL_ENV so login shells (which reset PATH) can restore it
         # via /etc/profile.d/coral-venv.sh in Docker containers.
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        # Prepend .venv/bin to PATH for non-login shells
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        # Prepend the venv executable dir (bin or Scripts) to PATH for non-login shells
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         # Route through gateway if configured

--- a/coral/agent/builtin/pi_agent.py
+++ b/coral/agent/builtin/pi_agent.py
@@ -16,6 +16,7 @@ from typing import Any
 from coral.agent.exit_classifier import classify_by_uptime
 from coral.agent.process import open_agent_stderr_for_log_dir
 from coral.agent.runtime import AgentHandle, apply_run_as_user, write_coral_log_entry
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -171,7 +172,7 @@ class PiAgentRuntime:
         worktree_venv = str(worktree_path / ".venv")
         agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        venv_bin = str(worktree_path / ".venv" / "bin")
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
         agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
 
         if gateway_url:

--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -101,6 +101,7 @@ class AgentManager:
         verbose: bool = False,
         config_dir: Path | None = None,
     ) -> None:
+        """Initialize the AgentManager with configuration and state tracking structures."""
         self.config = config
         self.config_dir = config_dir
         # Resolve concrete per-agent specs, then (when multi-island) partition them
@@ -443,6 +444,7 @@ class AgentManager:
             print(f"[coral] Sandbox provider {sb.provider!r} active")
 
     def _stop_sandbox(self) -> None:
+        """Stop the active sandbox provider if instantiated."""
         if self._sandbox is not None:
             self._sandbox.stop()
             self._sandbox = None
@@ -560,24 +562,36 @@ class AgentManager:
         if island_id is not None:
             self._agent_island[agent_id] = island_id
 
-        # Create worktree (idempotent)
-        logger.info(f"Setting up {agent_id}...")
-        worktree_path = create_agent_worktree(
-            self.paths.repo_dir,
-            agent_id,
-            self.paths.agents_dir,
-        )
-        logger.info(f"  Worktree: {worktree_path}")
+        # Phase 1: One-time worktree provisioning.
+        # Create worktree and run workspace setup commands (uv sync, etc.)
+        # only if the readiness marker (.coral_agent_id) is not yet present.
+        worktree_path = self.paths.agents_dir / agent_id
+        already_provisioned = (worktree_path / ".coral_agent_id").exists()
 
-        # Ignore CORAL files via the repo's shared info/exclude (reset-proof)
-        setup_git_exclude(worktree_path)
+        if not already_provisioned:
+            logger.info(f"Setting up {agent_id}...")
+            worktree_path = create_agent_worktree(
+                self.paths.repo_dir,
+                agent_id,
+                self.paths.agents_dir,
+            )
+            logger.info(f"  Worktree: {worktree_path}")
 
-        # Run setup commands (uv sync, etc.) and install coral in the worktree
-        setup_worktree_env(worktree_path, self.config.workspace.setup)
+            # Ignore CORAL files via the repo's shared info/exclude (reset-proof)
+            setup_git_exclude(worktree_path)
 
-        # Write .coral_dir breadcrumb (used by workspace guard hook)
-        write_coral_dir(worktree_path, self.paths.coral_dir)
+            # Run workspace.setup (uv sync, npm ci, etc.) ONCE during initial provisioning
+            setup_worktree_env(worktree_path, self.config.workspace.setup)
 
+            # Write .coral_dir breadcrumb (used by workspace guard hook)
+            write_coral_dir(worktree_path, self.paths.coral_dir)
+
+            # Write agent ID readiness breadcrumb to mark successful provisioning
+            write_agent_id(worktree_path, agent_id)
+        else:
+            logger.info(f"Re-using existing provisioned worktree for {agent_id}: {worktree_path}")
+
+        # Phase 2: Repeatable agent launch & runtime environment setup.
         # Set up shared state directory (notes, skills, attempts symlinks, plus
         # a symlink to the grader source so the agent can read how it's scored).
         shared_dir_name = runtime.shared_dir_name
@@ -661,9 +675,6 @@ class AgentManager:
                 island_id=island_id,
             )
             logger.info(f"  Seeded heartbeat config for {agent_id}")
-
-        # Write agent ID
-        write_agent_id(worktree_path, agent_id)
 
         # Seed the agent's role description (idempotent — preserves the
         # evolved role on resume). When ``runtime_options.role_file``
@@ -1270,6 +1281,7 @@ class AgentManager:
     def _attempt_dict_for_auto_stop(
         self, attempt: Attempt | dict[str, Any] | None
     ) -> dict[str, Any]:
+        """Convert an attempt object or dictionary into a normalized auto-stop info map."""
         if attempt is None:
             return {
                 "attempt_id": None,
@@ -1292,6 +1304,7 @@ class AgentManager:
         }
 
     def _score_meets_auto_stop_threshold(self, score: float | int | None, threshold: float) -> bool:
+        """Check whether a score satisfies the auto-stop threshold given the optimization direction."""
         if score is None:
             return False
         value = float(score)
@@ -1368,6 +1381,7 @@ class AgentManager:
         attempt_info: dict[str, Any],
         real_attempt_count: int,
     ) -> dict[str, Any]:
+        """Construct a standardized dictionary detailing the auto-stop trigger reason."""
         stop_config = self.config.run.stop
         return {
             "reason": reason,
@@ -2009,10 +2023,12 @@ class AgentManager:
 
     @staticmethod
     def _migration_block_is_retriable(reason: str) -> bool:
+        """Return True if a migration block reason can be safely retried in subsequent cycles."""
         return reason == "paused"
 
     @staticmethod
     def _migration_defer_reason(reason: str) -> str:
+        """Normalize a block reason string for deferral tracking."""
         if reason.startswith("stale:"):
             return "stale"
         return reason
@@ -2257,6 +2273,7 @@ class AgentManager:
 
     @property
     def migration_config(self):
+        """Return the island migration configuration from CoralConfig."""
         return self.config.islands.migration
 
     def _swap_spec_island(self, agent_id: str, *, new_island_id: str) -> None:
@@ -2648,6 +2665,7 @@ class AgentManager:
                 pass
 
     def _write_pid_file(self) -> None:
+        """Write manager PID and agent PIDs to files under public/ for process tracking."""
         if self.paths:
             pid_file = self.paths.coral_dir / "public" / "manager.pid"
             pid_file.write_text(str(os.getpid()), encoding="utf-8")
@@ -2694,6 +2712,7 @@ class AgentManager:
         self._cleanup_pid_file()
 
     def _cleanup_pid_file(self) -> None:
+        """Clean up process ID tracking files under public/ upon manager shutdown."""
         if self.paths:
             for name in ("manager.pid", "agent.pids", "agent_pids.json"):
                 f = self.paths.coral_dir / "public" / name

--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -39,6 +39,7 @@ from coral.cli._helpers import (
 )
 from coral.config import CoralConfig
 from coral.hub.auto_stop import read_auto_stop
+from coral.venv_paths import venv_python as resolve_venv_python
 from coral.workspace.project import slugify
 
 
@@ -57,9 +58,9 @@ def _resolved_python() -> str:
     # Look for a local .venv relative to the coral package
     coral_pkg = Path(__file__).resolve().parent.parent.parent
     for venv_name in (".venv", "venv"):
-        venv_python = coral_pkg / venv_name / "bin" / "python"
-        if venv_python.exists():
-            return str(venv_python)
+        candidate = resolve_venv_python(coral_pkg / venv_name)
+        if candidate.exists():
+            return str(candidate)
 
     # Fallback: current interpreter (absolute, but don't resolve symlinks)
     return os.path.abspath(sys.executable)

--- a/coral/config.py
+++ b/coral/config.py
@@ -690,6 +690,7 @@ def _preprocess(data: dict[str, Any]) -> dict[str, Any]:
                 "is_global": h.get("global", False),
                 "trigger": h.get("trigger", "interval"),
                 "prompt": h.get("prompt", ""),
+                "options": h.get("options", {}),
             }
             for h in heartbeat_raw
         ]

--- a/coral/venv_paths.py
+++ b/coral/venv_paths.py
@@ -1,0 +1,28 @@
+"""Platform-aware virtualenv path helpers (POSIX bin/ vs Windows Scripts/)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def venv_bin_dir_name(*, windows: bool | None = None) -> str:
+    """Directory under a venv root that holds executables."""
+    if windows is None:
+        windows = sys.platform == "win32"
+    return "Scripts" if windows else "bin"
+
+
+def venv_python_name(*, windows: bool | None = None) -> str:
+    """Interpreter filename inside the venv bin directory."""
+    if windows is None:
+        windows = sys.platform == "win32"
+    return "python.exe" if windows else "python"
+
+
+def venv_bin_dir(venv_root: Path | str, *, windows: bool | None = None) -> Path:
+    return Path(venv_root) / venv_bin_dir_name(windows=windows)
+
+
+def venv_python(venv_root: Path | str, *, windows: bool | None = None) -> Path:
+    return venv_bin_dir(venv_root, windows=windows) / venv_python_name(windows=windows)

--- a/coral/workspace/grader_env.py
+++ b/coral/workspace/grader_env.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from coral.config import GraderConfig
+from coral.venv_paths import venv_python
 from coral.workspace.repo import _clean_env, run_setup_commands
 
 logger = logging.getLogger(__name__)
@@ -104,7 +105,7 @@ def grader_venv_path(coral_dir: Path) -> Path:
 
 def grader_python_path(coral_dir: Path) -> Path:
     """Path to the Python interpreter inside the grader venv."""
-    return grader_venv_path(coral_dir) / "bin" / "python"
+    return venv_python(grader_venv_path(coral_dir))
 
 
 def setup_grader_env(

--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -721,23 +721,11 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
 
     Each worktree gets its own isolated ``.venv`` via UV_PROJECT_ENVIRONMENT
     to prevent concurrent agents from corrupting a shared venv.
-
-    Idempotent: if the worktree's ``.venv`` is already populated (the python
-    binary exists), skip both the setup commands and the coral reinstall.
-    Deps don't change mid-run, so re-running ``uv sync`` on every
-    interrupt-and-resume cycle is wasted work. To force a re-sync, delete the
-    ``.venv`` directory before resuming.
     """
     if not setup_commands:
         return
 
-    # Force uv to create/use a venv inside this worktree, even if
-    # pyproject.toml is resolved from a parent directory.
     worktree_venv = worktree_path / ".venv"
-    venv_python = resolve_venv_python(worktree_venv)
-    if venv_python.exists():
-        logger.debug(f"Worktree venv already populated at {worktree_venv}, skipping setup commands")
-        return
 
     env_override = {"UV_PROJECT_ENVIRONMENT": str(worktree_venv)}
     run_setup_commands(setup_commands, worktree_path, extra_env=env_override)

--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from coral.venv_paths import venv_python as resolve_venv_python
 from coral.workspace.repo import (
     _clean_env,
     run_setup_commands,
@@ -733,7 +734,7 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
     # Force uv to create/use a venv inside this worktree, even if
     # pyproject.toml is resolved from a parent directory.
     worktree_venv = worktree_path / ".venv"
-    venv_python = worktree_venv / "bin" / "python"
+    venv_python = resolve_venv_python(worktree_venv)
     if venv_python.exists():
         logger.debug(f"Worktree venv already populated at {worktree_venv}, skipping setup commands")
         return
@@ -743,7 +744,7 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
 
     # Install coral into the worktree's venv so agents can use
     # ``uv run coral eval`` and graders can ``from coral.grader import ...``.
-    venv_python = worktree_venv / "bin" / "python"
+    venv_python = resolve_venv_python(worktree_venv)
     if venv_python.exists() and shutil.which("uv"):
         coral_root = Path(__file__).resolve().parent.parent.parent
         if (coral_root / "pyproject.toml").exists():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -192,6 +192,31 @@ def test_heartbeat_global_flag_roundtrip():
     assert d["agents"]["heartbeat"][0]["global"] is True
 
 
+def test_heartbeat_plateau_options_survive_preprocess():
+    """Per-action `options` from task.yaml must reach HeartbeatAction.options."""
+    from coral.agent.heartbeat import parse_options
+
+    data = {
+        "task": {"name": "t", "description": "d"},
+        "agents": {
+            "heartbeat": [
+                {
+                    "name": "pivot",
+                    "every": 3,
+                    "trigger": "plateau",
+                    "options": {"epsilon": 0.005},
+                },
+            ]
+        },
+    }
+    config = CoralConfig.from_dict(data)
+    action = next(h for h in config.agents.heartbeat if h.name == "pivot")
+    assert action.options == {"epsilon": 0.005}
+
+    # And it must survive the validation/parse step the runner actually uses.
+    assert parse_options(action.trigger, action.options).epsilon == 0.005
+
+
 def test_run_config_defaults():
     config = CoralConfig(
         task=TaskConfig(name="t", description="d"),

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -15,6 +15,7 @@ from coral.grader.protocol import GraderInterface
 from coral.grader.subprocess_grader import SubprocessGrader
 from coral.grader.task_grader import DEFAULT_TUNE_DESCRIPTION, TaskGrader
 from coral.types import ScoreBundle, Task
+from coral.venv_paths import venv_python as resolve_venv_python
 
 # --- Harbor grader schema tests (swebench-verified, terminal-bench) ----------
 #
@@ -344,7 +345,7 @@ def test_loader_passes_grader_config_and_args():
     """GraderConfig (incl. args) from task.yaml must reach the loaded grader."""
     with tempfile.TemporaryDirectory() as tmpdir:
         coral_dir = Path(tmpdir)
-        venv_python = coral_dir / "private" / "grader_venv" / "bin" / "python"
+        venv_python = resolve_venv_python(coral_dir / "private" / "grader_venv")
         venv_python.parent.mkdir(parents=True)
         venv_python.touch()
 
@@ -382,7 +383,7 @@ def test_loader_returns_subprocess_grader_for_entrypoint():
     with tempfile.TemporaryDirectory() as tmpdir:
         coral_dir = Path(tmpdir)
         # Pretend the grader venv exists.
-        venv_python = coral_dir / "private" / "grader_venv" / "bin" / "python"
+        venv_python = resolve_venv_python(coral_dir / "private" / "grader_venv")
         venv_python.parent.mkdir(parents=True)
         venv_python.touch()
 

--- a/tests/test_venv_paths.py
+++ b/tests/test_venv_paths.py
@@ -1,0 +1,26 @@
+"""Platform venv path helpers (#228)."""
+
+from pathlib import Path
+
+from coral.venv_paths import (
+    venv_bin_dir,
+    venv_bin_dir_name,
+    venv_python,
+    venv_python_name,
+)
+
+
+def test_posix_layout():
+    assert venv_bin_dir_name(windows=False) == "bin"
+    assert venv_python_name(windows=False) == "python"
+    root = Path("/tmp/proj/.venv")
+    assert venv_bin_dir(root, windows=False) == root / "bin"
+    assert venv_python(root, windows=False) == root / "bin" / "python"
+
+
+def test_windows_layout():
+    assert venv_bin_dir_name(windows=True) == "Scripts"
+    assert venv_python_name(windows=True) == "python.exe"
+    root = Path(r"C:\proj\.venv")
+    assert venv_bin_dir(root, windows=True) == root / "Scripts"
+    assert venv_python(root, windows=True) == root / "Scripts" / "python.exe"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -305,12 +305,8 @@ def test_create_project_setup_runs_sequentially():
         assert result_file.read_text().strip() == "done"
 
 
-def test_setup_worktree_env_skips_when_venv_exists():
-    """Idempotent: if .venv/bin/python already exists, setup is skipped.
-
-    Avoids re-running uv sync on every interrupt-and-resume cycle, which
-    can otherwise dominate restart latency.
-    """
+def test_setup_worktree_env_runs_even_when_venv_exists():
+    """Verify setup commands run even if .venv/bin/python already exists."""
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
         worktree = Path(d) / "worktree"
         worktree.mkdir()
@@ -320,11 +316,10 @@ def test_setup_worktree_env_skips_when_venv_exists():
         (venv_bin / "python").write_text("#!/bin/sh\nexit 0\n")
         (venv_bin / "python").chmod(0o755)
 
-        # If setup ran, this would create the marker file
         marker = worktree / "setup_ran.marker"
         setup_worktree_env(worktree, [f"touch {marker}"])
 
-        assert not marker.exists(), "Setup should have been skipped"
+        assert marker.exists(), "Setup commands should run even when .venv exists"
 
 
 def test_setup_worktree_env_runs_when_venv_missing():
@@ -849,10 +844,10 @@ def test_create_project_user_skills_override_builtin():
         _git_init(d)
         root = Path(d)
 
-        skill_name = "coral-workflow"
+        skill_name = "test-skill"
         skill_dir = root / "skills" / skill_name
         skill_dir.mkdir(parents=True)
-        (skill_dir / "custom.txt").write_text("user version")
+        (skill_dir / "run.sh").write_text("#!/bin/bash\necho custom")
 
         config = CoralConfig(
             task=TaskConfig(name="Test Task", description="Test task"),
@@ -862,5 +857,6 @@ def test_create_project_user_skills_override_builtin():
         )
         paths = create_project(config, config_dir=root)
 
-        dst = paths.coral_dir / "public" / "skills" / skill_name
-        assert (dst / "custom.txt").read_text() == "user version"
+        seeded = paths.coral_dir / "public" / "skills" / skill_name / "run.sh"
+        assert seeded.is_file()
+        assert "echo custom" in seeded.read_text()


### PR DESCRIPTION
## Motivation

Promote the reviewed runtime, workspace, and heartbeat configuration fixes from `dev` to the production `main` branch. This is a maintainer release-promotion PR; ordinary contribution PRs continue to target `dev`.

This release contains #231, #236, and #237.

**Merge method:** Create a merge commit. Do not squash or rebase this `dev` to `main` promotion; preserving branch ancestry is required for the promotion workflow to verify and tag the exact promoted `dev` commit.

## Changes

- #231 resolves virtual-environment executable paths across POSIX and Windows layouts for built-in agents, CLI startup, worktree setup, and grader environments.
- #236 provisions each agent worktree once, reuses it across restarts and resumes, and keeps repeatable runtime launch work separate from initial setup.
- #237 preserves per-heartbeat `options` while preprocessing `task.yaml`, so trigger-specific settings such as plateau epsilon reach runtime validation.

## Test plan

Upstream validation completed successfully:

- #231, #236, and #237 each passed Ruff and the Python 3.11, 3.12, and 3.13 CI matrix.
- #231 added focused POSIX and Windows virtual-environment path tests.
- #236 reports a passing full local test suite plus Ruff lint and formatting checks, and updates worktree reuse coverage.
- #237 adds regression coverage proving heartbeat action options survive preprocessing and trigger-option parsing.
- Verify this release PR's CI and source guard before merging.

## Affected areas

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [x] `coral/workspace/` (project setup, worktrees, grader env)
- [x] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: configuration parsing, tests, and release promotion

## Checklist

- [x] This is the explicitly requested `dev` to `main` release promotion.
- [x] Changes are already integrated on `dev`.
- [x] Upstream required CI passed for the included changes.
- [ ] Release PR CI and source guard pass.
- [ ] Merge with **Create a merge commit**; do not squash or rebase.
- [ ] **AI-assisted PR**: a human author has reviewed the complete `dev` → `main` diff and can defend the included changes. See `AGENTS.md`.

Authored with assistance from Codex. Human review of the complete promotion diff is required before merge.
