### PR TITLE
fix(workspace): propagate uv pip install failure as RuntimeError

### DIFF
--- a/.claude/skills/coral-new-task/SKILL.md
+++ b/.claude/skills/coral-new-task/SKILL.md
@@ -123,6 +123,7 @@ If the grader needs reference files (model weights, ground-truth answers, scorin
 
 ```python
 import importlib.resources
+
 scorer_dir = str(importlib.resources.files("<task>_grader.scorers"))
 ```
 

--- a/coral/workspace/worktree.py
+++ b/coral/workspace/worktree.py
@@ -747,4 +747,6 @@ def setup_worktree_env(worktree_path: Path, setup_commands: list[str]) -> None:
                 env=env,
             )
             if result.returncode != 0:
-                logger.warning(f"Failed to install coral in worktree: {result.stderr.strip()}")
+                raise RuntimeError(
+                    f"Failed to install coral into worktree venv at {worktree_path}: {result.stderr.strip()}"
+                )

--- a/plugin/skills/creating-a-coral-task/SKILL.md
+++ b/plugin/skills/creating-a-coral-task/SKILL.md
@@ -46,6 +46,7 @@ coral validate .          # bootstraps the grader venv, runs the grader on seed/
 ```python
 from coral.grader import TaskGrader
 
+
 class Grader(TaskGrader):
     def evaluate(self) -> float:
         result = self.run_program(self.args.get("program_file", "solution.py"))

--- a/plugin/skills/creating-a-coral-task/references/cookbook.md
+++ b/plugin/skills/creating-a-coral-task/references/cookbook.md
@@ -41,10 +41,11 @@ Ship the tests under `grader.private` (so agents can't read them — list a dir 
 import json, shutil
 from pathlib import Path
 
+
 def evaluate(self) -> float | ScoreBundle:
     tests = Path(self.private_dir) / "taskdata" / "test_hidden.py"
     dest = Path(self.codebase_path) / "test_hidden.py"
-    shutil.copy(tests, dest)   # codebase_path is force-removed after, so this is safe + temporary
+    shutil.copy(tests, dest)  # codebase_path is force-removed after, so this is safe + temporary
 
     # A tiny in-process pytest plugin counts pass/fail and prints JSON we parse back.
     out = self.run_script_json(
@@ -84,7 +85,9 @@ def evaluate(self) -> float | ScoreBundle:
         return self.fail("output incorrect — speed doesn't count until it's correct")
     baseline = float(self.args.get("baseline_seconds", 1.0))
     ratio = baseline / out["dt"]
-    return self.score(ratio, explanation=f"{ratio:.2f}× baseline ({out['dt']:.3f}s vs {baseline:.3f}s)")
+    return self.score(
+        ratio, explanation=f"{ratio:.2f}× baseline ({out['dt']:.3f}s vs {baseline:.3f}s)"
+    )
 ```
 
 The correctness gate is the important part: gate on correctness, *then* score the thing you're optimizing. Otherwise agents discover that `return 0` is very fast.
@@ -96,12 +99,13 @@ Return several named `Score`s plus one `aggregated` number. Each metric shows in
 ```python
 from coral.types import Score, ScoreBundle
 
+
 def evaluate(self) -> ScoreBundle:
     m = self.run_script_json("...emit {'acc':..,'latency_ms':..,'size_kb':..} ...")
     scores = {
-        "accuracy":   Score(value=m["acc"],            name="accuracy"),
-        "latency":    Score(value=1000.0 / m["latency_ms"], name="latency", explanation="1/sec"),
-        "compactness":Score(value=1.0 / m["size_kb"],   name="compactness"),
+        "accuracy": Score(value=m["acc"], name="accuracy"),
+        "latency": Score(value=1000.0 / m["latency_ms"], name="latency", explanation="1/sec"),
+        "compactness": Score(value=1.0 / m["size_kb"], name="compactness"),
     }
     weights = {"accuracy": 0.7, "latency": 0.2, "compactness": 0.1}
     aggregated = sum(scores[k].value * w for k, w in weights.items())
@@ -123,8 +127,9 @@ When the agent runs `coral eval --tune`, `self.tune` is `True` and the attempt *
 def describe_tune(self) -> str:
     return "Tune mode scores on a 500-example dev slice (≈10× faster); real evals use the full test set."
 
+
 def evaluate(self) -> float | ScoreBundle:
-    n = 500 if self.tune else None        # None = full set
+    n = 500 if self.tune else None  # None = full set
     acc = self._score_on(n_examples=n)
     label = "dev slice" if self.tune else "full test set"
     return self.score(acc, explanation=f"accuracy on {label}")
@@ -146,6 +151,7 @@ grader:
 
 ```python
 from pathlib import Path
+
 _TASKDATA = Path(self.private_dir) / "taskdata"
 ```
 

--- a/plugin/skills/creating-a-coral-task/references/grader-api.md
+++ b/plugin/skills/creating-a-coral-task/references/grader-api.md
@@ -50,17 +50,20 @@ Always run the agent's program through these — they pick the right interpreter
 ```python
 @dataclass
 class Score:
-    value: float | int | None      # None when ungradeable (timeout, crash). Convert pass/fail to a float yourself.
-    name: str                       # "correctness", "efficiency", ...
+    value: (
+        float | int | None
+    )  # None when ungradeable (timeout, crash). Convert pass/fail to a float yourself.
+    name: str  # "correctness", "efficiency", ...
     explanation: str | None = None
     metadata: dict = field(default_factory=dict)
 
+
 @dataclass
 class ScoreBundle:
-    scores: dict[str, Score]        # name -> Score
-    aggregated: float | None = None # the single number used for ranking + plateau detection
-    is_public: bool = True          # False omits the per-score breakdown from public attempts
-    feedback: str | None = None     # message the agent reads
+    scores: dict[str, Score]  # name -> Score
+    aggregated: float | None = None  # the single number used for ranking + plateau detection
+    is_public: bool = True  # False omits the per-score breakdown from public attempts
+    feedback: str | None = None  # message the agent reads
     metadata: dict = field(default_factory=dict)
 ```
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -860,3 +860,36 @@ def test_create_project_user_skills_override_builtin():
         seeded = paths.coral_dir / "public" / "skills" / skill_name / "run.sh"
         assert seeded.is_file()
         assert "echo custom" in seeded.read_text()
+
+
+def test_setup_worktree_env_uv_pip_install_failure(monkeypatch):
+    """Verify that a non-zero exit code from uv pip install raises a RuntimeError."""
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        worktree = Path(d) / "worktree"
+        worktree.mkdir()
+
+        # Mock resolve_venv_python and shutil.which to pass presence checks
+        fake_python = worktree / ".venv" / "bin" / "python"
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
+
+        monkeypatch.setattr("coral.workspace.worktree.resolve_venv_python", lambda venv: fake_python)
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if cmd == "uv" else None)
+
+        # Mock subprocess.run to simulate a failed 'uv pip install' call
+        real_run = subprocess.run
+
+        def mock_subprocess_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and len(cmd) >= 3 and cmd[:3] == ["uv", "pip", "install"]:
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=1,
+                    stdout="",
+                    stderr="forced install failure",
+                )
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr("subprocess.run", mock_subprocess_run)
+
+        with pytest.raises(RuntimeError, match="Failed to install coral into worktree venv"):
+            setup_worktree_env(worktree, ["echo setup"])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -305,7 +305,7 @@ def test_create_project_setup_runs_sequentially():
         assert result_file.read_text().strip() == "done"
 
 
-def test_setup_worktree_env_runs_even_when_venv_exists():
+def test_setup_worktree_env_runs_even_when_venv_exists(monkeypatch):
     """Verify setup commands run even if .venv/bin/python already exists."""
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
         worktree = Path(d) / "worktree"
@@ -315,6 +315,8 @@ def test_setup_worktree_env_runs_even_when_venv_exists():
         venv_bin.mkdir(parents=True)
         (venv_bin / "python").write_text("#!/bin/sh\nexit 0\n")
         (venv_bin / "python").chmod(0o755)
+
+        monkeypatch.setattr("shutil.which", lambda cmd: None)
 
         marker = worktree / "setup_ran.marker"
         setup_worktree_env(worktree, [f"touch {marker}"])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -873,7 +873,9 @@ def test_setup_worktree_env_uv_pip_install_failure(monkeypatch):
         fake_python.parent.mkdir(parents=True)
         fake_python.touch()
 
-        monkeypatch.setattr("coral.workspace.worktree.resolve_venv_python", lambda venv: fake_python)
+        monkeypatch.setattr(
+            "coral.workspace.worktree.resolve_venv_python", lambda venv: fake_python
+        )
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if cmd == "uv" else None)
 
         # Mock subprocess.run to simulate a failed 'uv pip install' call


### PR DESCRIPTION
## Motivation

Previously, `setup_worktree_env()` treated installing CORAL into a newly created worktree virtual environment as a best-effort operation. When `uv pip install` failed with a non-zero exit code, it logged a warning and returned successfully.

Because setup returned normally, downstream execution persisted `.coral_agent_id` (the provisioning readiness breadcrumb). As a result, incomplete worktree environments were marked as fully provisioned, preventing later launches from retrying setup and leaving agents unable to execute `uv run coral eval`.

This violated the successful-provisioning requirements in #211 and affected PR #236.

This closes #238 

## Changes

- **Propagate installation failure**: Updated `setup_worktree_env()` in `coral/workspace/worktree.py` to raise a `RuntimeError` containing `result.stderr` whenever `uv pip install` returns a non-zero exit code.
- **Unit test coverage**: Added `test_setup_worktree_env_uv_pip_install_failure()` in `tests/test_workspace.py` to verify that `uv pip install` failures raise a `RuntimeError` as expected.

## Test plan

- Executed workspace unit tests: `uv run pytest tests/test_workspace.py -v`
- Verified that `test_setup_worktree_env_uv_pip_install_failure` succeeds and correctly catches the raised `RuntimeError`.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [x] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other: <!-- specify -->

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).