### PR TITLE
feat(task): add structured validation runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Key concepts:
 |-----------|---------|
 | `coral/types.py` | Core types: `Task`, `Score`, `ScoreBundle`, `Attempt` |
 | `coral/config.py` | OmegaConf-backed YAML configuration (`CoralConfig`, `GraderConfig`, `AgentConfig`, `GatewayConfig`, `WarmStartConfig`, `HeartbeatActionConfig`, ...) |
-| `coral/task/` | Frontend-independent task validation with structured reports and diagnostics |
+| `coral/task/` | Frontend-independent task validation with structured reports, progress events, and baseline grading |
 | `coral/agent/` | Agent lifecycle: `manager.py` (multi-agent supervisor), `runtime.py` (abstract), `state.py`, `heartbeat.py`, `exit_classifier.py`, `warmstart.py`, `process.py`, `registry.py` |
 | `coral/sandbox/` | Pluggable agent sandboxing (`agents.sandbox`): `protocol.py` (`SandboxProvider` + spec/context types), `registry.py` (name or `module:Class` entrypoint resolution), `srt.py` (built-in srt provider: OS-level FS/network enforcement + allow-all proxy) |
 | `coral/agent/builtin/` | Concrete runtimes: `claude_code`, `codex`, `cursor_agent`, `kiro`, `opencode` |

--- a/coral/cli/author.py
+++ b/coral/cli/author.py
@@ -6,6 +6,10 @@ import argparse
 import re
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from coral.task.validation import ValidationProgressEvent
 
 
 def _module_identifier(name: str) -> str:
@@ -163,101 +167,47 @@ def cmd_init(args: argparse.Namespace) -> None:
     print("  coral start -c task.yaml  # launch agents")
 
 
+def _render_validation_progress(event: ValidationProgressEvent) -> None:
+    """Render shared validation progress with the legacy CLI wording."""
+    if event.stage == "structure" and event.status == "completed":
+        print("Validation: OK")
+    elif event.stage == "workspace" and event.status == "completed":
+        print(event.message)
+    elif event.stage == "grader_environment" and event.status == "started":
+        print(event.message)
+    elif event.stage == "baseline" and event.status == "started":
+        print(f"\n{event.message}")
+
+
 def cmd_validate(args: argparse.Namespace) -> None:
     """Test your grader against seed code.
 
     Examples:
       coral validate my-task        Dry-run the grader in my-task/
     """
-    import shutil
-    import tempfile
-
-    from coral.cli.validation import validate_task
-    from coral.config import CoralConfig
+    from coral.task.validation import run_validation
 
     task_dir = Path(args.path).resolve()
+    result = run_validation(task_dir, on_event=_render_validation_progress)
 
-    errors = validate_task(task_dir)
-    if errors:
-        print("Validation errors:", file=sys.stderr)
-        for err in errors:
-            print(f"  - {err}", file=sys.stderr)
-        sys.exit(1)
-    print("Validation: OK")
-
-    config = CoralConfig.from_yaml(task_dir / "task.yaml")
-
-    with tempfile.TemporaryDirectory(prefix="coral_test_eval_") as tmpdir:
-        tmpdir = Path(tmpdir)
-        workspace = tmpdir / "workspace"
-        workspace.mkdir()
-
-        seed_dir = task_dir / "seed"
-        if seed_dir.is_dir() and any(seed_dir.iterdir()):
-            for item in seed_dir.iterdir():
-                if item.name == "__pycache__":
-                    continue
-                dst = workspace / item.name
-                if item.is_dir():
-                    shutil.copytree(item, dst)
-                else:
-                    shutil.copy2(item, dst)
-            print(f"Seed: copied {seed_dir.name}/ into workspace")
+    if result.failure is not None:
+        if result.failure.stage == "structure" and result.report.error_messages:
+            print("Validation errors:", file=sys.stderr)
+            for error in result.report.error_messages:
+                print(f"  - {error}", file=sys.stderr)
+        elif result.failure.stage == "baseline":
+            print(f"\n{result.failure.message}", file=sys.stderr)
         else:
-            print("Warning: No seed/ directory — grader will run against an empty workspace.")
-            print("  This is fine if your task expects agents to build from scratch.")
+            print(result.failure.message, file=sys.stderr)
+        sys.exit(1)
 
-        coral_dir = tmpdir / ".coral"
-        private_dir = coral_dir / "private"
-        private_dir.mkdir(parents=True)
+    if result.baseline is None:
+        print("Validation failed: no baseline result", file=sys.stderr)
+        sys.exit(1)
 
-        for private_path_str in config.grader.private:
-            src = Path(private_path_str)
-            if not src.is_absolute():
-                src = (task_dir / src).resolve()
-            if src.exists():
-                dst = private_dir / src.name
-                if src.is_dir():
-                    shutil.copytree(src, dst)
-                else:
-                    shutil.copy2(src, dst)
-
-        # Bootstrap the grader's isolated venv where the entrypoint runs.
-        from coral.workspace.grader_env import setup_grader_env
-
-        print("Setting up grader venv (.coral/private/grader_venv)...")
-        setup_grader_env(coral_dir, config.grader, task_dir)
-
-        from coral.grader.loader import load_grader
-        from coral.types import Task
-
-        try:
-            grader = load_grader(config, coral_dir)
-        except Exception as e:
-            print(f"Error loading grader: {e}", file=sys.stderr)
-            sys.exit(1)
-
-        task = Task(
-            id=config.task.name,
-            name=config.task.name,
-            description=config.task.description,
-        )
-
-        print(
-            f"\nRunning grader against {'seed code' if seed_dir.is_dir() else 'empty workspace'}..."
-        )
-        import asyncio
-
-        try:
-            result = asyncio.run(grader.grade(str(workspace), [task]))
-            score = result.aggregated
-            print(f"\n{'=' * 50}")
-            print(f"Score: {score}")
-            if result.scores:
-                for name, s in result.scores.items():
-                    if s.explanation:
-                        print(f"  {name}: {s.explanation}")
-            print(f"{'=' * 50}")
-        except Exception as e:
-            print(f"\nGrader crashed: {e}", file=sys.stderr)
-            sys.exit(1)
+    print(f"\n{'=' * 50}")
+    print(f"Score: {result.baseline.aggregated}")
+    for name, score in result.baseline.scores.items():
+        if score.explanation:
+            print(f"  {name}: {score.explanation}")
+    print(f"{'=' * 50}")

--- a/coral/task/__init__.py
+++ b/coral/task/__init__.py
@@ -1,5 +1,21 @@
 """Task inspection and validation APIs."""
 
-from coral.task.validation import ValidationDiagnostic, ValidationReport, validate_task
+from coral.task.validation import (
+    ValidationDiagnostic,
+    ValidationFailure,
+    ValidationProgressEvent,
+    ValidationReport,
+    ValidationRunResult,
+    run_validation,
+    validate_task,
+)
 
-__all__ = ["ValidationDiagnostic", "ValidationReport", "validate_task"]
+__all__ = [
+    "ValidationDiagnostic",
+    "ValidationFailure",
+    "ValidationProgressEvent",
+    "ValidationReport",
+    "ValidationRunResult",
+    "run_validation",
+    "validate_task",
+]

--- a/coral/task/__init__.py
+++ b/coral/task/__init__.py
@@ -7,6 +7,7 @@ from coral.task.validation import (
     ValidationReport,
     ValidationRunResult,
     run_validation,
+    run_validation_async,
     validate_task,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "ValidationReport",
     "ValidationRunResult",
     "run_validation",
+    "run_validation_async",
     "validate_task",
 ]

--- a/coral/task/validation.py
+++ b/coral/task/validation.py
@@ -226,12 +226,12 @@ def validate_task(task_dir: Path) -> ValidationReport:
     return ValidationReport(task_dir, tuple(diagnostics))
 
 
-def run_validation(
+async def run_validation_async(
     task_dir: Path,
     *,
     on_event: Callable[[ValidationProgressEvent], None] | None = None,
 ) -> ValidationRunResult:
-    """Run structural checks and grade the task baseline in an isolated workspace."""
+    """Run structural checks and asynchronously grade a task baseline."""
     events: list[ValidationProgressEvent] = []
 
     def emit(stage: ValidationStage, status: ValidationProgressStatus, message: str) -> None:
@@ -372,9 +372,18 @@ def run_validation(
         target = "seed code" if seed_dir.is_dir() else "empty workspace"
         emit("baseline", "started", f"Running grader against {target}...")
         try:
-            baseline = asyncio.run(grader.grade(str(workspace), [task]))
+            baseline = await grader.grade(str(workspace), [task])
         except Exception as exc:
             return stop("baseline", "grader.baseline.failed", f"Grader crashed: {exc}")
         emit("baseline", "completed", "Baseline grading completed")
 
     return ValidationRunResult(report=report, events=tuple(events), baseline=baseline)
+
+
+def run_validation(
+    task_dir: Path,
+    *,
+    on_event: Callable[[ValidationProgressEvent], None] | None = None,
+) -> ValidationRunResult:
+    """Run validation synchronously for CLI and other non-async callers."""
+    return asyncio.run(run_validation_async(task_dir, on_event=on_event))

--- a/coral/task/validation.py
+++ b/coral/task/validation.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+import shutil
+import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
 from coral.config import CoralConfig
+from coral.types import ScoreBundle, Task
 
 
 @dataclass(frozen=True)
@@ -52,6 +57,71 @@ class ValidationReport:
             "task_dir": str(self.task_dir),
             "valid": self.valid,
             "diagnostics": [diagnostic.to_dict() for diagnostic in self.diagnostics],
+        }
+
+
+ValidationStage = Literal[
+    "structure",
+    "workspace",
+    "grader_environment",
+    "grader_load",
+    "baseline",
+]
+ValidationProgressStatus = Literal["started", "completed", "failed"]
+
+
+@dataclass(frozen=True)
+class ValidationProgressEvent:
+    """One frontend-neutral progress update from a validation run."""
+
+    stage: ValidationStage
+    status: ValidationProgressStatus
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "stage": self.stage,
+            "status": self.status,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationFailure:
+    """A structured failure that stopped a validation run."""
+
+    stage: ValidationStage
+    code: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "stage": self.stage,
+            "code": self.code,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationRunResult:
+    """Structural diagnostics, progress, and baseline output from one run."""
+
+    report: ValidationReport
+    events: tuple[ValidationProgressEvent, ...]
+    baseline: ScoreBundle | None = None
+    failure: ValidationFailure | None = None
+
+    @property
+    def successful(self) -> bool:
+        return self.report.valid and self.failure is None and self.baseline is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "successful": self.successful,
+            "report": self.report.to_dict(),
+            "events": [event.to_dict() for event in self.events],
+            "baseline": self.baseline.to_dict() if self.baseline is not None else None,
+            "failure": self.failure.to_dict() if self.failure is not None else None,
         }
 
 
@@ -154,3 +224,157 @@ def validate_task(task_dir: Path) -> ValidationReport:
             )
 
     return ValidationReport(task_dir, tuple(diagnostics))
+
+
+def run_validation(
+    task_dir: Path,
+    *,
+    on_event: Callable[[ValidationProgressEvent], None] | None = None,
+) -> ValidationRunResult:
+    """Run structural checks and grade the task baseline in an isolated workspace."""
+    events: list[ValidationProgressEvent] = []
+
+    def emit(stage: ValidationStage, status: ValidationProgressStatus, message: str) -> None:
+        event = ValidationProgressEvent(stage=stage, status=status, message=message)
+        events.append(event)
+        if on_event is not None:
+            on_event(event)
+
+    emit("structure", "started", "Checking task structure")
+    try:
+        report = validate_task(task_dir)
+    except Exception as exc:
+        message = f"Failed to validate task structure: {exc}"
+        report = ValidationReport(
+            task_dir=task_dir,
+            diagnostics=(
+                ValidationDiagnostic(
+                    code="task.structure.failed",
+                    message=message,
+                ),
+            ),
+        )
+        failure = ValidationFailure(
+            stage="structure",
+            code="task.structure.failed",
+            message=message,
+        )
+        emit(failure.stage, "failed", failure.message)
+        return ValidationRunResult(report=report, events=tuple(events), failure=failure)
+
+    def stop(stage: ValidationStage, code: str, message: str) -> ValidationRunResult:
+        failure = ValidationFailure(stage=stage, code=code, message=message)
+        emit(stage, "failed", message)
+        return ValidationRunResult(report=report, events=tuple(events), failure=failure)
+
+    if not report.valid:
+        return stop(
+            "structure",
+            "task.structure.invalid",
+            "Task structure validation failed",
+        )
+    try:
+        config = CoralConfig.from_yaml(task_dir / "task.yaml")
+    except Exception as exc:
+        return stop(
+            "structure",
+            "task.config.load_failed",
+            f"Failed to load task configuration: {exc}",
+        )
+    emit("structure", "completed", "Task structure is valid")
+
+    emit("workspace", "started", "Preparing validation workspace")
+    try:
+        tempdir = tempfile.TemporaryDirectory(prefix="coral_test_eval_")
+    except Exception as exc:
+        return stop(
+            "workspace",
+            "task.workspace.failed",
+            f"Failed to prepare validation workspace: {exc}",
+        )
+
+    with tempdir as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+        workspace = tmpdir / "workspace"
+        try:
+            workspace.mkdir()
+            seed_dir = task_dir / "seed"
+            has_seed = seed_dir.is_dir() and any(seed_dir.iterdir())
+            if has_seed:
+                for item in seed_dir.iterdir():
+                    if item.name == "__pycache__":
+                        continue
+                    dst = workspace / item.name
+                    if item.is_dir():
+                        shutil.copytree(item, dst)
+                    else:
+                        shutil.copy2(item, dst)
+                workspace_message = f"Seed: copied {seed_dir.name}/ into workspace"
+            else:
+                workspace_message = (
+                    "Warning: No seed/ directory — grader will run against an empty workspace.\n"
+                    "  This is fine if your task expects agents to build from scratch."
+                )
+
+            coral_dir = tmpdir / ".coral"
+            private_dir = coral_dir / "private"
+            private_dir.mkdir(parents=True)
+
+            for private_path_str in config.grader.private:
+                src = Path(private_path_str)
+                if not src.is_absolute():
+                    src = (task_dir / src).resolve()
+                if src.exists():
+                    dst = private_dir / src.name
+                    if src.is_dir():
+                        shutil.copytree(src, dst)
+                    else:
+                        shutil.copy2(src, dst)
+        except Exception as exc:
+            return stop(
+                "workspace",
+                "task.workspace.failed",
+                f"Failed to prepare validation workspace: {exc}",
+            )
+        emit("workspace", "completed", workspace_message)
+
+        from coral.workspace.grader_env import setup_grader_env
+
+        emit(
+            "grader_environment",
+            "started",
+            "Setting up grader venv (.coral/private/grader_venv)...",
+        )
+        try:
+            setup_grader_env(coral_dir, config.grader, task_dir)
+        except Exception as exc:
+            return stop(
+                "grader_environment",
+                "grader.environment.failed",
+                f"Failed to set up grader environment: {exc}",
+            )
+        emit("grader_environment", "completed", "Grader environment is ready")
+
+        from coral.grader.loader import load_grader
+
+        emit("grader_load", "started", "Loading grader entrypoint")
+        try:
+            grader = load_grader(config, coral_dir)
+        except Exception as exc:
+            return stop("grader_load", "grader.load.failed", f"Error loading grader: {exc}")
+        emit("grader_load", "completed", "Grader entrypoint loaded")
+
+        task = Task(
+            id=config.task.name,
+            name=config.task.name,
+            description=config.task.description,
+        )
+        target = "seed code" if seed_dir.is_dir() else "empty workspace"
+        emit("baseline", "started", f"Running grader against {target}...")
+        try:
+            baseline = asyncio.run(grader.grade(str(workspace), [task]))
+        except Exception as exc:
+            return stop("baseline", "grader.baseline.failed", f"Grader crashed: {exc}")
+        emit("baseline", "completed", "Baseline grading completed")
+
+    return ValidationRunResult(report=report, events=tuple(events), baseline=baseline)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import tempfile
 from pathlib import Path
 
@@ -192,6 +193,38 @@ def test_run_validation_returns_baseline_and_progress_events(tmp_path, monkeypat
     ]
 
 
+async def test_run_validation_async_runs_inside_existing_event_loop(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    class FakeGrader:
+        async def grade(self, codebase_path, tasks):
+            assert asyncio.get_running_loop().is_running()
+            return ScoreBundle(
+                scores={"eval": Score(value=2.0, name="eval", explanation="async baseline")},
+                aggregated=2.0,
+            )
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: None,
+    )
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: FakeGrader(),
+    )
+
+    observed_events = []
+    result = await task_validation.run_validation_async(
+        task_dir,
+        on_event=observed_events.append,
+    )
+
+    assert result.successful
+    assert result.baseline.aggregated == 2.0
+    assert observed_events == list(result.events)
+    assert (result.events[-1].stage, result.events[-1].status) == ("baseline", "completed")
+
+
 def test_run_validation_returns_structured_grader_environment_failure(tmp_path, monkeypatch):
     task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
 
@@ -357,6 +390,7 @@ def test_task_package_exports_validation_runner_api():
     import coral.task as task_api
 
     assert task_api.run_validation is task_validation.run_validation
+    assert task_api.run_validation_async is task_validation.run_validation_async
     assert task_api.ValidationProgressEvent is task_validation.ValidationProgressEvent
     assert task_api.ValidationFailure is task_validation.ValidationFailure
     assert task_api.ValidationRunResult is task_validation.ValidationRunResult

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import argparse
 import tempfile
 from pathlib import Path
 
+import pytest
+
+from coral.cli.author import cmd_validate
 from coral.cli.validation import validate_task
 from coral.task import validation as task_validation
 from coral.task.validation import ValidationDiagnostic, ValidationReport
+from coral.types import Score, ScoreBundle
 
 _TASK_YAML = """\
 task:
@@ -123,3 +128,405 @@ def test_validate_rejects_private_inside_grader_package():
         errors = validate_task(task_dir)
         assert any("inside the grader package" in e for e in errors)
         assert any("grader/taskdata" in e for e in errors)
+
+
+def test_run_validation_returns_baseline_and_progress_events(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+    seed_dir = task_dir / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "solution.txt").write_text("baseline", encoding="utf-8")
+
+    def fake_setup_grader_env(coral_dir, grader_config, config_dir):
+        assert (coral_dir / "private").is_dir()
+        assert grader_config.entrypoint == "p.g:G"
+        assert config_dir == task_dir
+
+    class FakeGrader:
+        async def grade(self, codebase_path, tasks):
+            assert (Path(codebase_path) / "solution.txt").read_text(encoding="utf-8") == "baseline"
+            assert [(task.id, task.name, task.description) for task in tasks] == [("t", "t", "d")]
+            return ScoreBundle(
+                scores={"eval": Score(value=1.25, name="eval", explanation="baseline ok")},
+                aggregated=1.25,
+            )
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        fake_setup_grader_env,
+    )
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: FakeGrader(),
+    )
+
+    observed_events = []
+    result = task_validation.run_validation(task_dir, on_event=observed_events.append)
+
+    assert result.successful
+    assert result.report.valid
+    assert result.baseline.to_dict() == {
+        "scores": {
+            "eval": {
+                "value": 1.25,
+                "name": "eval",
+                "explanation": "baseline ok",
+                "metadata": {},
+            }
+        },
+        "aggregated": 1.25,
+        "is_public": True,
+    }
+    assert result.failure is None
+    assert observed_events == list(result.events)
+    assert [(event.stage, event.status) for event in result.events] == [
+        ("structure", "started"),
+        ("structure", "completed"),
+        ("workspace", "started"),
+        ("workspace", "completed"),
+        ("grader_environment", "started"),
+        ("grader_environment", "completed"),
+        ("grader_load", "started"),
+        ("grader_load", "completed"),
+        ("baseline", "started"),
+        ("baseline", "completed"),
+    ]
+
+
+def test_run_validation_returns_structured_grader_environment_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    def fail_setup(coral_dir, grader_config, config_dir):
+        raise RuntimeError("install failed")
+
+    monkeypatch.setattr("coral.workspace.grader_env.setup_grader_env", fail_setup)
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: pytest.fail("grader loading must not run after setup fails"),
+    )
+
+    observed_events = []
+    result = task_validation.run_validation(task_dir, on_event=observed_events.append)
+
+    assert not result.successful
+    assert result.baseline is None
+    assert result.failure.stage == "grader_environment"
+    assert result.failure.code == "grader.environment.failed"
+    assert result.failure.message == "Failed to set up grader environment: install failed"
+    assert observed_events[-1] == result.events[-1]
+    assert (result.events[-1].stage, result.events[-1].status) == (
+        "grader_environment",
+        "failed",
+    )
+
+
+def test_run_validation_returns_structured_baseline_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    class FailingGrader:
+        async def grade(self, codebase_path, tasks):
+            raise ValueError("invalid baseline output")
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: None,
+    )
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: FailingGrader(),
+    )
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.baseline is None
+    assert result.failure.stage == "baseline"
+    assert result.failure.code == "grader.baseline.failed"
+    assert result.failure.message == "Grader crashed: invalid baseline output"
+    assert (result.events[-1].stage, result.events[-1].status) == ("baseline", "failed")
+
+
+def test_run_validation_returns_structured_grader_load_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    def fail_load(config, coral_dir):
+        raise ImportError("grader package missing")
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: None,
+    )
+    monkeypatch.setattr("coral.grader.loader.load_grader", fail_load)
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.failure.stage == "grader_load"
+    assert result.failure.code == "grader.load.failed"
+    assert result.failure.message == "Error loading grader: grader package missing"
+    assert (result.events[-1].stage, result.events[-1].status) == ("grader_load", "failed")
+
+
+def test_validation_run_result_is_serializable():
+    report = ValidationReport(task_dir=Path("task"), diagnostics=())
+    event = task_validation.ValidationProgressEvent(
+        stage="grader_load",
+        status="failed",
+        message="Error loading grader: missing",
+    )
+    failure = task_validation.ValidationFailure(
+        stage="grader_load",
+        code="grader.load.failed",
+        message="Error loading grader: missing",
+    )
+    result = task_validation.ValidationRunResult(
+        report=report,
+        events=(event,),
+        failure=failure,
+    )
+
+    assert result.to_dict() == {
+        "successful": False,
+        "report": {
+            "task_dir": "task",
+            "valid": True,
+            "diagnostics": [],
+        },
+        "events": [
+            {
+                "stage": "grader_load",
+                "status": "failed",
+                "message": "Error loading grader: missing",
+            }
+        ],
+        "baseline": None,
+        "failure": {
+            "stage": "grader_load",
+            "code": "grader.load.failed",
+            "message": "Error loading grader: missing",
+        },
+    }
+
+
+def test_run_validation_returns_structured_workspace_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+    seed_dir = task_dir / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "solution.txt").write_text("baseline", encoding="utf-8")
+
+    def fail_copy(source, destination):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(task_validation.shutil, "copy2", fail_copy)
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: pytest.fail(
+            "grader setup must not run after workspace preparation fails"
+        ),
+    )
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.failure.stage == "workspace"
+    assert result.failure.code == "task.workspace.failed"
+    assert result.failure.message == "Failed to prepare validation workspace: disk full"
+    assert (result.events[-1].stage, result.events[-1].status) == ("workspace", "failed")
+
+
+def test_run_validation_structures_temp_workspace_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    def fail_tempdir(*args, **kwargs):
+        raise OSError("no temporary space")
+
+    monkeypatch.setattr(task_validation.tempfile, "TemporaryDirectory", fail_tempdir)
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.failure.stage == "workspace"
+    assert result.failure.code == "task.workspace.failed"
+    assert result.failure.message == ("Failed to prepare validation workspace: no temporary space")
+    assert [(event.stage, event.status) for event in result.events[-2:]] == [
+        ("workspace", "started"),
+        ("workspace", "failed"),
+    ]
+
+
+def test_task_package_exports_validation_runner_api():
+    import coral.task as task_api
+
+    assert task_api.run_validation is task_validation.run_validation
+    assert task_api.ValidationProgressEvent is task_validation.ValidationProgressEvent
+    assert task_api.ValidationFailure is task_validation.ValidationFailure
+    assert task_api.ValidationRunResult is task_validation.ValidationRunResult
+
+
+def test_run_validation_stops_after_structural_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, "  timeout: 60")
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: pytest.fail(
+            "grader setup must not run when structural validation fails"
+        ),
+    )
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert not result.report.valid
+    assert result.report.diagnostics[0].code == "grader.entrypoint.missing"
+    assert result.failure.stage == "structure"
+    assert result.failure.code == "task.structure.invalid"
+    assert [(event.stage, event.status) for event in result.events] == [
+        ("structure", "started"),
+        ("structure", "failed"),
+    ]
+
+
+def test_run_validation_structures_config_reload_failure(tmp_path, monkeypatch):
+    task_dir = tmp_path / "task"
+    report = ValidationReport(task_dir=task_dir, diagnostics=())
+
+    class FailingConfig:
+        @classmethod
+        def from_yaml(cls, path):
+            raise OSError("changed during validation")
+
+    monkeypatch.setattr(task_validation, "validate_task", lambda path: report)
+    monkeypatch.setattr(task_validation, "CoralConfig", FailingConfig)
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.failure.stage == "structure"
+    assert result.failure.code == "task.config.load_failed"
+    assert result.failure.message == (
+        "Failed to load task configuration: changed during validation"
+    )
+    assert [(event.stage, event.status) for event in result.events] == [
+        ("structure", "started"),
+        ("structure", "failed"),
+    ]
+
+
+def test_run_validation_structures_unexpected_static_check_failure(tmp_path, monkeypatch):
+    task_dir = tmp_path / "task"
+
+    def fail_validation(path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(task_validation, "validate_task", fail_validation)
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.report.diagnostics[0].code == "task.structure.failed"
+    assert result.report.diagnostics[0].message == (
+        "Failed to validate task structure: permission denied"
+    )
+    assert result.failure.stage == "structure"
+    assert result.failure.code == "task.structure.failed"
+    assert [(event.stage, event.status) for event in result.events] == [
+        ("structure", "started"),
+        ("structure", "failed"),
+    ]
+
+
+def test_cmd_validate_renders_shared_runner_result(tmp_path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    report = ValidationReport(task_dir=task_dir.resolve(), diagnostics=())
+    events = (
+        task_validation.ValidationProgressEvent(
+            stage="structure",
+            status="completed",
+            message="Task structure is valid",
+        ),
+        task_validation.ValidationProgressEvent(
+            stage="workspace",
+            status="completed",
+            message="Seed: copied seed/ into workspace",
+        ),
+        task_validation.ValidationProgressEvent(
+            stage="grader_environment",
+            status="started",
+            message="Setting up grader venv (.coral/private/grader_venv)...",
+        ),
+        task_validation.ValidationProgressEvent(
+            stage="baseline",
+            status="started",
+            message="Running grader against seed code...",
+        ),
+    )
+    baseline = ScoreBundle(
+        scores={"eval": Score(value=1.25, name="eval", explanation="baseline ok")},
+        aggregated=1.25,
+    )
+
+    def fake_run_validation(path, *, on_event=None):
+        assert path == task_dir.resolve()
+        for event in events:
+            on_event(event)
+        return task_validation.ValidationRunResult(
+            report=report,
+            events=events,
+            baseline=baseline,
+        )
+
+    monkeypatch.setattr(task_validation, "run_validation", fake_run_validation)
+
+    cmd_validate(argparse.Namespace(path=str(task_dir)))
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out.splitlines() == [
+        "Validation: OK",
+        "Seed: copied seed/ into workspace",
+        "Setting up grader venv (.coral/private/grader_venv)...",
+        "",
+        "Running grader against seed code...",
+        "",
+        "==================================================",
+        "Score: 1.25",
+        "  eval: baseline ok",
+        "==================================================",
+    ]
+
+
+def test_cmd_validate_prints_structure_failure_without_diagnostics(tmp_path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    failure = task_validation.ValidationFailure(
+        stage="structure",
+        code="task.config.load_failed",
+        message="Failed to load task configuration: changed during validation",
+    )
+    result = task_validation.ValidationRunResult(
+        report=ValidationReport(task_dir=task_dir.resolve(), diagnostics=()),
+        events=(),
+        failure=failure,
+    )
+    monkeypatch.setattr(
+        task_validation,
+        "run_validation",
+        lambda path, on_event=None: result,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_validate(argparse.Namespace(path=str(task_dir)))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "Failed to load task configuration: changed during validation\n"
+
+
+def test_cmd_validate_preserves_static_validation_error_output(tmp_path, capsys):
+    task_dir = _make_task(tmp_path, "  timeout: 60")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_validate(argparse.Namespace(path=str(task_dir)))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("Validation errors:\n  - No grader configured.")


### PR DESCRIPTION
## Motivation

Issue #242 proposes frontend-independent task validation that can be shared by
the CLI, a future TUI, and future web clients. PR #249 introduced structured
static diagnostics, but the full validation workflow—workspace preparation,
grader environment setup, grader loading, and baseline grading—still lived in
`cmd_validate()` and reported runtime failures only through CLI control flow.

This PR completes a focused part of roadmap phase 1 by adding a reusable
validation runner with structured progress and failure data.

Refs #242.

## Changes

- Add serializable `ValidationProgressEvent`, `ValidationFailure`, and
  `ValidationRunResult` types to `coral.task.validation` and export them from
  `coral.task`.
- Add `run_validation()` to run structural checks, prepare an isolated
  workspace and private data, set up/load the grader, and grade the baseline.
- Emit ordered `started` / `completed` / `failed` progress events through both
  a callback and the final result.
- Return structured failures for static checks, task reloads, temporary
  workspace preparation, grader environment setup, grader loading, and
  baseline crashes.
- Make `coral validate` a presentation adapter over the shared runner while
  preserving its successful output and static-error wording.
- Add regression coverage for success, event order, serialization, every
  failure stage, public exports, and CLI compatibility.
- Update `CLAUDE.md` to describe the expanded `coral/task/` responsibility.

This PR does not add `coral validate --json`, a TUI, a TUI framework
dependency, or persistent `TaskDesign` metadata.

## Test plan

- `uv run pytest tests/ -v` — 711 passed, 1 skipped.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — 139 files already formatted.
- `uv run mypy --follow-imports=skip coral/task/validation.py coral/cli/author.py`
  — passed.
- `uv run coral validate examples/dna_design` — `Validation: OK`, 100/100
  sequences valid, and a finalized numeric baseline score.
- `git diff --check upstream/dev...HEAD` — passed.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [x] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: frontend-independent task validation API and developer guidance

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description. (Not applicable; no such contract changes.)
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`. (Not applicable; no new example.)
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

Authored with assistance from Codex. The human author reviewed every changed
line and confirmed the change is ready for maintainer review; the checks listed
above were run locally with Codex assistance.
