### PR TITLE
feat(task): add local Harbor task adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Key concepts:
 - **Agents are the optimizers** — Claude Code (or Codex / Cursor / Kiro / OpenCode) subprocesses, each in its own git worktree.
 - **Shared state via `.coral/`** — split into `public/` (visible to agents through a runtime-specific symlink like `.claude/`, `.codex/`, `.opencode/`) and `private/` (grader venv, hidden inputs — denied to agents). The grader's own *source* is surfaced read-only to agents as `<shared_dir>/grader/` (a symlink to the real `grader/` package) so they can read how they're scored.
 - **Async eval loop** — `coral eval -m "..."` stages+commits and writes a *pending* attempt; a long-running grader daemon picks it up, grades it inside a detached worktree, and writes the final score back. Default behavior blocks until the score lands; `--no-wait` returns immediately.
+- **Harbor source mode** — a mutually exclusive `task.source` form can point at one local Harbor 0.22.0/schema 1.4 task. CORAL derives the instruction, keeps the Harbor task and raw trial logs private, uploads an empty-workspace candidate into a fresh Docker environment, and publishes only named rewards plus a sanitized summary.
 - **CLI orchestration** — 18 commands (see Commands below), grouped under `coral start / status / eval / log / ...`.
 
 ## Directory Structure
@@ -17,12 +18,13 @@ Key concepts:
 | Directory | Purpose |
 |-----------|---------|
 | `coral/types.py` | Core types: `Task`, `Score`, `ScoreBundle`, `Attempt` |
-| `coral/config.py` | OmegaConf-backed YAML configuration (`CoralConfig`, `GraderConfig`, `AgentConfig`, `GatewayConfig`, `WarmStartConfig`, `HeartbeatActionConfig`, ...) |
+| `coral/config.py` | OmegaConf-backed YAML configuration (`CoralConfig`, `TaskRewardConfig`, `GraderConfig`, `AgentConfig`, `GatewayConfig`, `WarmStartConfig`, `HeartbeatActionConfig`, ...) |
+| `coral/harbor_task.py` | Initial-profile local Harbor task inspection, immutable source digest, and private staging |
 | `coral/task/` | Frontend-independent task validation with structured reports, progress events, and baseline grading |
 | `coral/agent/` | Agent lifecycle: `manager.py` (multi-agent supervisor), `runtime.py` (abstract), `state.py`, `heartbeat.py`, `exit_classifier.py`, `warmstart.py`, `process.py`, `registry.py` |
 | `coral/sandbox/` | Pluggable agent sandboxing (`agents.sandbox`): `protocol.py` (`SandboxProvider` + spec/context types), `registry.py` (name or `module:Class` entrypoint resolution), `srt.py` (built-in srt provider: OS-level FS/network enforcement + allow-all proxy) |
 | `coral/agent/builtin/` | Concrete runtimes: `claude_code`, `codex`, `cursor_agent`, `kiro`, `opencode` |
-| `coral/grader/` | Grader stack: `protocol.py`, `base.py`, `task_grader.py`, `loader.py`, `subprocess_grader.py`, `daemon.py` (long-running grader), `builtin/function_grader.py` |
+| `coral/grader/` | Grader stack: `protocol.py`, `base.py`, `task_grader.py`, `loader.py`, `subprocess_grader.py`, `harbor.py` (pinned local-task adapter), `daemon.py`, `builtin/function_grader.py` |
 | `coral/hub/` | Shared state: `attempts.py`, `notes.py`, `skills.py`, `checkpoint.py` (git-tracked snapshots of `.coral/public/`), `heartbeat.py`, `prompts/` (built-in heartbeat prompts) |
 | `coral/hooks/` | `post_commit.py` — implements `submit_eval` (called by `coral eval`) |
 | `coral/workspace/` | Run layout: `project.py` (run dir setup), `worktree.py` (per-agent git worktrees + symlinks), `repo.py` (clone/init), `grader_env.py` (`.coral/private/grader_venv/`) |
@@ -50,6 +52,8 @@ coral start --config task.yaml
     │   │   └── grader_daemon.pid, grader_daemon_heartbeat
     │   ├── private/
     │   │   ├── grader_venv/   isolated uv venv where the grader entrypoint runs
+    │   │   ├── harbor_task/   staged task/tests/solution for task.source mode
+    │   │   ├── harbor_runs/   raw Harbor trial data (never agent-visible)
     │   │   └── ...        anything listed in grader.private (hidden from agents)
     │   ├── config.yaml, config_dir
     │   └── .git/          checkpoint repo for shared-state versioning
@@ -81,7 +85,7 @@ Each agent loop:
 
 - **Python 3.11+**, Hatchling build, **uv** for environment management.
 - **Core deps**: `pyyaml`, `omegaconf`, `starlette` (dashboard).
-- **Optional extras**: `swebench`, `datasets`, `docker`, `harbor` (heavyweight task graders).
+- **Harbor adapter runtime**: `uv` launches exact `harbor==0.22.0` in an isolated Python 3.12 environment; Docker is required, while CORAL's host interpreter remains Python 3.11+.
 - **Runtimes** are external CLIs invoked as subprocesses — Claude Code (`claude`), Codex (`codex`), Cursor Agent (`cursor-agent`), Kiro (`kiro`), OpenCode (`opencode`).
 
 ## Commands
@@ -161,6 +165,8 @@ uv run ruff format .
 
 3. **Wiring a grader**: `grader.entrypoint = "module.path:ClassName"` (required) plus `grader.setup: ["uv pip install -e ./grader"]`. The daemon resolves the entrypoint inside `.coral/private/grader_venv/` via `coral.grader.subprocess_grader.SubprocessGrader`. The legacy `eval/grader.py` auto-discovery has been removed. Hidden data (answer keys, test fixtures) must be declared under `grader.private` (copied into `.coral/private/`, read via `self.private_dir`) — `.coral/private/` is the only path agent runtimes are denied. The rest of the grader package is the opposite of hidden: **everything inside `grader/` is visible to agents** — the whole source is surfaced read-only at `<shared_dir>/grader/` (a symlink to the real package) so they can read how they're scored. So a `grader.private` path must live **outside** `grader/` (conventionally a sibling `taskdata/`, declared as `taskdata`) — `coral validate` errors if one is inside the package, since it would be both copied to `.coral/private/` *and* leaked via the surfaced source. Non-secret bundled data read via `Path(__file__).parent` may sit inside `grader/`, but it's visible — never put a secret there. `FunctionGrader` exists for wrapping plain callables but is no longer wired through `task.yaml` — ship a thin `TaskGrader` subclass instead.
 
+   The exception is the Harbor-backed `task.source` form: user config omits portable grader fields, `config._configure_harbor_task` resolves the local task and wires `coral.grader.harbor:HarborTaskGrader` into the run snapshot, and `workspace.project` stages the complete Harbor task privately. The initial adapter supports only a local, single-step Linux container task and an empty candidate workspace; do not silently widen it to registry, dataset, multi-step, host-worktree, or bulk-migration support.
+
 4. **Eval is async by default**: `coral eval` writes a pending `Attempt` to `.coral/public/attempts/<hash>.json` and the daemon writes the final `ScoreBundle` back. `grader.max_pending_per_agent` (default 1) caps in-flight submissions per agent; `grader.parallel.max_workers` (default 1) controls daemon concurrency — bump only when the grader is concurrency-safe.
 
 5. **Hub modules** are pure I/O over `.coral/public/`:
@@ -182,11 +188,14 @@ uv run ruff format .
 | `pyproject.toml` | Package config, dependencies, `coral` console entrypoint |
 | `coral/types.py` | `Task`, `Score`, `ScoreBundle`, `Attempt` |
 | `coral/config.py` | YAML config dataclasses + OmegaConf merge + dotlist overrides |
+| `coral/harbor_task.py` | Validate/digest/stage a local Harbor task without importing Harbor into CORAL's host interpreter |
 | `coral/grader/protocol.py` | `GraderInterface` protocol |
 | `coral/grader/base.py` | `BaseGrader` base class |
 | `coral/grader/task_grader.py` | `TaskGrader` — recommended base for task graders |
 | `coral/grader/loader.py` | Resolve grader from `grader.entrypoint` (subprocess in grader venv) |
 | `coral/grader/subprocess_grader.py` | Worker-subprocess grader runtime used by entrypoint path |
+| `coral/grader/harbor.py` | Harbor reward adapter and private/public result boundary |
+| `coral/_runners/harbor_task.py` | Python 3.12 subprocess entrypoint using public Harbor Trial/Task APIs |
 | `coral/grader/daemon.py` | Long-running grader daemon (one per run) |
 | `coral/grader/builtin/function_grader.py` | Wrap functions as graders |
 | `coral/workspace/project.py` | `setup_run_dir()` — builds `.coral/{public,private}/`, clones repo, seeds bundled skills/agents |

--- a/coral/_runners/__init__.py
+++ b/coral/_runners/__init__.py
@@ -1,0 +1,1 @@
+"""Subprocess entrypoints that execute in isolated dependency environments."""

--- a/coral/_runners/harbor_task.py
+++ b/coral/_runners/harbor_task.py
@@ -1,0 +1,186 @@
+"""Pinned Harbor v0.22.0 trial runner for the CORAL local-task adapter.
+
+This file is executed by ``uv run --isolated`` under Python 3.12, so importing
+it from CORAL's normal Python environment is neither required nor supported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.metadata
+import json
+import shlex
+from pathlib import Path, PurePosixPath
+from typing import override
+
+from harbor import (
+    AgentContext,
+    BaseAgent,
+    BaseEnvironment,
+    EnvironmentType,
+    Trial,
+    TrialAgentConfig,
+    TrialConfig,
+    TrialEnvironmentConfig,
+    TrialTaskConfig,
+)
+from harbor import (
+    Task as HarborTask,
+)
+
+HARBOR_RUNTIME_VERSION = "0.22.0"
+HARBOR_SCHEMA_VERSION = "1.4"
+_PROTECTED_WORKDIRS = {
+    PurePosixPath("/"),
+    PurePosixPath("/logs"),
+    PurePosixPath("/tests"),
+    PurePosixPath("/solution"),
+}
+
+
+class CandidateWorkspaceAgent(BaseAgent):
+    """Transfer a CORAL candidate into Harbor's agent workdir without optimizing it."""
+
+    SUPPORTS_WINDOWS = False
+
+    def __init__(self, *args: object, codebase_path: str, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self._codebase_path = Path(codebase_path).resolve()
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "coral_candidate_workspace"
+
+    @override
+    def version(self) -> str:
+        return "1"
+
+    @override
+    async def setup(self, environment: BaseEnvironment) -> None:
+        return None
+
+    @override
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        del instruction, context
+        result = await environment.exec("pwd", user="root")
+        if result.return_code != 0:
+            raise RuntimeError(result.stderr or "Harbor environment could not report its workdir")
+        workdir_text = (result.stdout or "").strip()
+        workdir = PurePosixPath(workdir_text)
+        protected = workdir == PurePosixPath("/") or any(
+            workdir == protected_dir or protected_dir in workdir.parents
+            for protected_dir in _PROTECTED_WORKDIRS
+            if protected_dir != PurePosixPath("/")
+        )
+        if not workdir.is_absolute() or protected:
+            raise ValueError(
+                "Harbor task must use a dedicated absolute workdir other than "
+                f"/, /logs, /tests, or /solution; got {workdir_text!r}"
+            )
+
+        quoted = shlex.quote(workdir.as_posix())
+        prepare = await environment.exec(
+            f"mkdir -p {quoted}",
+            cwd="/",
+            user="root",
+        )
+        if prepare.return_code != 0:
+            raise RuntimeError(prepare.stderr or f"Could not prepare Harbor workdir {workdir}")
+        contents = await environment.exec(
+            f"find {quoted} -mindepth 1 -maxdepth 1 -print -quit",
+            cwd="/",
+            user="root",
+        )
+        if contents.return_code != 0:
+            raise RuntimeError(contents.stderr or f"Could not inspect Harbor workdir {workdir}")
+        if (contents.stdout or "").strip():
+            raise ValueError(
+                "Initial CORAL Harbor compatibility requires a dedicated empty task workdir; "
+                f"{workdir} already contains files"
+            )
+        await environment.upload_dir(self._codebase_path, workdir.as_posix())
+
+
+async def _run(request: dict[str, object]) -> dict[str, object]:
+    runtime_version = importlib.metadata.version("harbor")
+    if runtime_version != HARBOR_RUNTIME_VERSION:
+        raise RuntimeError(f"Expected Harbor {HARBOR_RUNTIME_VERSION}, running {runtime_version}")
+
+    task_path = Path(str(request["task_path"])).resolve()
+    candidate_path = Path(str(request["candidate_path"])).resolve()
+    trials_dir = Path(str(request["trials_dir"])).resolve()
+    trial_name = str(request["trial_name"])
+
+    task = HarborTask(task_path)
+    if task.config.schema_version != HARBOR_SCHEMA_VERSION:
+        raise ValueError(
+            f"Expected Harbor task schema {HARBOR_SCHEMA_VERSION}, got {task.config.schema_version}"
+        )
+    if task.has_steps:
+        raise ValueError("Initial CORAL Harbor compatibility supports single-step tasks only")
+    if task.config.environment.os.value != "linux":
+        raise ValueError("Initial CORAL Harbor compatibility supports Linux tasks only")
+
+    config = TrialConfig(
+        task=TrialTaskConfig(path=task_path),
+        agent=TrialAgentConfig(
+            import_path="__main__:CandidateWorkspaceAgent",
+            kwargs={"codebase_path": str(candidate_path)},
+        ),
+        environment=TrialEnvironmentConfig(
+            type=EnvironmentType.DOCKER,
+            force_build=False,
+            delete=True,
+        ),
+        trials_dir=trials_dir,
+        trial_name=trial_name,
+    )
+    trial = await Trial.create(config=config)
+    result = await trial.run()
+
+    if result.exception_info is not None:
+        raise RuntimeError(
+            f"{result.exception_info.exception_type}: {result.exception_info.exception_message}"
+        )
+    if result.verifier_result is None or result.verifier_result.rewards is None:
+        raise RuntimeError("Harbor verifier returned no rewards")
+
+    return {
+        "runtime_version": runtime_version,
+        "schema_version": task.config.schema_version,
+        "task_name": task.name,
+        "task_package_version": (
+            task.config.task.version if task.config.task is not None else None
+        ),
+        "task_digest": result.task_checksum,
+        "rewards": result.verifier_result.rewards,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("request", type=Path)
+    args = parser.parse_args()
+    try:
+        request = json.loads(args.request.read_text(encoding="utf-8"))
+        payload = asyncio.run(_run(request))
+        print(json.dumps({"result": payload}, separators=(",", ":")))
+    except Exception as exc:  # noqa: BLE001 - serialized across a subprocess boundary
+        print(
+            json.dumps(
+                {"error": f"{type(exc).__name__}: {exc}"},
+                separators=(",", ":"),
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/coral/config.py
+++ b/coral/config.py
@@ -9,6 +9,30 @@ from typing import Any
 import yaml
 from omegaconf import MISSING, OmegaConf
 
+from coral.harbor_task import (
+    HARBOR_ADAPTER_MARKER,
+    HARBOR_GRADER_ENTRYPOINT,
+    HARBOR_PRIVATE_TASK_DIR,
+    HARBOR_RUNTIME_VERSION,
+    inspect_local_harbor_task,
+)
+
+
+@dataclass
+class TaskRewardConfig:
+    """CORAL's objective selection for a Harbor-backed task."""
+
+    primary: str = ""
+    direction: str = "maximize"
+
+    def __post_init__(self) -> None:
+        if not self.primary.strip():
+            raise ValueError("task.reward.primary must be a non-empty Harbor reward key")
+        if self.direction not in ("maximize", "minimize"):
+            raise ValueError(
+                f"task.reward.direction must be 'maximize' or 'minimize', got {self.direction!r}"
+            )
+
 
 @dataclass
 class TaskConfig:
@@ -17,6 +41,12 @@ class TaskConfig:
     name: str = MISSING
     description: str = MISSING
     tips: str = ""
+    source: str = ""
+    reward: TaskRewardConfig | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.reward, dict):
+            self.reward = TaskRewardConfig(**self.reward)
 
 
 @dataclass
@@ -475,9 +505,10 @@ class CoralConfig:
         layers.append(OmegaConf.create(data))
         combined = OmegaConf.merge(*layers) if len(layers) > 1 else layers[0]
         combined_dict: dict[str, Any] = OmegaConf.to_container(combined)  # type: ignore[assignment]
-        combined_dict = _preprocess(combined_dict)
+        combined_dict = _preprocess(combined_dict, base_dir=base_dir)
         merged = OmegaConf.merge(schema, OmegaConf.create(combined_dict))
         cfg: CoralConfig = OmegaConf.to_object(merged)  # type: ignore[assignment]
+        _validate_harbor_runtime_config(cfg)
         return cfg
 
     def to_dict(self) -> dict[str, Any]:
@@ -485,6 +516,11 @@ class CoralConfig:
         container: dict[str, Any] = OmegaConf.to_container(sc, resolve=True)  # type: ignore[assignment]
         # Remove internal-only fields
         container.pop("task_dir", None)
+        task_data = container.get("task", {})
+        if not task_data.get("source"):
+            task_data.pop("source", None)
+        if task_data.get("reward") is None:
+            task_data.pop("reward", None)
         # Serialize heartbeat is_global as "global" for YAML compat
         for h in container.get("agents", {}).get("heartbeat", []):
             h["global"] = h.pop("is_global", False)
@@ -503,7 +539,21 @@ class CoralConfig:
         overrides = OmegaConf.from_dotlist(dotlist)
         merged = OmegaConf.merge(base, overrides)
         cfg: CoralConfig = OmegaConf.to_object(merged)  # type: ignore[assignment]
+        if cfg.task.source:
+            if cfg.task.reward is None:
+                raise ValueError("Harbor-backed task requires task.reward")
+            cfg.grader.direction = cfg.task.reward.direction
+            cfg.grader.args["primary_reward"] = cfg.task.reward.primary
+        _validate_harbor_runtime_config(cfg)
         return cfg
+
+
+def _validate_harbor_runtime_config(config: CoralConfig) -> None:
+    if config.task.source and config.run.session == "docker":
+        raise ValueError(
+            "Harbor-backed tasks require CORAL to run on the host; "
+            "run.session=docker would require unsupported Docker-in-Docker"
+        )
 
 
 def _apply_binding(entry: dict[str, Any], binding: Any) -> None:
@@ -641,8 +691,140 @@ def _load_preset(ref: Any, base_dir: Path | None) -> dict[str, Any]:
     return loaded
 
 
-def _preprocess(data: dict[str, Any]) -> dict[str, Any]:
+def _configure_harbor_task(
+    data: dict[str, Any],
+    *,
+    base_dir: Path | None,
+) -> None:
+    """Hydrate the local Harbor source form into CORAL's runtime config.
+
+    User-authored ``task.yaml`` keeps Harbor-owned fields out of CORAL.  The
+    resolved name, instruction, digest, and built-in grader wiring are added
+    only to the in-memory/run snapshot used by CORAL.
+    """
+    task_data = data.get("task")
+    if not isinstance(task_data, dict):
+        return
+    task_data = dict(task_data)
+    data["task"] = task_data
+
+    source = task_data.get("source")
+    if source in (None, ""):
+        if task_data.get("reward") not in (None, {}):
+            raise ValueError("task.reward is only valid when task.source is set")
+        return
+    if not isinstance(source, str) or not source.strip():
+        raise ValueError("task.source must be a non-empty string")
+    task_data["source"] = source.strip()
+
+    raw_grader_data = data.get("grader")
+    if raw_grader_data is None:
+        grader_data: dict[str, Any] = {}
+    elif not isinstance(raw_grader_data, dict):
+        raise ValueError("grader must be a mapping")
+    else:
+        grader_data = dict(raw_grader_data)
+    grader_args = grader_data.get("args") or {}
+    hydrated = (
+        grader_data.get("entrypoint") == HARBOR_GRADER_ENTRYPOINT
+        and isinstance(grader_args, dict)
+        and grader_args.get("harbor_adapter") == HARBOR_ADAPTER_MARKER
+    )
+
+    reward_data = task_data.get("reward")
+    if not isinstance(reward_data, dict):
+        raise ValueError("Harbor-backed task requires task.reward with primary and direction")
+    primary = reward_data.get("primary")
+    direction = reward_data.get("direction", "maximize")
+    if not isinstance(primary, str) or not primary.strip():
+        raise ValueError("task.reward.primary must be a non-empty Harbor reward key")
+    if direction not in ("maximize", "minimize"):
+        raise ValueError(
+            f"task.reward.direction must be 'maximize' or 'minimize', got {direction!r}"
+        )
+    reward_data = {"primary": primary.strip(), "direction": direction}
+    task_data["reward"] = reward_data
+
+    if hydrated:
+        grader_args = dict(grader_args)
+        required = ("name", "description")
+        missing = [field_name for field_name in required if not task_data.get(field_name)]
+        if missing:
+            raise ValueError(
+                "Resolved Harbor run config is missing task metadata: " + ", ".join(missing)
+            )
+        grader_data["direction"] = direction
+        grader_args["primary_reward"] = primary.strip()
+        grader_data["args"] = grader_args
+        data["grader"] = grader_data
+        return
+
+    duplicated_task_fields = [
+        field_name for field_name in ("name", "description", "tips") if field_name in task_data
+    ]
+    if duplicated_task_fields:
+        raise ValueError(
+            "Harbor-backed task.yaml must not duplicate Harbor-owned fields: "
+            + ", ".join(f"task.{field_name}" for field_name in duplicated_task_fields)
+        )
+
+    unsupported_grader_fields = sorted(
+        set(grader_data) - {"timeout", "max_pending_per_agent", "parallel"}
+    )
+    if unsupported_grader_fields:
+        raise ValueError(
+            "Harbor-backed task.yaml cannot define portable grader fields: "
+            + ", ".join(f"grader.{field_name}" for field_name in unsupported_grader_fields)
+        )
+
+    raw_workspace_data = data.get("workspace")
+    if raw_workspace_data is None:
+        workspace_data: dict[str, Any] = {}
+    elif not isinstance(raw_workspace_data, dict):
+        raise ValueError("workspace must be a mapping")
+    else:
+        workspace_data = raw_workspace_data
+    unsupported_workspace_fields = sorted(
+        field_name
+        for field_name in ("repo_path", "setup")
+        if field_name in workspace_data and workspace_data[field_name] not in (None, "", ".", [])
+    )
+    if unsupported_workspace_fields:
+        raise ValueError(
+            "Initial Harbor compatibility creates an empty CORAL workspace and does not "
+            "support: "
+            + ", ".join(f"workspace.{field_name}" for field_name in unsupported_workspace_fields)
+        )
+
+    descriptor = inspect_local_harbor_task(source, base_dir=base_dir)
+    task_data["name"] = descriptor.name
+    task_data["description"] = descriptor.instruction
+    task_data["tips"] = ""
+
+    grader_data["entrypoint"] = HARBOR_GRADER_ENTRYPOINT
+    grader_data["direction"] = direction
+    grader_data["args"] = {
+        "harbor_adapter": HARBOR_ADAPTER_MARKER,
+        "harbor_runtime_version": HARBOR_RUNTIME_VERSION,
+        "harbor_schema_version": descriptor.schema_version,
+        "harbor_task_digest": descriptor.digest,
+        "harbor_task_name": descriptor.name,
+        "harbor_task_package_version": descriptor.package_version,
+        "harbor_task_subdir": HARBOR_PRIVATE_TASK_DIR,
+        "primary_reward": primary.strip(),
+    }
+    data["task"] = task_data
+    data["grader"] = grader_data
+
+
+def _preprocess(
+    data: dict[str, Any],
+    *,
+    base_dir: Path | None = None,
+) -> dict[str, Any]:
     """Transform legacy keys and normalize heartbeat config before OmegaConf merge."""
+    _configure_harbor_task(data, base_dir=base_dir)
+
     # Reject removed grader.type / grader.module fields with migration guidance.
     grader_data = data.get("grader")
     if isinstance(grader_data, dict):

--- a/coral/grader/harbor.py
+++ b/coral/grader/harbor.py
@@ -1,0 +1,375 @@
+"""CORAL ``TaskGrader`` adapter for a pinned local Harbor task."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from coral.grader.task_grader import TaskGrader
+from coral.harbor_task import (
+    HARBOR_ADAPTER_MARKER,
+    HARBOR_PRIVATE_TASK_DIR,
+    HARBOR_RUNTIME_VERSION,
+    inspect_local_harbor_task,
+)
+from coral.types import Score, ScoreBundle
+
+_IGNORED_CANDIDATE_NAMES = {".git", ".coral", "__pycache__"}
+_CORAL_SHARED_STATE_NAMES = {
+    ".claude",
+    ".codex",
+    ".cursor",
+    ".dsh",
+    ".kiro",
+    ".opencode",
+    ".pi",
+}
+
+
+class _HarborRunnerTimeoutError(RuntimeError):
+    def __init__(self, timeout: float, stdout: str, stderr: str) -> None:
+        super().__init__(f"Harbor runner timed out after {timeout}s")
+        self.timeout = timeout
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _run_harbor_runner(
+    command: list[str],
+    *,
+    environment: dict[str, str],
+    timeout: float | None,
+    cleanup_grace: float,
+) -> subprocess.CompletedProcess[str]:
+    """Run Harbor and give asyncio cancellation time to clean Docker resources."""
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=environment,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            process.send_signal(signal.SIGINT)
+        else:
+            process.terminate()
+        try:
+            stdout, stderr = process.communicate(timeout=cleanup_grace)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+        raise _HarborRunnerTimeoutError(timeout or 0, stdout, stderr) from None
+
+    if process.returncode is None:
+        raise RuntimeError("Harbor runner exited without a return code")
+    return subprocess.CompletedProcess(
+        args=command,
+        returncode=process.returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _parse_last_json(stdout: str) -> dict[str, Any]:
+    for line in reversed(stdout.strip().splitlines()):
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            return value
+    raise RuntimeError("Harbor runner did not return a structured result")
+
+
+def _copy_candidate_workspace(source: Path, destination: Path) -> None:
+    """Copy project files without Git/CORAL state or escaping symlinks."""
+    source = source.resolve()
+    if not source.is_dir():
+        raise FileNotFoundError(f"Candidate workspace not found: {source}")
+
+    def copy_symlink(path: Path, target: Path) -> None:
+        link_value = Path(os.readlink(path))
+        relative_link = path.relative_to(source)
+        inside_shared_state = bool(
+            relative_link.parts and relative_link.parts[0] in _CORAL_SHARED_STATE_NAMES
+        )
+        if link_value.is_absolute():
+            if inside_shared_state:
+                return
+            raise ValueError(f"Candidate workspace contains an absolute symlink: {path}")
+        resolved = (path.parent / link_value).resolve()
+        try:
+            relative_target = resolved.relative_to(source)
+        except ValueError as exc:
+            if inside_shared_state:
+                return
+            raise ValueError(f"Candidate workspace symlink escapes the repository: {path}") from exc
+        if relative_target.parts and relative_target.parts[0] in _IGNORED_CANDIDATE_NAMES:
+            if inside_shared_state:
+                return
+            raise ValueError(f"Candidate workspace symlink targets private runtime state: {path}")
+        target.symlink_to(link_value, target_is_directory=path.is_dir())
+
+    destination.mkdir(parents=True)
+    for root, dirs, files in os.walk(source, followlinks=False):
+        root_path = Path(root)
+        relative_root = root_path.relative_to(source)
+        target_root = destination / relative_root
+        target_root.mkdir(parents=True, exist_ok=True)
+
+        retained_dirs: list[str] = []
+        for name in dirs:
+            path = root_path / name
+            if name in _IGNORED_CANDIDATE_NAMES:
+                continue
+            if path.is_symlink():
+                if name not in _CORAL_SHARED_STATE_NAMES:
+                    copy_symlink(path, target_root / name)
+                continue
+            retained_dirs.append(name)
+        dirs[:] = retained_dirs
+
+        for name in files:
+            path = root_path / name
+            if name in _IGNORED_CANDIDATE_NAMES or name.endswith(".pyc"):
+                continue
+            if path.is_symlink():
+                if name not in _CORAL_SHARED_STATE_NAMES:
+                    copy_symlink(path, target_root / name)
+                continue
+            shutil.copy2(path, target_root / name)
+
+
+def _score_bundle_from_result(
+    result: dict[str, Any],
+    *,
+    primary_reward: str,
+    direction: str,
+    expected_digest: str,
+    summary_path: str,
+) -> ScoreBundle:
+    rewards = result.get("rewards")
+    if not isinstance(rewards, dict) or not rewards:
+        raise RuntimeError("Harbor verifier returned no rewards")
+    if primary_reward not in rewards:
+        available = ", ".join(sorted(str(key) for key in rewards))
+        raise RuntimeError(
+            f"Harbor verifier did not return primary reward {primary_reward!r}; "
+            f"available rewards: {available or '(none)'}"
+        )
+
+    scores: dict[str, Score] = {}
+    for name, value in rewards.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise RuntimeError(f"Harbor reward {name!r} is not numeric")
+        scores[str(name)] = Score(value=value, name=str(name))
+
+    runtime_version = result.get("runtime_version")
+    if runtime_version != HARBOR_RUNTIME_VERSION:
+        raise RuntimeError(
+            f"Harbor runtime drift: expected {HARBOR_RUNTIME_VERSION}, got {runtime_version!r}"
+        )
+
+    metadata = {
+        "harbor": {
+            "adapter": HARBOR_ADAPTER_MARKER,
+            "runtime_version": runtime_version,
+            "schema_version": result.get("schema_version"),
+            "task_name": result.get("task_name"),
+            "task_package_version": result.get("task_package_version"),
+            "source_digest": expected_digest,
+            "harbor_task_checksum": result.get("task_digest"),
+            "primary_reward": primary_reward,
+            "direction": direction,
+            "summary": summary_path,
+        }
+    }
+    reward_value = scores[primary_reward].value
+    return ScoreBundle(
+        scores=scores,
+        aggregated=float(reward_value) if reward_value is not None else None,
+        feedback=f"Harbor verifier completed. Sanitized summary: `{summary_path}`",
+        metadata=metadata,
+    )
+
+
+class HarborTaskGrader(TaskGrader):
+    """Evaluate a CORAL candidate with Harbor v0.22.0 in an isolated runtime."""
+
+    def evaluate(self) -> ScoreBundle:
+        args = self.args
+        if args.get("harbor_adapter") != HARBOR_ADAPTER_MARKER:
+            raise ValueError("Invalid or missing Harbor adapter marker")
+        if args.get("harbor_runtime_version") != HARBOR_RUNTIME_VERSION:
+            raise ValueError(
+                "Harbor adapter runtime must remain pinned to "
+                f"{HARBOR_RUNTIME_VERSION}, got {args.get('harbor_runtime_version')!r}"
+            )
+
+        task_subdir = str(args.get("harbor_task_subdir", ""))
+        expected_digest = str(args.get("harbor_task_digest", ""))
+        primary_reward = str(args.get("primary_reward", ""))
+        if not task_subdir or not expected_digest or not primary_reward:
+            raise ValueError("Incomplete Harbor adapter configuration")
+        if task_subdir != HARBOR_PRIVATE_TASK_DIR:
+            raise ValueError(
+                f"Harbor task must be staged at {HARBOR_PRIVATE_TASK_DIR!r}, got {task_subdir!r}"
+            )
+
+        private_dir = Path(self.private_dir).resolve()
+        task_dir = private_dir / task_subdir
+        descriptor = inspect_local_harbor_task(task_dir)
+        if descriptor.digest != expected_digest:
+            raise RuntimeError(
+                "Staged Harbor task digest changed: "
+                f"expected {expected_digest}, got {descriptor.digest}"
+            )
+        expected_schema = str(args.get("harbor_schema_version", ""))
+        expected_name = str(args.get("harbor_task_name", ""))
+        if descriptor.schema_version != expected_schema:
+            raise RuntimeError(
+                "Staged Harbor schema differs from the resolved run config: "
+                f"expected {expected_schema!r}, got {descriptor.schema_version!r}"
+            )
+        if descriptor.name != expected_name:
+            raise RuntimeError(
+                "Staged Harbor task name differs from the resolved run config: "
+                f"expected {expected_name!r}, got {descriptor.name!r}"
+            )
+
+        private_run = private_dir / "harbor_runs" / Path(self.codebase_path).name / uuid4().hex
+        private_run.mkdir(parents=True)
+        request_path = private_run / "request.json"
+        candidate_path = private_run / "candidate"
+        try:
+            _copy_candidate_workspace(Path(self.codebase_path).resolve(), candidate_path)
+        except Exception:
+            shutil.rmtree(candidate_path, ignore_errors=True)
+            raise
+        request_path.write_text(
+            json.dumps(
+                {
+                    "task_path": str(task_dir),
+                    "candidate_path": str(candidate_path),
+                    "trials_dir": str(private_run / "trials"),
+                    "trial_name": f"coral-eval-{private_run.name[:12]}",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        runner = Path(__file__).parent.parent / "_runners" / "harbor_task.py"
+        command = [
+            "uv",
+            "run",
+            "--isolated",
+            "--no-project",
+            "--no-config",
+            "--python",
+            "3.12",
+            "--with",
+            f"harbor=={HARBOR_RUNTIME_VERSION}",
+            "python",
+            str(runner),
+            str(request_path),
+        ]
+        environment = os.environ.copy()
+        environment.pop("VIRTUAL_ENV", None)
+        environment.pop("UV_PROJECT_ENVIRONMENT", None)
+        environment.setdefault(
+            "UV_CACHE_DIR",
+            str(Path(tempfile.gettempdir()) / "coral-harbor-uv-cache"),
+        )
+        environment.setdefault("UV_NO_PROGRESS", "1")
+
+        if self.timeout is None:
+            runner_timeout = None
+            cleanup_grace = 20.0
+        else:
+            cleanup_grace = float(min(20, max(1, self.timeout // 10)))
+            runner_timeout = float(max(1, self.timeout - cleanup_grace - 1))
+        stdout = ""
+        stderr = ""
+        try:
+            completed = _run_harbor_runner(
+                command,
+                environment=environment,
+                timeout=runner_timeout,
+                cleanup_grace=cleanup_grace,
+            )
+            stdout = completed.stdout
+            stderr = completed.stderr
+        except _HarborRunnerTimeoutError as exc:
+            stdout = exc.stdout
+            stderr = exc.stderr
+            raise RuntimeError(f"Harbor evaluation timed out after {runner_timeout}s") from None
+        finally:
+            # The immutable attempt commit remains in CORAL's repo; retaining
+            # another full candidate copy beside Harbor's private logs would
+            # multiply disk use on every evaluation.
+            shutil.rmtree(candidate_path, ignore_errors=True)
+            (private_run / "runner.stdout.log").write_text(stdout, encoding="utf-8")
+            (private_run / "runner.stderr.log").write_text(stderr, encoding="utf-8")
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"Harbor runner exited {completed.returncode}; "
+                "details are retained in manager-only Harbor run logs"
+            )
+
+        payload = _parse_last_json(stdout)
+        if "error" in payload:
+            error_name = str(payload["error"]).split(":", 1)[0]
+            if not error_name.replace("_", "").isalnum():
+                error_name = "HarborError"
+            raise RuntimeError(
+                f"Harbor evaluation failed ({error_name}); "
+                "details are retained in manager-only Harbor run logs"
+            )
+        result = payload.get("result")
+        if not isinstance(result, dict):
+            raise RuntimeError("Harbor runner response is missing result data")
+        if result.get("schema_version") != descriptor.schema_version:
+            raise RuntimeError(
+                "Harbor runner returned an unexpected schema version: "
+                f"{result.get('schema_version')!r}"
+            )
+        if result.get("task_name") != descriptor.name:
+            raise RuntimeError(
+                f"Harbor runner returned an unexpected task name: {result.get('task_name')!r}"
+            )
+
+        public_summary = self.eval_logs_dir / "harbor-summary.json"
+        summary_path = self.eval_logs_worktree_path(public_summary).as_posix()
+        bundle = _score_bundle_from_result(
+            result,
+            primary_reward=primary_reward,
+            direction=self.config.direction,
+            expected_digest=expected_digest,
+            summary_path=summary_path,
+        )
+        summary = {
+            "runtime_version": result.get("runtime_version"),
+            "schema_version": result.get("schema_version"),
+            "task_name": result.get("task_name"),
+            "task_package_version": result.get("task_package_version"),
+            "source_digest": expected_digest,
+            "harbor_task_checksum": result.get("task_digest"),
+            "primary_reward": primary_reward,
+            "direction": self.config.direction,
+            "rewards": result.get("rewards"),
+        }
+        temporary_summary = public_summary.with_suffix(".json.tmp")
+        temporary_summary.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        temporary_summary.replace(public_summary)
+        return bundle

--- a/coral/harbor_task.py
+++ b/coral/harbor_task.py
@@ -1,0 +1,205 @@
+"""Local Harbor task inspection and private staging helpers.
+
+The initial compatibility profile intentionally stays small: one local,
+single-step, Linux container task using Harbor schema 1.4.  Harbor itself is
+still the runtime authority; these host-side checks only fail early and keep
+portable verifier assets out of CORAL agent worktrees.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+HARBOR_RUNTIME_VERSION = "0.22.0"
+HARBOR_SCHEMA_VERSION = "1.4"
+HARBOR_GRADER_ENTRYPOINT = "coral.grader.harbor:HarborTaskGrader"
+HARBOR_PRIVATE_TASK_DIR = "harbor_task"
+HARBOR_ADAPTER_MARKER = "local-single-step-v1"
+
+_ENVIRONMENT_DEFINITIONS = ("Dockerfile", "docker-compose.yaml", "docker-compose.yml")
+_CANARY_LINE_RE = re.compile(r"^(<!--.*canary.*-->|#.*canary.*)$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class HarborTaskDescriptor:
+    """Validated metadata needed to configure the local Harbor adapter."""
+
+    source: Path
+    name: str
+    instruction: str
+    schema_version: str
+    package_version: str | None
+    digest: str
+
+
+def _strip_canary(text: str) -> str:
+    """Match Harbor v0.22.0's leading instruction canary removal."""
+    lines = text.split("\n")
+    index = 0
+    while index < len(lines) and _CANARY_LINE_RE.match(lines[index].strip()):
+        index += 1
+    while index < len(lines) and not lines[index].strip():
+        index += 1
+    return "\n".join(lines[index:])
+
+
+def _resolve_local_source(source: str, base_dir: Path | None) -> Path:
+    if not isinstance(source, str) or not source.strip():
+        raise ValueError("task.source must be a non-empty local Harbor task directory")
+
+    path = Path(source).expanduser()
+    if not path.is_absolute():
+        path = (base_dir or Path.cwd()) / path
+    path = path.resolve()
+
+    if not path.is_dir():
+        if "@" in source and not source.startswith(("./", "../", "/")):
+            raise ValueError(
+                "Registry Harbor task sources are not supported by the initial adapter; "
+                "use a local task directory"
+            )
+        raise ValueError(f"Local Harbor task directory not found: {path}")
+    return path
+
+
+def _reject_symlinks(task_dir: Path) -> None:
+    for path in task_dir.rglob("*"):
+        if path.is_symlink():
+            rel = path.relative_to(task_dir)
+            raise ValueError(
+                f"Initial Harbor compatibility does not support symlinks: {rel.as_posix()}"
+            )
+        if not path.is_dir() and not path.is_file():
+            rel = path.relative_to(task_dir)
+            raise ValueError(
+                "Initial Harbor compatibility supports regular files and directories only: "
+                f"{rel.as_posix()}"
+            )
+
+
+def _task_digest(task_dir: Path) -> str:
+    """Hash relative paths and bytes without host-specific filesystem modes."""
+    digest = hashlib.sha256()
+    for path in sorted(task_dir.rglob("*"), key=lambda item: item.relative_to(task_dir).as_posix()):
+        rel = path.relative_to(task_dir).as_posix()
+        kind = "dir" if path.is_dir() else "file"
+        digest.update(f"{kind}\0{rel}\0".encode())
+        if path.is_file():
+            with path.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def inspect_local_harbor_task(
+    source: str | Path,
+    *,
+    base_dir: Path | None = None,
+) -> HarborTaskDescriptor:
+    """Validate and describe an initial-profile local Harbor task."""
+    task_dir = _resolve_local_source(str(source), base_dir)
+    _reject_symlinks(task_dir)
+
+    config_path = task_dir / "task.toml"
+    instruction_path = task_dir / "instruction.md"
+    environment_dir = task_dir / "environment"
+    test_path = task_dir / "tests" / "test.sh"
+
+    if not config_path.is_file():
+        raise ValueError(f"Harbor task is missing task.toml: {task_dir}")
+    if not instruction_path.is_file():
+        raise ValueError(f"Harbor task is missing instruction.md: {task_dir}")
+    if not environment_dir.is_dir():
+        raise ValueError(f"Harbor task is missing environment/: {task_dir}")
+    if not any((environment_dir / name).is_file() for name in _ENVIRONMENT_DEFINITIONS):
+        raise ValueError(
+            "Initial Harbor compatibility requires environment/Dockerfile or "
+            "environment/docker-compose.yaml"
+        )
+    if not test_path.is_file():
+        raise ValueError("Initial Harbor compatibility requires a Linux tests/test.sh verifier")
+
+    try:
+        raw: dict[str, Any] = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError(f"Invalid Harbor task.toml: {exc}") from exc
+
+    schema_version = str(raw.get("schema_version", raw.get("version", "")))
+    if schema_version != HARBOR_SCHEMA_VERSION:
+        raise ValueError(
+            f"Initial Harbor compatibility requires task schema {HARBOR_SCHEMA_VERSION}, "
+            f"got {schema_version or 'missing'}"
+        )
+    if raw.get("steps"):
+        raise ValueError("Initial Harbor compatibility supports single-step tasks only")
+    if raw.get("artifacts"):
+        raise ValueError(
+            "Initial Harbor compatibility does not yet publish declared task artifacts"
+        )
+
+    environment = raw.get("environment") or {}
+    if not isinstance(environment, dict):
+        raise ValueError("Harbor task.toml [environment] must be a table")
+    task_os = str(environment.get("os", "linux")).lower()
+    if task_os != "linux":
+        raise ValueError(
+            f"Initial Harbor compatibility supports Linux container tasks only, got {task_os!r}"
+        )
+
+    task_table = raw.get("task") or {}
+    if not isinstance(task_table, dict):
+        raise ValueError("Harbor task.toml [task] must be a table")
+    name = task_table.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("Initial Harbor compatibility requires non-empty [task].name")
+
+    instruction = _strip_canary(instruction_path.read_text(encoding="utf-8")).strip()
+    if not instruction:
+        raise ValueError("Harbor instruction.md must not be empty")
+
+    package_version = task_table.get("version")
+    if package_version is not None and not isinstance(package_version, str):
+        raise ValueError("Harbor [task].version must be a string when present")
+
+    return HarborTaskDescriptor(
+        source=task_dir,
+        name=name.strip(),
+        instruction=instruction,
+        schema_version=schema_version,
+        package_version=package_version,
+        digest=_task_digest(task_dir),
+    )
+
+
+def stage_local_harbor_task(
+    source: str | Path,
+    *,
+    base_dir: Path,
+    private_dir: Path,
+    expected_digest: str,
+) -> Path:
+    """Copy a verified Harbor task into CORAL's manager-only private area."""
+    descriptor = inspect_local_harbor_task(source, base_dir=base_dir)
+    if descriptor.digest != expected_digest:
+        raise ValueError(
+            "Harbor task changed after configuration was loaded: "
+            f"expected {expected_digest}, got {descriptor.digest}"
+        )
+
+    destination = private_dir / HARBOR_PRIVATE_TASK_DIR
+    if destination.exists():
+        raise FileExistsError(f"Harbor private task destination already exists: {destination}")
+    shutil.copytree(descriptor.source, destination)
+
+    staged = inspect_local_harbor_task(destination)
+    if staged.digest != expected_digest:
+        raise RuntimeError(
+            f"Staged Harbor task digest mismatch: expected {expected_digest}, got {staged.digest}"
+        )
+    return destination

--- a/coral/task/validation.py
+++ b/coral/task/validation.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from coral.config import CoralConfig
+from coral.harbor_task import stage_local_harbor_task
 from coral.types import ScoreBundle, Task
 
 
@@ -188,6 +189,18 @@ def validate_task(task_dir: Path) -> ValidationReport:
             )
         )
 
+    if config.task.source and (task_dir / "seed").exists():
+        diagnostics.append(
+            ValidationDiagnostic(
+                code="task.harbor.seed_mixed",
+                message=(
+                    "Harbor-backed task.yaml cannot also provide seed/; the initial "
+                    "compatibility profile starts from an empty agent-owned workspace"
+                ),
+                path="seed",
+            )
+        )
+
     # The grader package is surfaced read-only to agents at <shared_dir>/grader/.
     # Private paths inside it would therefore be copied into .coral/private/ and
     # exposed through the surfaced source at the same time.
@@ -299,7 +312,7 @@ async def run_validation_async(
         try:
             workspace.mkdir()
             seed_dir = task_dir / "seed"
-            has_seed = seed_dir.is_dir() and any(seed_dir.iterdir())
+            has_seed = not config.task.source and seed_dir.is_dir() and any(seed_dir.iterdir())
             if has_seed:
                 for item in seed_dir.iterdir():
                     if item.name == "__pycache__":
@@ -319,6 +332,22 @@ async def run_validation_async(
             coral_dir = tmpdir / ".coral"
             private_dir = coral_dir / "private"
             private_dir.mkdir(parents=True)
+
+            if config.task.source:
+                expected_digest = str(config.grader.args.get("harbor_task_digest", ""))
+                if not expected_digest:
+                    raise ValueError(
+                        "Resolved Harbor task configuration is missing its source digest"
+                    )
+                stage_local_harbor_task(
+                    config.task.source,
+                    base_dir=task_dir,
+                    private_dir=private_dir,
+                    expected_digest=expected_digest,
+                )
+                workspace_message = (
+                    "Harbor source staged privately; using an empty Gate B candidate workspace"
+                )
 
             for private_path_str in config.grader.private:
                 src = Path(private_path_str)
@@ -369,7 +398,7 @@ async def run_validation_async(
             name=config.task.name,
             description=config.task.description,
         )
-        target = "seed code" if seed_dir.is_dir() else "empty workspace"
+        target = "seed code" if has_seed else "empty workspace"
         emit("baseline", "started", f"Running grader against {target}...")
         try:
             baseline = await grader.grade(str(workspace), [task])

--- a/coral/workspace/project.py
+++ b/coral/workspace/project.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 
 from coral.config import CoralConfig
+from coral.harbor_task import stage_local_harbor_task
 from coral.hub._island import island_root
 from coral.hub.checkpoint import init_checkpoint_repo
 from coral.workspace.repo import (
@@ -214,7 +215,7 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
                 └── agents/              # worktrees off repo/
     """
     results_dir = Path(config.workspace.results_dir).resolve()
-    source_repo = Path(config.workspace.repo_path).resolve()
+    source_repo = None if config.task.source else Path(config.workspace.repo_path).resolve()
 
     task_slug = slugify(config.task.name)
     task_dir = results_dir / task_slug
@@ -242,6 +243,17 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
     (coral_dir / "public").mkdir(parents=True, exist_ok=True)
     (coral_dir / "private").mkdir(parents=True, exist_ok=True)
     agents_dir.mkdir(parents=True, exist_ok=True)
+
+    if config.task.source:
+        expected_digest = str(config.grader.args.get("harbor_task_digest", ""))
+        if not expected_digest:
+            raise ValueError("Resolved Harbor task configuration is missing its source digest")
+        stage_local_harbor_task(
+            config.task.source,
+            base_dir=effective_config_dir,
+            private_dir=coral_dir / "private",
+            expected_digest=expected_digest,
+        )
 
     if config.islands.count == 1:
         _build_island_subtree(
@@ -283,14 +295,24 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
         logger.info(f"Symlinked {latest_link} -> {rel}")
 
     # Clone source repo into run_dir/repo/
-    repo_dir = clone_or_init_repo(source_repo, run_repo)
+    if config.task.source:
+        # Gate B starts from an empty, agent-owned workspace.  The Harbor task
+        # definition, tests, and solution stay under .coral/private/ and are
+        # uploaded only by the manager-side verifier adapter.
+        empty_workspace = coral_dir / "private" / "harbor_workspace"
+        empty_workspace.mkdir()
+        repo_dir = clone_or_init_repo(empty_workspace, run_repo)
+    else:
+        if source_repo is None:
+            raise RuntimeError("Legacy workspace source unexpectedly missing")
+        repo_dir = clone_or_init_repo(source_repo, run_repo)
 
     # Resolve task_dir (directory containing task.yaml)
     task_source_dir = config.task_dir or config_dir or Path.cwd()
 
     # Auto-copy seed/ into repo (if present in task directory)
     seed_dir = task_source_dir / "seed"
-    if seed_dir.is_dir():
+    if not config.task.source and seed_dir.is_dir():
         copy_seed_directory(seed_dir, repo_dir)
 
     # Copy private grader data into .coral/ (hidden from agents)

--- a/design/harbor-task-format.md
+++ b/design/harbor-task-format.md
@@ -15,6 +15,11 @@ agent runtimes, assignments, islands, shared state, attempt budgets, stop
 conditions, worktree lifecycle, and the dashboard. Those settings must remain
 outside Harbor's `task.toml`.
 
+CORAL should keep `task.yaml` as its existing CLI and orchestration entrypoint.
+A Harbor-backed `task.yaml` should reference exactly one local or registry
+Harbor task instead of duplicating that task's instruction, metadata,
+environment, or verifier fields.
+
 The first adapter should target Harbor task schema `1.4` and a pinned Harbor
 `v0.22.0` runtime. It should support local task directories and versioned
 registry references resolved to a recorded content digest, translate Harbor's
@@ -136,10 +141,11 @@ CORAL must not add private keys to Harbor's standard `task.toml` schema. If a
 portable task is downloaded and run with Harbor alone, its task semantics and
 verification must remain intact.
 
-### CORAL owns the optimization-run contract
+### `task.yaml` remains the CORAL optimization-run contract
 
-**Proposed:** a separate `coral.yaml` references one Harbor task and contains
-only CORAL orchestration and objective-selection state:
+**Proposed:** extend the existing `task.yaml` so it can reference one Harbor
+task while continuing to contain CORAL orchestration and objective-selection
+state:
 
 ```yaml
 task:
@@ -170,9 +176,26 @@ run:
     max_real_attempts: 100
 ```
 
-The filename and exact shape are **Proposed**, not accepted. The invariant is
-more important than the name: CORAL orchestration must not leak into
-`task.toml`, and Harbor task metadata must not be duplicated into CORAL config.
+The retained filename follows CORAL's current CLI and authoring workflow. The
+new field shape is **Proposed**, not accepted. The important compatibility rule
+is a one-of contract:
+
+- a legacy `task.yaml` contains the current inline task/grader fields and no
+  `task.source`;
+- a Harbor-backed `task.yaml` contains `task.source` and CORAL orchestration,
+  but does not duplicate `task.name`, `task.description`, `task.tips`, or
+  portable grader fields owned by the referenced Harbor task.
+
+Validation must reject mixed configurations rather than guess which definition
+wins. Keeping `task.yaml` does not create a CORAL fork of Harbor's schema:
+Harbor still owns `task.toml`, while `task.yaml` remains a separate CORAL file
+that points to it.
+
+A local `task.source` is resolved relative to the directory containing
+`task.yaml` and must identify one directory with a `task.toml`; it does not scan
+for tasks or accept a dataset implicitly. A registry source identifies one
+`org/name@tag` package before digest pinning. This keeps the selected Harbor
+task deterministic for `coral validate`, `start`, and `eval`.
 
 Persisted CORAL configs must not use a mutable registry alias such as `latest`.
 At run creation CORAL should resolve a local directory or `org/name@tag` to an
@@ -185,19 +208,19 @@ schema, task package version, and Harbor runtime version in the run metadata.
 | --- | --- | --- |
 | `task.name` | `[task].name` in `task.toml` | **Proposed.** Harbor requires stable `org/name`; migration may need an explicit organization. |
 | `task.description` | `instruction.md` plus `[task].description` | **Proposed.** Full agent-facing content goes in `instruction.md`; the TOML description stays short. |
-| `task.tips` | `instruction.md` | **Proposed.** Merge into a clearly labelled guidance section; do not duplicate it in `coral.yaml`. |
+| `task.tips` | `instruction.md` | **Proposed.** Merge into a clearly labelled guidance section; do not duplicate it in Harbor-backed `task.yaml`. |
 | `seed/` | agent-visible starting workspace | **Open.** It must never map to Harbor `solution/`. See workspace materialization below. |
 | `grader.entrypoint` | `tests/`, verifier config, or a temporary legacy bridge | **Proposed.** Canonical tasks use Harbor verification; generic `TaskGrader` remains transition-only. |
 | `grader.setup` | verifier/environment image build | **Proposed.** Convert reproducible installs into Dockerfiles or verifier images; do not execute arbitrary legacy setup implicitly. |
 | `grader.timeout` | `[verifier].timeout_sec` | **Proposed.** CORAL may impose a stricter outer infrastructure timeout but must record which layer fired. |
 | `grader.private` | Harbor `tests/`, separate verifier environment, and declared verifier-only artifacts | **Proposed.** Never copy these paths into a CORAL agent worktree. |
 | `grader.args` | task-specific Harbor metadata/config or migration code | **Open per field.** Do not dump arbitrary runtime args into `[metadata]` and call them portable. |
-| `grader.direction` | `task.reward.direction` in `coral.yaml` | **Proposed.** Preserve raw Harbor reward values; CORAL applies maximize/minimize when ranking attempts. |
+| `grader.direction` | `task.reward.direction` in `task.yaml` | **Proposed.** Preserve raw Harbor reward values; CORAL applies maximize/minimize when ranking attempts. |
 | `grader.max_pending_per_agent` | CORAL orchestration config | **Proposed.** Queue policy is not task semantics. |
 | `grader.parallel.max_workers` | CORAL orchestration config | **Proposed.** Harbor/provider concurrency is a separate adapter setting. |
 | `workspace.repo_path` and `seed/` copying | workspace materializer | **Open.** Must produce the same agent-visible Git baseline as the Harbor environment. |
 | `workspace.setup` | Harbor environment build where portable; CORAL run bootstrap otherwise | **Open.** Every command needs an owner and reproducibility rule. |
-| `agents.*`, `islands.*`, `sharing.*`, `run.*` | `coral.yaml` | **Proposed.** These stay entirely outside `task.toml`. |
+| `agents.*`, `islands.*`, `sharing.*`, `run.*` | `task.yaml` | **Proposed.** These stay entirely outside `task.toml`. |
 | `ScoreBundle.scores` | one CORAL `Score` per Harbor reward key | **Proposed.** Preserve names and numeric values exactly. |
 | `ScoreBundle.aggregated` | explicit primary reward or approved aggregation | **Proposed.** Never infer weights or average an arbitrary reward dictionary. |
 | `ScoreBundle.feedback` | sanitized verifier summary | **Proposed.** Public feedback policy still applies. |
@@ -309,7 +332,7 @@ The adapter must preserve these invariants before any bulk migration:
    Public eval logs contain an artifact manifest and approved copies, not an
    indiscriminate Harbor job directory.
 5. Registry credentials, environment secrets, and provider tokens stay in the
-   manager process and are never serialized into `coral.yaml`, attempt JSON,
+   manager process and are never serialized into `task.yaml`, attempt JSON,
    CORAL.md, or PR/test output.
 6. Task resolution is immutable for a run. A registry tag is resolved once and
    its digest is persisted before agents start.
@@ -391,7 +414,9 @@ This RFC refines, but does not reorder, the phases in Issue #225.
 
 - support a pinned local Harbor directory and a versioned registry reference
   resolved to a recorded content digest;
-- preserve legacy `task.yaml` behavior;
+- select legacy or Harbor-backed loading from the validated, mutually exclusive
+  `task.yaml` shape;
+- preserve legacy `task.yaml` behavior when `task.source` is absent;
 - persist task digest and compatibility metadata in every run;
 - add CLI diagnostics without changing default authoring output.
 
@@ -413,7 +438,8 @@ successful baseline is not enough.
 
 ### Gate E — authoring and controlled migration
 
-- `coral init` can scaffold a Harbor task and separate CORAL config;
+- `coral init` can scaffold a Harbor task plus a compatible `task.yaml` that
+  references it;
 - `coral validate`, `start`, and `eval` support the new source explicitly;
 - migration tooling produces a report and refuses ambiguous field mappings;
 - convert a small reviewed batch before any generated bulk migration;
@@ -431,7 +457,7 @@ semantics.
 
 | Decision | Recommendation | Alternative | Status |
 | --- | --- | --- | --- |
-| CORAL config filename | `coral.yaml` | keep `task.yaml` for orchestration, but that perpetuates naming ambiguity | **Open** |
+| CORAL orchestration entrypoint | keep `task.yaml` and add a Harbor-backed `task.source` mode | introduce a separate `coral.yaml` | **Proposed** following PR discussion; exact source field shape remains **Open** |
 | first Harbor runtime range | start with exact `v0.22.0` and schema `1.4`; widen only after compatibility tests | target an older release matching current wrappers | **Open**; current wrappers are not a task-loader compatibility proof |
 | local and registry references | support local paths first, then pinned `org/name@tag`; persist digest | registry-first | **Proposed** |
 | dataset references | defer until the task adapter is stable, then add an explicit dataset source and task selector | overload `task.source` with path, task, and dataset guessing | **Proposed** |
@@ -452,6 +478,11 @@ resolved or explicitly deferred every Open item needed for Gate B. Acceptance
 of this document does not claim that the adapter, migration, score parity, or
 Harbor v0.22 compatibility has been implemented.
 
+For the configuration boundary, Phase 1 acceptance additionally requires
+agreement that Harbor-backed and legacy `task.yaml` forms are mutually
+exclusive, and that a Harbor-backed form references exactly one Harbor task
+without copying portable task fields into CORAL configuration.
+
 Subsequent implementation PRs should reference Issue #225 but must not use
 `Fixes #225` until the complete migration and deprecation acceptance criteria
 are satisfied.
@@ -459,6 +490,7 @@ are satisfied.
 ## Primary references
 
 - [CORAL Issue #225](https://github.com/Human-Agent-Society/CORAL/issues/225)
+- [PR #251 configuration discussion](https://github.com/Human-Agent-Society/CORAL/pull/251#issuecomment-5392439317)
 - [Harbor task structure](https://www.harborframework.com/docs/tasks)
 - [Harbor core concepts](https://www.harborframework.com/docs/core-concepts)
 - [Harbor task publishing](https://www.harborframework.com/docs/tasks/publishing)

--- a/design/harbor-task-format.md
+++ b/design/harbor-task-format.md
@@ -1,10 +1,11 @@
 # Harbor task compatibility and migration RFC
 
-- **Status:** Proposed
+- **Status:** Phase 1 contract plus an implemented, bounded Gate B spike
 - **Issue:** [#225](https://github.com/Human-Agent-Society/CORAL/issues/225)
-- **Scope:** Phase 1 only — mapping, compatibility boundaries, and migration gates
-- **CORAL baseline:** `6523a8c50bd9663ecc14f2695d9a0389a0bb9d23`
-  (`dev`, 2026-08-23)
+- **Scope:** Phase 1 mapping plus a local, single-step, empty-workdir adapter;
+  later migration gates remain deferred
+- **CORAL baseline:** `88a2da15b0b3780357b473218b140403f1410a12`
+  (`dev`, 2026-08-31)
 - **Harbor baseline:** task schema `1.4`, Harbor `v0.22.0`, verified 2026-08-23
 
 ## Summary
@@ -20,19 +21,50 @@ A Harbor-backed `task.yaml` should reference exactly one local or registry
 Harbor task instead of duplicating that task's instruction, metadata,
 environment, or verifier fields.
 
-The first adapter should target Harbor task schema `1.4` and a pinned Harbor
-`v0.22.0` runtime. It should support local task directories and versioned
-registry references resolved to a recorded content digest, translate Harbor's
-numeric reward mapping into CORAL's `ScoreBundle`, and preserve CORAL's
-private/public feedback boundary. Its initial compatibility profile should be
-single-step and container-backed rather than claiming every optional schema
-1.4 capability. It should not bulk-migrate examples until representative task
-families demonstrate score, feedback, artifact, timeout, and security parity.
+The initial adapter targets Harbor task schema `1.4` and a pinned Harbor
+`v0.22.0` runtime. This PR implements one deliberately narrow profile: a local,
+single-step Linux container task whose workdir is empty at startup. Registry
+resolution, pre-populated workdir export, datasets, multi-step tasks, declared
+public artifacts, provider selection, and bulk migration remain later gates.
 
-This RFC does not implement the adapter. Several decisions remain open because
-they require a prototype against Harbor's environment API, especially how to
-materialize an agent-visible Git workspace without exposing `solution/` or
-`tests/`.
+The implemented path translates Harbor's numeric reward mapping into CORAL's
+`ScoreBundle` and preserves CORAL's private/public feedback boundary. It proves
+that a CORAL candidate can be uploaded into a fresh Harbor environment and
+verified without launching a second optimization agent. It does not claim
+that all optional schema 1.4 capabilities or the complete migration in Issue
+#225 are implemented.
+
+## Implemented Gate B spike
+
+The implementation in this PR adds the following bounded path:
+
+1. A Harbor-backed `task.yaml` uses `task.source` plus
+   `task.reward.primary`/`direction`. It rejects duplicated legacy task or
+   portable grader fields.
+2. CORAL resolves one local Harbor directory relative to `task.yaml`, requires
+   schema `1.4`, records a content digest, derives the task name and instruction,
+   and copies the complete Harbor task into `.coral/private/`.
+3. The run starts from an empty Git workspace. Harbor `solution/`, `tests/`,
+   task configuration, and verifier inputs never enter an agent worktree.
+4. Evaluation launches exact `harbor==0.22.0` under isolated Python 3.12,
+   starts a fresh Docker environment through Harbor's public `Task`/`Trial`
+   APIs, verifies that the task workdir is dedicated and empty, and uploads
+   only the candidate snapshot through a non-optimizing transfer agent.
+5. Every numeric Harbor reward becomes a named CORAL `Score`; the configured
+   primary key becomes `ScoreBundle.aggregated`, while direction remains a
+   CORAL ranking concern and does not rewrite raw reward values.
+6. Raw trial output stays under manager-only `harbor_runs/`. Agents receive
+   only reward values, compatibility metadata, and a sanitized summary under
+   `eval_logs/`.
+7. The outer timeout fires early enough to interrupt the Harbor asyncio runner
+   and give it a cleanup window before a final force-kill fallback.
+
+The spike fails closed for registry references, non-1.4 schemas, multi-step or
+Windows tasks, non-empty container workdirs, source/task symlinks, declared
+public artifacts, mixed `seed/` or external starter repositories, and missing
+or non-numeric primary rewards. CORAL's own `run.session=docker` is also
+rejected because Harbor requires host Docker rather than Docker-in-Docker.
+These are explicit capability limits, not silent partial support.
 
 ## Decision language
 
@@ -47,7 +79,7 @@ This document uses three statuses:
 
 ### CORAL today
 
-At the baseline above, CORAL has 393 `task*.yaml` or `task*.yml` files under
+At the baseline above, CORAL has 397 `task*.yaml` or `task*.yml` files under
 `examples/`.
 `CoralConfig` combines two different concerns in one YAML document:
 
@@ -177,8 +209,8 @@ run:
 ```
 
 The retained filename follows CORAL's current CLI and authoring workflow. The
-new field shape is **Proposed**, not accepted. The important compatibility rule
-is a one-of contract:
+field shape is **Implemented for the initial local profile**. The important
+compatibility rule is a one-of contract:
 
 - a legacy `task.yaml` contains the current inline task/grader fields and no
   `task.source`;
@@ -193,9 +225,10 @@ that points to it.
 
 A local `task.source` is resolved relative to the directory containing
 `task.yaml` and must identify one directory with a `task.toml`; it does not scan
-for tasks or accept a dataset implicitly. A registry source identifies one
-`org/name@tag` package before digest pinning. This keeps the selected Harbor
-task deterministic for `coral validate`, `start`, and `eval`.
+for tasks or accept a dataset implicitly. The current implementation rejects
+registry sources; Gate C reserves `org/name@tag` before digest pinning. This
+keeps the selected local Harbor task deterministic for `coral validate`,
+`start`, and `eval`.
 
 Persisted CORAL configs must not use a mutable registry alias such as `latest`.
 At run creation CORAL should resolve a local directory or `org/name@tag` to an
@@ -250,12 +283,13 @@ Harbor VerifierResult.rewards
 4. `rewards is None`, a missing primary key, task/environment build failure,
    verifier failure, and timeout produce a structured grader-error/timeout
    attempt. They do not produce a real attempt with score `0`.
-5. Public feedback contains only a bounded, task-approved verifier summary.
-   Full logs and artifacts are indexed under eval logs according to their
-   visibility policy.
+5. Public feedback contains only a bounded verifier summary. The initial
+   adapter keeps raw Harbor logs private and rejects declared public artifacts
+   until an explicit visibility/copy policy is implemented.
 6. The adapter records Harbor task digest, task version, schema version,
-   Harbor runtime version, provider, reward mapping, and relevant log/artifact
-   references in attempt metadata.
+   Harbor runtime version, reward mapping, and the sanitized summary reference
+   in attempt metadata. Provider metadata and artifact references remain
+   deferred with provider/artifact support.
 
 ## Workspace materialization and evaluation flow
 
@@ -263,25 +297,24 @@ The central incompatibility is that CORAL evolves a Git worktree while Harbor
 normally owns an agent trial inside an environment. Mapping `seed/` to
 `solution/` would expose an oracle and is rejected.
 
-**Proposed adapter boundary:**
+**Implemented initial adapter boundary:**
 
 ```text
-resolve Harbor task path/tag -> verify schema + pin digest
-                             -> materialize agent-visible workspace
-                             -> initialize CORAL repo/worktrees
+resolve local Harbor task path -> verify schema + pin digest
+                               -> create empty agent-visible workspace
+                               -> initialize CORAL repo/worktrees
 
 candidate CORAL commit -> create fresh Harbor environment
                        -> upload candidate workspace to the agent workdir
                        -> run Harbor verifier without a second optimization agent
-                       -> collect VerifierResult + declared artifacts/logs
+                       -> collect VerifierResult; retain raw logs privately
                        -> translate to ScoreBundle + Attempt
 ```
 
-Phase 2 must first prove that the pinned Harbor API can export/import the
-agent-visible workdir and run verification without launching a competing
-optimization agent. This is **Open**. The proof must use Harbor's public Python
-interfaces or a stable CLI contract; importing private modules is not an
-acceptable long-term adapter.
+This PR proves candidate import and verification without launching a competing
+optimization agent, using Harbor's public Python interfaces. Exporting a
+pre-populated Harbor workdir into CORAL remains **Open**; the implemented
+profile therefore requires Harbor's container workdir to start empty.
 
 If that contract is unavailable, the fallback choices are:
 
@@ -341,12 +374,12 @@ The adapter must preserve these invariants before any bulk migration:
 
 ## Version and compatibility policy
 
-**Proposed initial support:**
+**Implemented initial support:**
 
-- Harbor runtime: exactly `v0.22.0` for Gate B, pinned in CORAL's
-  lock/install path;
+- Harbor runtime: exactly `v0.22.0` for Gate B, pinned in the isolated runner
+  invocation;
 - Harbor task schema: exactly `1.4`;
-- registry task: immutable digest recorded, with a non-`latest` user-facing tag;
+- registry task: deferred to Gate C;
 - CORAL legacy task loader: retained during the migration window.
 
 Schema acceptance is not blanket support for every optional Harbor feature.
@@ -355,8 +388,9 @@ with an actionable validation error rather than ignore them.
 
 | Harbor v0.22 capability | Initial status |
 | --- | --- |
-| single-step `instruction.md`, environment, verifier, numeric rewards, and declared artifacts | **Proposed for Gate B** |
-| local task directory | **Proposed for Gate B** |
+| single-step `instruction.md`, empty workdir, environment, verifier, and numeric rewards | **Implemented for the bounded Gate B spike** |
+| declared public artifacts | **Deferred.** Reject rather than silently hide or publish them. |
+| local task directory | **Implemented for the bounded Gate B spike** |
 | registry task reference | **Proposed for Gate C**, after digest pinning is proven |
 | dataset reference and task selection | **Deferred.** Build on the task adapter; do not make dataset selection implicit in `task.source`. |
 | multi-step task | **Deferred.** Reject initially; a CORAL attempt is not a Harbor step, and reward/cancellation semantics need a separate mapping. |
@@ -402,13 +436,16 @@ This RFC refines, but does not reorder, the phases in Issue #225.
 - Replace obsolete Harbor repository links with current official sources.
 - Agree on the first supported Harbor runtime and schema.
 
-### Gate B — build a narrow loader/verification spike
+### Gate B — build a narrow loader/verification spike (partially implemented)
 
-- local task directory only;
-- one container-backed deterministic task;
-- no registry, no bulk migration, no CLI default change;
-- prove workspace materialization, verifier-only isolation, reward mapping,
-  timeout/error mapping, cancellation ownership, and cleanup.
+- local task directory only — **implemented**;
+- one container-backed deterministic empty-workdir task — **implemented and
+  exercised end-to-end**;
+- no registry, no bulk migration, no CLI default change — **implemented**;
+- private task staging, reward mapping, timeout/error classification, and a
+  cancellation cleanup window — **implemented**;
+- pre-populated workspace export, declared public artifacts, and the wider
+  representative parity matrix — **not yet implemented**.
 
 ### Gate C — introduce the dual loader behind an explicit task source
 
@@ -457,15 +494,15 @@ semantics.
 
 | Decision | Recommendation | Alternative | Status |
 | --- | --- | --- | --- |
-| CORAL orchestration entrypoint | keep `task.yaml` and add a Harbor-backed `task.source` mode | introduce a separate `coral.yaml` | **Proposed** following PR discussion; exact source field shape remains **Open** |
-| first Harbor runtime range | start with exact `v0.22.0` and schema `1.4`; widen only after compatibility tests | target an older release matching current wrappers | **Open**; current wrappers are not a task-loader compatibility proof |
-| local and registry references | support local paths first, then pinned `org/name@tag`; persist digest | registry-first | **Proposed** |
+| CORAL orchestration entrypoint | keep `task.yaml` and add a Harbor-backed `task.source` mode | introduce a separate `coral.yaml` | **Implemented for the local spike** |
+| first Harbor runtime range | start with exact `v0.22.0` and schema `1.4`; widen only after compatibility tests | target an older release matching current wrappers | **Implemented for the local spike** |
+| local and registry references | support local paths first, then pinned `org/name@tag`; persist digest | registry-first | **Local implemented; registry deferred** |
 | dataset references | defer until the task adapter is stable, then add an explicit dataset source and task selector | overload `task.source` with path, task, and dataset guessing | **Proposed** |
 | mutable `latest` | reject in persisted run config | resolve silently on each start | **Proposed**; silent re-resolution breaks reproducibility |
-| visible starter workspace | export Harbor agent workdir into a CORAL Git baseline, then upload candidate snapshots for verification | run CORAL agents inside Harbor environments | **Open**, requires Phase 2 API spike |
+| visible starter workspace | export Harbor agent workdir into a CORAL Git baseline, then upload candidate snapshots for verification | run CORAL agents inside Harbor environments | **Empty workdir implemented; pre-populated export remains Open** |
 | non-container tasks | keep legacy until an explicit supported provider/profile exists | native verifier path using Harbor files only | **Open**; the alternative has reduced portability |
-| multiple rewards | require a primary key and optional explicit aggregation | infer first key or average | **Proposed** |
-| minimize objectives | store raw reward; let CORAL ranking apply direction | negate reward in adapter | **Proposed** |
+| multiple rewards | require a primary key and optional explicit aggregation | infer first key or average | **Primary-key mapping implemented; aggregation deferred** |
+| minimize objectives | store raw reward; let CORAL ranking apply direction | negate reward in adapter | **Implemented** |
 | custom/rubric graders | migrate to Harbor tests/RewardKit where possible; keep a transition escape hatch | preserve `TaskGrader` indefinitely as a second canonical system | **Open** |
 | private verifier mode | prefer separate verifier environment for sensitive tasks | shared verifier with task-owned risk acceptance | **Proposed** |
 | legacy removal timeline | evidence-based dual-loader window | immediate breaking migration | **Open** |
@@ -473,10 +510,11 @@ semantics.
 
 ## Acceptance criteria for Phase 1
 
-This RFC is complete when Maintainers have reviewed the Proposed decisions and
-resolved or explicitly deferred every Open item needed for Gate B. Acceptance
-of this document does not claim that the adapter, migration, score parity, or
-Harbor v0.22 compatibility has been implemented.
+Phase 1 is complete when Maintainers have reviewed the Proposed decisions and
+resolved or explicitly deferred every Open item needed for the next supported
+profile. This PR now includes the bounded Gate B spike documented above, but
+does not claim complete migration, representative score parity, registry
+support, or compatibility with Harbor versions beyond `v0.22.0`.
 
 For the configuration boundary, Phase 1 acceptance additionally requires
 agreement that Harbor-backed and legacy `task.yaml` forms are mutually

--- a/design/harbor-task-format.md
+++ b/design/harbor-task-format.md
@@ -1,0 +1,473 @@
+# Harbor task compatibility and migration RFC
+
+- **Status:** Proposed
+- **Issue:** [#225](https://github.com/Human-Agent-Society/CORAL/issues/225)
+- **Scope:** Phase 1 only — mapping, compatibility boundaries, and migration gates
+- **CORAL baseline:** `6523a8c50bd9663ecc14f2695d9a0389a0bb9d23`
+  (`dev`, 2026-08-23)
+- **Harbor baseline:** task schema `1.4`, Harbor `v0.22.0`, verified 2026-08-23
+
+## Summary
+
+CORAL should adopt the standard Harbor task directory as its portable task and
+evaluation contract. CORAL should continue to own optimization orchestration:
+agent runtimes, assignments, islands, shared state, attempt budgets, stop
+conditions, worktree lifecycle, and the dashboard. Those settings must remain
+outside Harbor's `task.toml`.
+
+The first adapter should target Harbor task schema `1.4` and a pinned Harbor
+`v0.22.0` runtime. It should support local task directories and versioned
+registry references resolved to a recorded content digest, translate Harbor's
+numeric reward mapping into CORAL's `ScoreBundle`, and preserve CORAL's
+private/public feedback boundary. Its initial compatibility profile should be
+single-step and container-backed rather than claiming every optional schema
+1.4 capability. It should not bulk-migrate examples until representative task
+families demonstrate score, feedback, artifact, timeout, and security parity.
+
+This RFC does not implement the adapter. Several decisions remain open because
+they require a prototype against Harbor's environment API, especially how to
+materialize an agent-visible Git workspace without exposing `solution/` or
+`tests/`.
+
+## Decision language
+
+This document uses three statuses:
+
+- **Existing** — behavior verified in current CORAL or current Harbor sources.
+- **Proposed** — the recommended contract for Maintainer approval.
+- **Open** — a decision or feasibility point that Phase 2 must resolve before
+  the adapter API is treated as stable.
+
+## Source baseline
+
+### CORAL today
+
+At the baseline above, CORAL has 393 `task*.yaml` or `task*.yml` files under
+`examples/`.
+`CoralConfig` combines two different concerns in one YAML document:
+
+1. portable task and evaluation content:
+   - `task.name`, `task.description`, and `task.tips`;
+   - `grader.entrypoint`, setup commands, timeout, args, private paths, and
+     score direction;
+   - the visible starting repository selected through `workspace.repo_path`;
+2. optimization-run orchestration:
+   - agent runtime/model/bindings, assignments, skills, heartbeat, sandbox,
+     gateway, and reliability controls;
+   - islands, migration, and sharing;
+   - run/session/UI/stop settings and result-directory layout.
+
+The authoritative implementation is
+[`coral/config.py`](../coral/config.py). Project creation copies `seed/` into a
+CORAL-managed Git repository, copies grader-private inputs under
+`.coral/private/`, and builds an isolated grader virtual environment; see
+[`coral/workspace/project.py`](../coral/workspace/project.py) and
+[`coral/workspace/grader_env.py`](../coral/workspace/grader_env.py).
+
+Grader entrypoints return a [`ScoreBundle`](../coral/types.py), and finalized
+attempts retain the aggregate score, public feedback, and selected metadata.
+Current Harbor-backed examples do not load Harbor tasks as CORAL's canonical
+task format. Instead, task-specific `TaskGrader` packages shell out to
+`harbor run` and parse job output; see
+[`examples/swebench-verified`](../examples/swebench-verified),
+[`examples/terminal-bench`](../examples/terminal-bench), and the Harbor v0.13
+result fixtures in [`tests/test_grader.py`](../tests/test_grader.py).
+
+### Harbor today
+
+The current official project is
+[`harbor-framework/harbor`](https://github.com/harbor-framework/harbor), not the
+older `corca-ai/harbor` URL referenced in Issue #225. The latest verified
+release for this RFC is
+[`v0.22.0`](https://github.com/harbor-framework/harbor/releases/tag/v0.22.0),
+published on 2026-08-22.
+
+The official [Task Structure](https://www.harborframework.com/docs/tasks)
+defines:
+
+```text
+instruction.md
+task.toml
+environment/
+solution/       # optional oracle/reference solution
+tests/
+```
+
+The released v0.22.0 task schema default is `1.4`. `task.toml` separates task
+metadata, agent/verifier timeouts, environment resources and network policy,
+optional solution settings, and verifier isolation. The agent executes in a
+Harbor environment; `tests/test.sh` or `test.bat` writes numeric rewards to
+`/logs/verifier/reward.json` or `reward.txt`. Harbor exposes those numbers as
+`VerifierResult.rewards: dict[str, float | int] | None` in the tagged
+[`VerifierResult` model](https://github.com/harbor-framework/harbor/blob/v0.22.0/src/harbor/models/verifier/result.py).
+
+Harbor's live documentation can advance ahead of an installed release. The
+compatibility contract therefore uses the tagged v0.22.0 source and release
+notes as authority; live documentation is a discovery aid, not the version
+boundary.
+
+Harbor's [Core Concepts](https://www.harborframework.com/docs/core-concepts)
+distinguish a portable task, a dataset, an agent, a container environment, a
+trial, and a job. Registry packages use `org/name@tag`; publishing validates
+and stores the canonical task configuration and digest. See
+[Publishing a task](https://www.harborframework.com/docs/tasks/publishing) and
+[Tasks and Datasets](https://www.harborframework.com/docs/sharing/sharing).
+
+These are current facts, not a compatibility promise across every Harbor
+release. CORAL's existing v0.13 job-result parser is not evidence that it is
+compatible with Harbor v0.22 task loading or trial execution.
+
+## Proposed ownership boundary
+
+### Harbor owns the portable task contract
+
+**Proposed:** Harbor owns all information needed to understand and verify a
+task independently of CORAL:
+
+- task identity, description, authors, keywords, and task package version;
+- human instruction;
+- initial environment and resource/network requirements;
+- optional oracle solution;
+- verifier code, verifier environment, timeouts, numeric rewards, and declared
+  artifacts;
+- task schema version and registry packaging.
+
+CORAL must not add private keys to Harbor's standard `task.toml` schema. If a
+portable task is downloaded and run with Harbor alone, its task semantics and
+verification must remain intact.
+
+### CORAL owns the optimization-run contract
+
+**Proposed:** a separate `coral.yaml` references one Harbor task and contains
+only CORAL orchestration and objective-selection state:
+
+```yaml
+task:
+  source: ./task                 # or org/name@versioned-tag
+  reward:
+    primary: reward
+    direction: maximize
+
+agents:
+  runtime: codex
+  model: gpt-5
+  count: 4
+
+islands:
+  count: 2
+
+sharing:
+  attempts: true
+  notes: true
+  skills: true
+
+workspace:
+  results_dir: ./results
+
+run:
+  session: local
+  stop:
+    max_real_attempts: 100
+```
+
+The filename and exact shape are **Proposed**, not accepted. The invariant is
+more important than the name: CORAL orchestration must not leak into
+`task.toml`, and Harbor task metadata must not be duplicated into CORAL config.
+
+Persisted CORAL configs must not use a mutable registry alias such as `latest`.
+At run creation CORAL should resolve a local directory or `org/name@tag` to an
+immutable task digest and record the original reference, digest, Harbor task
+schema, task package version, and Harbor runtime version in the run metadata.
+
+## Mapping from the current CORAL format
+
+| Current CORAL asset or field | Harbor / new location | Status and notes |
+| --- | --- | --- |
+| `task.name` | `[task].name` in `task.toml` | **Proposed.** Harbor requires stable `org/name`; migration may need an explicit organization. |
+| `task.description` | `instruction.md` plus `[task].description` | **Proposed.** Full agent-facing content goes in `instruction.md`; the TOML description stays short. |
+| `task.tips` | `instruction.md` | **Proposed.** Merge into a clearly labelled guidance section; do not duplicate it in `coral.yaml`. |
+| `seed/` | agent-visible starting workspace | **Open.** It must never map to Harbor `solution/`. See workspace materialization below. |
+| `grader.entrypoint` | `tests/`, verifier config, or a temporary legacy bridge | **Proposed.** Canonical tasks use Harbor verification; generic `TaskGrader` remains transition-only. |
+| `grader.setup` | verifier/environment image build | **Proposed.** Convert reproducible installs into Dockerfiles or verifier images; do not execute arbitrary legacy setup implicitly. |
+| `grader.timeout` | `[verifier].timeout_sec` | **Proposed.** CORAL may impose a stricter outer infrastructure timeout but must record which layer fired. |
+| `grader.private` | Harbor `tests/`, separate verifier environment, and declared verifier-only artifacts | **Proposed.** Never copy these paths into a CORAL agent worktree. |
+| `grader.args` | task-specific Harbor metadata/config or migration code | **Open per field.** Do not dump arbitrary runtime args into `[metadata]` and call them portable. |
+| `grader.direction` | `task.reward.direction` in `coral.yaml` | **Proposed.** Preserve raw Harbor reward values; CORAL applies maximize/minimize when ranking attempts. |
+| `grader.max_pending_per_agent` | CORAL orchestration config | **Proposed.** Queue policy is not task semantics. |
+| `grader.parallel.max_workers` | CORAL orchestration config | **Proposed.** Harbor/provider concurrency is a separate adapter setting. |
+| `workspace.repo_path` and `seed/` copying | workspace materializer | **Open.** Must produce the same agent-visible Git baseline as the Harbor environment. |
+| `workspace.setup` | Harbor environment build where portable; CORAL run bootstrap otherwise | **Open.** Every command needs an owner and reproducibility rule. |
+| `agents.*`, `islands.*`, `sharing.*`, `run.*` | `coral.yaml` | **Proposed.** These stay entirely outside `task.toml`. |
+| `ScoreBundle.scores` | one CORAL `Score` per Harbor reward key | **Proposed.** Preserve names and numeric values exactly. |
+| `ScoreBundle.aggregated` | explicit primary reward or approved aggregation | **Proposed.** Never infer weights or average an arbitrary reward dictionary. |
+| `ScoreBundle.feedback` | sanitized verifier summary | **Proposed.** Public feedback policy still applies. |
+| agent-visible `eval_logs/` directories | selected Harbor logs and artifact manifest | **Proposed.** Preserve both single-island and per-island locations; store references and public copies without leaking verifier-only data. |
+| `Attempt` status/budget class | Harbor result or exception classification | **Proposed.** Missing reward, verifier crash, setup failure, and timeout are grader infrastructure outcomes, not a score of zero. |
+
+## Reward and attempt translation
+
+Harbor's canonical verifier result is a mapping of numeric reward names to
+values. The adapter should translate it without changing meaning:
+
+```text
+Harbor VerifierResult.rewards
+  -> ScoreBundle.scores[name] = Score(value=value, name=name)
+  -> ScoreBundle.aggregated = scores[configured_primary].value
+```
+
+**Proposed rules:**
+
+1. `task.reward.primary` is required when more than one Harbor reward key can
+   be returned.
+2. If an approved aggregation is required, it is declared explicitly in
+   CORAL orchestration and versioned with the run. The adapter does not invent
+   weights or silently use the first dictionary key.
+3. `direction` controls CORAL ranking and stop thresholds; it does not negate
+   or rewrite the stored raw Harbor reward.
+4. `rewards is None`, a missing primary key, task/environment build failure,
+   verifier failure, and timeout produce a structured grader-error/timeout
+   attempt. They do not produce a real attempt with score `0`.
+5. Public feedback contains only a bounded, task-approved verifier summary.
+   Full logs and artifacts are indexed under eval logs according to their
+   visibility policy.
+6. The adapter records Harbor task digest, task version, schema version,
+   Harbor runtime version, provider, reward mapping, and relevant log/artifact
+   references in attempt metadata.
+
+## Workspace materialization and evaluation flow
+
+The central incompatibility is that CORAL evolves a Git worktree while Harbor
+normally owns an agent trial inside an environment. Mapping `seed/` to
+`solution/` would expose an oracle and is rejected.
+
+**Proposed adapter boundary:**
+
+```text
+resolve Harbor task path/tag -> verify schema + pin digest
+                             -> materialize agent-visible workspace
+                             -> initialize CORAL repo/worktrees
+
+candidate CORAL commit -> create fresh Harbor environment
+                       -> upload candidate workspace to the agent workdir
+                       -> run Harbor verifier without a second optimization agent
+                       -> collect VerifierResult + declared artifacts/logs
+                       -> translate to ScoreBundle + Attempt
+```
+
+Phase 2 must first prove that the pinned Harbor API can export/import the
+agent-visible workdir and run verification without launching a competing
+optimization agent. This is **Open**. The proof must use Harbor's public Python
+interfaces or a stable CLI contract; importing private modules is not an
+acceptable long-term adapter.
+
+If that contract is unavailable, the fallback choices are:
+
+1. add or upstream a Harbor API for prepare/upload/verify; or
+2. keep the affected CORAL task on the legacy loader.
+
+Running a no-op Harbor agent merely to reach the verifier is not recommended:
+it adds lifecycle and logging ambiguity and makes cancellation ownership
+unclear.
+
+**Proposed record relationship:** one completed CORAL candidate evaluation maps
+to one Harbor trial-like verifier result and one CORAL `Attempt`. A CORAL
+optimization run spans many such evaluations; it is not itself a single Harbor
+trial. Whether the adapter creates one Harbor job per evaluation or owns a
+longer-lived job/session is **Open** and must not change the
+one-result-per-attempt history contract.
+
+### Non-containerized tasks
+
+Harbor's current core task model is container-environment based. CORAL has many
+host-worktree tasks. The initial canonical adapter should therefore support
+only tasks whose Harbor environment can be reproduced by a supported provider.
+
+**Proposed transition rule:** host-only tasks remain on the legacy CORAL loader
+until one of these is accepted:
+
+- an official Harbor environment provider that safely models the required host
+  behavior; or
+- a separately named CORAL compatibility profile with explicit portability and
+  security limitations.
+
+Consuming only the Harbor directory layout while bypassing Harbor environment
+and verifier semantics must not be described as full Harbor compatibility.
+
+## Security and visibility invariants
+
+The adapter must preserve these invariants before any bulk migration:
+
+1. `solution/`, `tests/`, verifier source, answer keys, and verifier-only
+   environment variables are never copied into agent worktrees or
+   `.coral/public/`.
+2. Sensitive tasks use Harbor's separate verifier environment where feasible.
+   A shared verifier environment is accepted only when the task declares that
+   its tests and dependencies are safe from the agent.
+3. Only explicitly declared public artifacts and sanitized feedback cross from
+   Harbor verification into agent-visible CORAL state.
+4. Private logs remain under `.coral/private/` or another manager-only path.
+   Public eval logs contain an artifact manifest and approved copies, not an
+   indiscriminate Harbor job directory.
+5. Registry credentials, environment secrets, and provider tokens stay in the
+   manager process and are never serialized into `coral.yaml`, attempt JSON,
+   CORAL.md, or PR/test output.
+6. Task resolution is immutable for a run. A registry tag is resolved once and
+   its digest is persisted before agents start.
+7. Resuming a run uses the recorded digest and compatibility metadata; it does
+   not re-resolve a mutable tag.
+
+## Version and compatibility policy
+
+**Proposed initial support:**
+
+- Harbor runtime: exactly `v0.22.0` for Gate B, pinned in CORAL's
+  lock/install path;
+- Harbor task schema: exactly `1.4`;
+- registry task: immutable digest recorded, with a non-`latest` user-facing tag;
+- CORAL legacy task loader: retained during the migration window.
+
+Schema acceptance is not blanket support for every optional Harbor feature.
+The adapter must publish a capability profile and reject unsupported features
+with an actionable validation error rather than ignore them.
+
+| Harbor v0.22 capability | Initial status |
+| --- | --- |
+| single-step `instruction.md`, environment, verifier, numeric rewards, and declared artifacts | **Proposed for Gate B** |
+| local task directory | **Proposed for Gate B** |
+| registry task reference | **Proposed for Gate C**, after digest pinning is proven |
+| dataset reference and task selection | **Deferred.** Build on the task adapter; do not make dataset selection implicit in `task.source`. |
+| multi-step task | **Deferred.** Reject initially; a CORAL attempt is not a Harbor step, and reward/cancellation semantics need a separate mapping. |
+| simulated-user and loaded-trajectory runs | **Deferred.** Add only with explicit history, privacy, and lifecycle mappings. |
+| host-only environment | **Legacy loader** until an approved provider or compatibility profile exists. |
+
+Package version, task schema version, task package version, and registry tag
+are separate values and must be reported separately. Any new Harbor release or
+task schema is unsupported until the adapter compatibility suite passes. The
+supported set may then be widened one tested version at a time or expressed as
+an upper-bounded range once CI continuously exercises that range. Patch updates
+are not assumed compatible merely because the version is semver-like.
+
+The current v0.13 parser tests remain useful only for the two legacy wrappers.
+They do not define the canonical adapter's compatibility range.
+
+## Validation layers
+
+`coral validate` should eventually report distinct layers rather than collapse
+them into one success message:
+
+1. **Resolution** — local path or registry reference resolves to a pinned task.
+2. **Harbor schema** — Harbor loads and validates the task directory.
+3. **Materialization** — the agent-visible workspace can be created without
+   private content.
+4. **Verification smoke** — the initial workspace produces a structured Harbor
+   verifier result or a structured failure.
+5. **CORAL mapping** — reward selection, direction, feedback visibility, and
+   attempt metadata are complete.
+6. **Optional oracle/calibration** — when `solution/` or expected cases exist,
+   their results match declared expectations.
+
+Passing layers 1–4 proves structural executability. It does not prove that the
+reward captures user intent, and the UI/CLI must not claim otherwise.
+
+## Migration and rollout gates
+
+This RFC refines, but does not reorder, the phases in Issue #225.
+
+### Gate A — accept this compatibility contract
+
+- Maintainers decide the Open items below.
+- Replace obsolete Harbor repository links with current official sources.
+- Agree on the first supported Harbor runtime and schema.
+
+### Gate B — build a narrow loader/verification spike
+
+- local task directory only;
+- one container-backed deterministic task;
+- no registry, no bulk migration, no CLI default change;
+- prove workspace materialization, verifier-only isolation, reward mapping,
+  timeout/error mapping, cancellation ownership, and cleanup.
+
+### Gate C — introduce the dual loader behind an explicit task source
+
+- support a pinned local Harbor directory and a versioned registry reference
+  resolved to a recorded content digest;
+- preserve legacy `task.yaml` behavior;
+- persist task digest and compatibility metadata in every run;
+- add CLI diagnostics without changing default authoring output.
+
+### Gate D — pass the representative parity matrix
+
+| Family | Representative CORAL task | Required evidence |
+| --- | --- | --- |
+| deterministic numeric maximize | `circle_packing` or `dna_design` proxy mode | same valid/invalid behavior, reward name/value, public feedback |
+| minimize objective | `kernel_builder` or another current minimize task | same raw metric and leaderboard ordering without sign corruption |
+| private inputs | `mnist` or `stanford_covid_vaccine` | no private path visible; equivalent score and failure feedback |
+| rubric/LLM judge | `race-japan-elderly` or `apex-eggshell-skull` | judge config, multi-metric rewards, feedback and secret handling |
+| GPU/resource-heavy | a current GPU example | resource declaration and timeout behavior on a supported provider |
+| existing Harbor wrapper | `swebench-verified` | equivalent fixed-slice score, trajectories, logs, tune/real budget class |
+| existing Harbor wrapper | `terminal-bench` | equivalent pass rate, timeouts, logs and failure classification |
+
+Parity means repeated results within an agreed tolerance, equivalent validity
+gates, preserved direction, and no reduction in feedback or security. One
+successful baseline is not enough.
+
+### Gate E — authoring and controlled migration
+
+- `coral init` can scaffold a Harbor task and separate CORAL config;
+- `coral validate`, `start`, and `eval` support the new source explicitly;
+- migration tooling produces a report and refuses ambiguous field mappings;
+- convert a small reviewed batch before any generated bulk migration;
+- retain the legacy loader and warnings for a documented compatibility window.
+
+### Gate F — deprecate only after downstream evidence
+
+Deprecation starts only when representative built-ins, external usage, docs,
+templates, and bundled skills use the new contract and rollback remains
+possible. Removing `TaskGrader` as the canonical task-definition path does not
+preclude a clearly named legacy/custom extension while Harbor lacks required
+semantics.
+
+## Open decisions for Maintainers
+
+| Decision | Recommendation | Alternative | Status |
+| --- | --- | --- | --- |
+| CORAL config filename | `coral.yaml` | keep `task.yaml` for orchestration, but that perpetuates naming ambiguity | **Open** |
+| first Harbor runtime range | start with exact `v0.22.0` and schema `1.4`; widen only after compatibility tests | target an older release matching current wrappers | **Open**; current wrappers are not a task-loader compatibility proof |
+| local and registry references | support local paths first, then pinned `org/name@tag`; persist digest | registry-first | **Proposed** |
+| dataset references | defer until the task adapter is stable, then add an explicit dataset source and task selector | overload `task.source` with path, task, and dataset guessing | **Proposed** |
+| mutable `latest` | reject in persisted run config | resolve silently on each start | **Proposed**; silent re-resolution breaks reproducibility |
+| visible starter workspace | export Harbor agent workdir into a CORAL Git baseline, then upload candidate snapshots for verification | run CORAL agents inside Harbor environments | **Open**, requires Phase 2 API spike |
+| non-container tasks | keep legacy until an explicit supported provider/profile exists | native verifier path using Harbor files only | **Open**; the alternative has reduced portability |
+| multiple rewards | require a primary key and optional explicit aggregation | infer first key or average | **Proposed** |
+| minimize objectives | store raw reward; let CORAL ranking apply direction | negate reward in adapter | **Proposed** |
+| custom/rubric graders | migrate to Harbor tests/RewardKit where possible; keep a transition escape hatch | preserve `TaskGrader` indefinitely as a second canonical system | **Open** |
+| private verifier mode | prefer separate verifier environment for sensitive tasks | shared verifier with task-owned risk acceptance | **Proposed** |
+| legacy removal timeline | evidence-based dual-loader window | immediate breaking migration | **Open** |
+| Harbor multi-step tasks | reject in the initial profile and design a separate step/attempt mapping | treat CORAL attempts as Harbor steps | **Open**; the two lifecycles are not equivalent |
+
+## Acceptance criteria for Phase 1
+
+This RFC is complete when Maintainers have reviewed the Proposed decisions and
+resolved or explicitly deferred every Open item needed for Gate B. Acceptance
+of this document does not claim that the adapter, migration, score parity, or
+Harbor v0.22 compatibility has been implemented.
+
+Subsequent implementation PRs should reference Issue #225 but must not use
+`Fixes #225` until the complete migration and deprecation acceptance criteria
+are satisfied.
+
+## Primary references
+
+- [CORAL Issue #225](https://github.com/Human-Agent-Society/CORAL/issues/225)
+- [Harbor task structure](https://www.harborframework.com/docs/tasks)
+- [Harbor core concepts](https://www.harborframework.com/docs/core-concepts)
+- [Harbor task publishing](https://www.harborframework.com/docs/tasks/publishing)
+- [Harbor task and dataset sharing](https://www.harborframework.com/docs/sharing/sharing)
+- [Harbor v0.22.0 release](https://github.com/harbor-framework/harbor/releases/tag/v0.22.0)
+- [Harbor v0.22.0 task configuration](https://github.com/harbor-framework/harbor/blob/v0.22.0/src/harbor/models/task/config.py)
+- [Harbor v0.22.0 `VerifierResult`](https://github.com/harbor-framework/harbor/blob/v0.22.0/src/harbor/models/verifier/result.py)
+- [CORAL configuration](../coral/config.py)
+- [CORAL score and attempt types](../coral/types.py)
+- [CORAL project materialization](../coral/workspace/project.py)
+- [CORAL grader environment](../coral/workspace/grader_env.py)
+- [CORAL subprocess grader](../coral/grader/subprocess_grader.py)

--- a/docs/content/docs/getting-started/configuration.mdx
+++ b/docs/content/docs/getting-started/configuration.mdx
@@ -4,7 +4,9 @@ description: Full reference for task.yaml configuration.
 ---
 
 
-Every CORAL task is defined by a `task.yaml` file. This page documents all available options.
+Every CORAL run is configured by a `task.yaml` file. It can either contain the
+legacy inline task/grader definition or reference one local Harbor task. The two
+forms are mutually exclusive.
 
 ## Full example
 
@@ -112,15 +114,63 @@ worked example.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `name` | string | *required* | Task identifier |
-| `description` | string | *required* | What agents should do — included in CORAL.md |
+| `name` | string | *required for legacy tasks* | Task identifier |
+| `description` | string | *required for legacy tasks* | What agents should do — included in CORAL.md |
 | `tips` | string | `""` | Additional hints shown to agents |
+| `source` | string | `""` | Local Harbor task directory, resolved relative to `task.yaml`. |
+| `reward.primary` | string | *required with `source`* | Harbor reward key used as CORAL's aggregate score. |
+| `reward.direction` | string | `"maximize"` | CORAL ranking direction; raw Harbor rewards are not negated. |
+
+### Local Harbor task compatibility
+
+The initial Harbor adapter is an explicit, narrow compatibility profile:
+
+```yaml
+task:
+  source: ./task
+  reward:
+    primary: reward
+    direction: maximize
+
+agents:
+  runtime: codex
+  model: gpt-5
+
+workspace:
+  results_dir: ./results
+```
+
+The referenced directory remains a standard Harbor task with
+`instruction.md`, `task.toml`, `environment/`, and `tests/`. CORAL derives the
+task name and agent instruction from those files, stages the complete task
+under `.coral/private/`, and starts agents from an empty Git workspace. During
+evaluation it uploads only the candidate workspace to a fresh Harbor Docker
+environment, runs Harbor's verifier, and maps every numeric reward into a
+named `Score`. `reward.primary` selects `ScoreBundle.aggregated`; it does not
+change the stored raw value.
+
+This first profile supports exactly Harbor `0.22.0`, task schema `1.4`, one
+local, single-step Linux container task, and a dedicated agent workdir that is
+empty when the container starts. It
+does not yet support registry references, datasets, multi-step or Windows
+tasks, a separate starter repository, `seed/`, `workspace.setup`, task-level
+provider selection, declared public artifacts, or bulk migration.
+`grader.entrypoint`, `grader.setup`, `grader.args`, and `grader.private` must
+not be duplicated in the Harbor-backed input form; CORAL creates the internal
+adapter configuration in the resolved run snapshot.
+
+Docker must be running, and CORAL itself must run on the host
+(`run.session: docker` is rejected because Docker-in-Docker is unsupported).
+On first use, `uv` may download Python 3.12 and the pinned Harbor runtime.
+Harbor task files, verifier logs, and trial data remain manager-only; agents
+receive only the configured instruction, reward values, and a sanitized
+summary under `eval_logs/`.
 
 ## `grader` section
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `entrypoint` | string | *required* | Setuptools-style `module.path:ClassName` resolved inside the grader venv. |
+| `entrypoint` | string | *required for legacy tasks* | Setuptools-style `module.path:ClassName` resolved inside the grader venv. Harbor-backed tasks receive an internal adapter entrypoint. |
 | `setup` | list[string] | `[]` | Shell commands run inside `.coral/private/grader_venv/` at `coral start` / `coral validate` time (typically `uv pip install -e ./grader`). |
 | `timeout` | int | `300` | Eval timeout in seconds (0 = no limit) |
 | `direction` | string | `"maximize"` | `"maximize"` or `"minimize"` — which direction is better |
@@ -137,9 +187,11 @@ CORAL bootstraps a venv at `.coral/private/grader_venv/`, runs every
 command in `grader.setup` inside it, and spawns a worker subprocess from
 that venv whenever an attempt needs grading.
 
-`grader.entrypoint` is required — leaving it empty is an error at load
-time. See [Writing a Custom Grader](/docs/guides/custom-grader) for the
-packaged-grader layout.
+`grader.entrypoint` is required for the legacy inline form — leaving it empty
+is an error at load time. Harbor-backed tasks must omit it because CORAL wires
+the pinned adapter internally. See
+[Writing a Custom Grader](/docs/guides/custom-grader) for the packaged-grader
+layout.
 
 ## `agents` section
 
@@ -251,4 +303,4 @@ Controls what shared state is enabled in `.coral/public/`:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `results_dir` | string | `"./results"` | Where to store run results |
-| `repo_path` | string | `"."` | Path to the git repository root |
+| `repo_path` | string | `"."` | Path to the git repository root. The initial Harbor-backed profile rejects a separate repository and creates an empty candidate workspace. |

--- a/tests/test_harbor_task.py
+++ b/tests/test_harbor_task.py
@@ -1,0 +1,598 @@
+"""Tests for the initial local Harbor task compatibility profile."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from coral.config import CoralConfig, GraderConfig, TaskConfig
+from coral.grader.harbor import (
+    HarborTaskGrader,
+    _copy_candidate_workspace,
+    _HarborRunnerTimeoutError,
+    _run_harbor_runner,
+    _score_bundle_from_result,
+)
+from coral.harbor_task import (
+    HARBOR_ADAPTER_MARKER,
+    HARBOR_GRADER_ENTRYPOINT,
+    HARBOR_RUNTIME_VERSION,
+    inspect_local_harbor_task,
+    stage_local_harbor_task,
+)
+from coral.task.validation import validate_task
+from coral.workspace.project import create_project
+
+
+def _write_harbor_task(root: Path, *, schema: str = "1.4", steps: bool = False) -> Path:
+    task_dir = root / "harbor-task"
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "tests").mkdir()
+    (task_dir / "solution").mkdir()
+    task_toml = [
+        f'schema_version = "{schema}"',
+        "",
+        "[task]",
+        'name = "example/hello"',
+        'version = "1.0.0"',
+        "",
+        "[environment]",
+    ]
+    if steps:
+        task_toml.extend(["", "[[steps]]", 'name = "first"'])
+    (task_dir / "task.toml").write_text("\n".join(task_toml), encoding="utf-8")
+    (task_dir / "instruction.md").write_text("Create hello.txt.\n", encoding="utf-8")
+    (task_dir / "environment" / "Dockerfile").write_text(
+        "FROM ubuntu:24.04\nWORKDIR /app\n",
+        encoding="utf-8",
+    )
+    (task_dir / "tests" / "test.sh").write_text(
+        "#!/bin/sh\necho 1 > /logs/verifier/reward.txt\n",
+        encoding="utf-8",
+    )
+    (task_dir / "solution" / "answer.txt").write_text("secret\n", encoding="utf-8")
+    return task_dir
+
+
+def _write_coral_config(root: Path, source: str = "./harbor-task") -> Path:
+    config_path = root / "task.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "task:",
+                f"  source: {source}",
+                "  reward:",
+                "    primary: reward",
+                "    direction: maximize",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_inspect_local_harbor_task_records_identity_and_digest(tmp_path: Path) -> None:
+    task_dir = _write_harbor_task(tmp_path)
+
+    descriptor = inspect_local_harbor_task(task_dir)
+
+    assert descriptor.name == "example/hello"
+    assert descriptor.instruction == "Create hello.txt."
+    assert descriptor.schema_version == "1.4"
+    assert descriptor.package_version == "1.0.0"
+    assert descriptor.digest.startswith("sha256:")
+
+
+def test_harbor_instruction_strips_leading_canary_like_harbor_runtime(
+    tmp_path: Path,
+) -> None:
+    task_dir = _write_harbor_task(tmp_path)
+    (task_dir / "instruction.md").write_text(
+        "<!-- benchmark canary 123 -->\n# second CANARY marker\n\nCreate hello.txt.\n",
+        encoding="utf-8",
+    )
+
+    descriptor = inspect_local_harbor_task(task_dir)
+
+    assert descriptor.instruction == "Create hello.txt."
+
+
+def test_harbor_source_hydrates_runtime_config_without_user_grader_fields(
+    tmp_path: Path,
+) -> None:
+    _write_harbor_task(tmp_path)
+    config_path = _write_coral_config(tmp_path)
+
+    config = CoralConfig.from_yaml(config_path)
+
+    assert config.task.name == "example/hello"
+    assert config.task.description == "Create hello.txt."
+    assert config.task.source == "./harbor-task"
+    assert config.task.reward is not None
+    assert config.task.reward.primary == "reward"
+    assert config.grader.entrypoint == HARBOR_GRADER_ENTRYPOINT
+    assert config.grader.direction == "maximize"
+    assert config.grader.args["harbor_adapter"] == HARBOR_ADAPTER_MARKER
+    assert config.grader.args["harbor_runtime_version"] == HARBOR_RUNTIME_VERSION
+    assert config.grader.args["harbor_task_digest"].startswith("sha256:")
+
+
+def test_harbor_config_hydration_does_not_mutate_input_mapping(tmp_path: Path) -> None:
+    task_dir = _write_harbor_task(tmp_path)
+    data = {
+        "task": {
+            "source": str(task_dir),
+            "reward": {"primary": "reward", "direction": "maximize"},
+        },
+        "grader": {"timeout": 600},
+    }
+    original = json.loads(json.dumps(data))
+
+    CoralConfig.from_dict(data)
+
+    assert data == original
+
+
+def test_legacy_task_serialization_is_unchanged() -> None:
+    config = CoralConfig(task=TaskConfig(name="legacy", description="Keep existing behavior"))
+
+    task_data = config.to_dict()["task"]
+
+    assert "source" not in task_data
+    assert "reward" not in task_data
+
+
+def test_resolved_harbor_run_config_reloads_without_original_relative_source(
+    tmp_path: Path,
+) -> None:
+    _write_harbor_task(tmp_path)
+    config = CoralConfig.from_yaml(_write_coral_config(tmp_path))
+    snapshot_dir = tmp_path / "run" / ".coral"
+    snapshot_dir.mkdir(parents=True)
+    snapshot = snapshot_dir / "config.yaml"
+    config.to_yaml(snapshot)
+
+    restored = CoralConfig.from_yaml(snapshot)
+
+    assert restored.task.name == "example/hello"
+    assert restored.task.source == "./harbor-task"
+    assert restored.grader.args["harbor_task_digest"] == config.grader.args["harbor_task_digest"]
+
+
+def test_harbor_reward_dotlist_override_keeps_internal_grader_in_sync(
+    tmp_path: Path,
+) -> None:
+    _write_harbor_task(tmp_path)
+    config = CoralConfig.from_yaml(_write_coral_config(tmp_path))
+
+    merged = CoralConfig.merge_dotlist(
+        config,
+        ["task.reward.primary=quality", "task.reward.direction=minimize"],
+    )
+
+    assert merged.task.reward is not None
+    assert merged.task.reward.primary == "quality"
+    assert merged.grader.args["primary_reward"] == "quality"
+    assert merged.grader.direction == "minimize"
+
+
+def test_harbor_task_rejects_docker_in_docker_session(tmp_path: Path) -> None:
+    _write_harbor_task(tmp_path)
+    config_path = _write_coral_config(tmp_path)
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8") + "run:\n  session: docker\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unsupported Docker-in-Docker"):
+        CoralConfig.from_yaml(config_path)
+
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            "run:\n  session: docker\n",
+            "run:\n  session: local\n",
+        ),
+        encoding="utf-8",
+    )
+    config = CoralConfig.from_yaml(config_path)
+    with pytest.raises(ValueError, match="unsupported Docker-in-Docker"):
+        CoralConfig.merge_dotlist(config, ["run.session=docker"])
+
+
+@pytest.mark.parametrize(
+    ("extra", "message"),
+    [
+        ("  name: duplicate\n", "must not duplicate"),
+        ("grader:\n  entrypoint: custom:Grader\n", "cannot define portable grader"),
+        ("workspace:\n  repo_path: ./seed-repo\n", "creates an empty CORAL workspace"),
+    ],
+)
+def test_harbor_source_rejects_mixed_legacy_ownership(
+    tmp_path: Path,
+    extra: str,
+    message: str,
+) -> None:
+    _write_harbor_task(tmp_path)
+    base = _write_coral_config(tmp_path).read_text(encoding="utf-8")
+    (tmp_path / "task.yaml").write_text(base + extra, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        CoralConfig.from_yaml(tmp_path / "task.yaml")
+
+
+def test_harbor_source_rejects_registry_and_unsupported_schema(tmp_path: Path) -> None:
+    _write_coral_config(tmp_path, source="example/hello@1.0.0")
+    with pytest.raises(ValueError, match="Registry Harbor task sources"):
+        CoralConfig.from_yaml(tmp_path / "task.yaml")
+
+    _write_harbor_task(tmp_path, schema="1.5")
+    _write_coral_config(tmp_path)
+    with pytest.raises(ValueError, match="requires task schema 1.4"):
+        CoralConfig.from_yaml(tmp_path / "task.yaml")
+
+
+def test_harbor_source_rejects_multi_step_task(tmp_path: Path) -> None:
+    _write_harbor_task(tmp_path, steps=True)
+    _write_coral_config(tmp_path)
+
+    with pytest.raises(ValueError, match="single-step"):
+        CoralConfig.from_yaml(tmp_path / "task.yaml")
+
+
+def test_harbor_source_rejects_unpublished_declared_artifacts(tmp_path: Path) -> None:
+    task_dir = _write_harbor_task(tmp_path)
+    config_path = task_dir / "task.toml"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            'schema_version = "1.4"\n',
+            'schema_version = "1.4"\nartifacts = ["/tmp/result.json"]\n',
+        ),
+        encoding="utf-8",
+    )
+    _write_coral_config(tmp_path)
+
+    with pytest.raises(ValueError, match="does not yet publish declared task artifacts"):
+        CoralConfig.from_yaml(tmp_path / "task.yaml")
+
+
+def test_stage_harbor_task_checks_digest_and_keeps_solution_private(tmp_path: Path) -> None:
+    task_dir = _write_harbor_task(tmp_path)
+    descriptor = inspect_local_harbor_task(task_dir)
+    private_dir = tmp_path / "private"
+    private_dir.mkdir()
+
+    staged = stage_local_harbor_task(
+        "./harbor-task",
+        base_dir=tmp_path,
+        private_dir=private_dir,
+        expected_digest=descriptor.digest,
+    )
+
+    assert (staged / "solution" / "answer.txt").read_text(encoding="utf-8") == "secret\n"
+    with pytest.raises(ValueError, match="changed after configuration"):
+        other_private = tmp_path / "other-private"
+        other_private.mkdir()
+        stage_local_harbor_task(
+            task_dir,
+            base_dir=tmp_path,
+            private_dir=other_private,
+            expected_digest="sha256:wrong",
+        )
+
+
+def test_validate_rejects_seed_mixed_with_harbor_source(tmp_path: Path) -> None:
+    _write_harbor_task(tmp_path)
+    _write_coral_config(tmp_path)
+    (tmp_path / "seed").mkdir()
+
+    report = validate_task(tmp_path)
+
+    assert not report.valid
+    assert {diagnostic.code for diagnostic in report.diagnostics} == {"task.harbor.seed_mixed"}
+
+
+def test_create_project_stages_harbor_task_without_exposing_it_to_agents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_harbor_task(tmp_path)
+    config = CoralConfig.from_yaml(_write_coral_config(tmp_path))
+    config.task_dir = tmp_path
+    config.workspace.run_dir = str(tmp_path / "run")
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda *args, **kwargs: Path("unused"),
+    )
+
+    paths = create_project(config, config_dir=tmp_path)
+
+    assert (paths.coral_dir / "private" / "harbor_task" / "tests" / "test.sh").is_file()
+    assert not (paths.repo_dir / "task.toml").exists()
+    assert not (paths.repo_dir / "solution").exists()
+    assert not (paths.repo_dir / "harbor-task").exists()
+
+
+def test_score_bundle_preserves_named_rewards_and_primary_selection() -> None:
+    result = {
+        "runtime_version": HARBOR_RUNTIME_VERSION,
+        "schema_version": "1.4",
+        "task_name": "example/hello",
+        "task_package_version": "1.0.0",
+        "task_digest": "harbor-checksum",
+        "rewards": {"reward": 1, "quality": 0.75},
+    }
+
+    bundle = _score_bundle_from_result(
+        result,
+        primary_reward="quality",
+        direction="maximize",
+        expected_digest="sha256:source",
+        summary_path="eval_logs/abc/harbor-summary.json",
+    )
+
+    assert bundle.aggregated == 0.75
+    assert bundle.scores["reward"].value == 1
+    assert bundle.scores["quality"].value == 0.75
+    assert bundle.metadata["harbor"]["source_digest"] == "sha256:source"
+    assert bundle.metadata["harbor"]["direction"] == "maximize"
+    assert "eval_logs/abc/harbor-summary.json" in (bundle.feedback or "")
+
+
+def test_score_bundle_rejects_missing_primary_and_non_numeric_reward() -> None:
+    base = {
+        "runtime_version": HARBOR_RUNTIME_VERSION,
+        "rewards": {"reward": 1},
+    }
+    with pytest.raises(RuntimeError, match="did not return primary reward"):
+        _score_bundle_from_result(
+            base,
+            primary_reward="quality",
+            direction="maximize",
+            expected_digest="sha256:x",
+            summary_path="summary.json",
+        )
+
+    with pytest.raises(RuntimeError, match="not numeric"):
+        _score_bundle_from_result(
+            {**base, "rewards": {"reward": True}},
+            primary_reward="reward",
+            direction="maximize",
+            expected_digest="sha256:x",
+            summary_path="summary.json",
+        )
+
+
+def test_score_bundle_preserves_zero_primary_reward() -> None:
+    bundle = _score_bundle_from_result(
+        {
+            "runtime_version": HARBOR_RUNTIME_VERSION,
+            "rewards": {"reward": 0},
+        },
+        primary_reward="reward",
+        direction="minimize",
+        expected_digest="sha256:x",
+        summary_path="summary.json",
+    )
+
+    assert bundle.aggregated == 0.0
+    assert bundle.scores["reward"].value == 0
+
+
+def test_harbor_runner_timeout_is_a_grader_error_not_a_null_score(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task_dir = _write_harbor_task(tmp_path)
+    descriptor = inspect_local_harbor_task(task_dir)
+    private_dir = tmp_path / "run" / ".coral" / "private"
+    private_dir.mkdir(parents=True)
+    stage_local_harbor_task(
+        task_dir,
+        base_dir=tmp_path,
+        private_dir=private_dir,
+        expected_digest=descriptor.digest,
+    )
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    grader = HarborTaskGrader(
+        GraderConfig(
+            timeout=10,
+            args={
+                "harbor_adapter": HARBOR_ADAPTER_MARKER,
+                "harbor_runtime_version": HARBOR_RUNTIME_VERSION,
+                "harbor_schema_version": descriptor.schema_version,
+                "harbor_task_name": descriptor.name,
+                "harbor_task_subdir": "harbor_task",
+                "harbor_task_digest": descriptor.digest,
+                "primary_reward": "reward",
+            },
+        )
+    )
+    grader.private_dir = str(private_dir)
+    grader.codebase_path = str(candidate)
+
+    def time_out(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise _HarborRunnerTimeoutError(8, "private stdout", "private stderr")
+
+    monkeypatch.setattr("coral.grader.harbor._run_harbor_runner", time_out)
+
+    with pytest.raises(RuntimeError, match="timed out after 8.0s"):
+        grader.evaluate()
+    attempt_runs = list((private_dir / "harbor_runs" / "candidate").iterdir())
+    assert all(not (run / "candidate").exists() for run in attempt_runs)
+    assert (attempt_runs[0] / "runner.stdout.log").read_text(encoding="utf-8") == ("private stdout")
+    request = json.loads((attempt_runs[0] / "request.json").read_text(encoding="utf-8"))
+    assert request["trial_name"].startswith("coral-eval-")
+
+
+def test_runner_timeout_interrupts_before_force_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeProcess:
+        returncode = 130
+
+        def __init__(self) -> None:
+            self.communicate_timeouts: list[float | None] = []
+            self.signals: list[int] = []
+            self.terminated = False
+            self.killed = False
+
+        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+            self.communicate_timeouts.append(timeout)
+            if len(self.communicate_timeouts) == 1:
+                raise subprocess.TimeoutExpired(cmd="runner", timeout=timeout or 0)
+            return "cancelled stdout", "cancelled stderr"
+
+        def send_signal(self, sent_signal: int) -> None:
+            self.signals.append(sent_signal)
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+    process = FakeProcess()
+    monkeypatch.setattr("coral.grader.harbor.subprocess.Popen", lambda *a, **kw: process)
+
+    with pytest.raises(_HarborRunnerTimeoutError) as captured:
+        _run_harbor_runner(
+            ["runner"],
+            environment={},
+            timeout=8,
+            cleanup_grace=2,
+        )
+
+    assert process.communicate_timeouts == [8, 2]
+    if os.name == "posix":
+        assert process.signals == [signal.SIGINT]
+        assert not process.terminated
+    else:
+        assert process.signals == []
+        assert process.terminated
+    assert not process.killed
+    assert captured.value.stdout == "cancelled stdout"
+
+
+def test_candidate_copy_excludes_runtime_state_and_preserves_safe_symlinks(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "keep.txt").write_text("ok", encoding="utf-8")
+    (source / ".git").write_text("gitdir: elsewhere", encoding="utf-8")
+    (source / "cache.pyc").write_bytes(b"bytecode")
+    (source / "private.txt").write_text("private", encoding="utf-8")
+    (source / "link").symlink_to("private.txt")
+    (source / ".codex").symlink_to(tmp_path / "shared-state")
+    destination = tmp_path / "destination"
+
+    _copy_candidate_workspace(source, destination)
+
+    assert (destination / "keep.txt").read_text(encoding="utf-8") == "ok"
+    assert not (destination / ".git").exists()
+    assert not (destination / "cache.pyc").exists()
+    assert not (destination / ".codex").exists()
+    assert (destination / "link").is_symlink()
+    assert (destination / "link").readlink() == Path("private.txt")
+
+
+def test_candidate_copy_keeps_runtime_config_but_skips_shared_state_links(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    runtime_dir = source / ".codex"
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "config.toml").write_text("model = 'test'\n", encoding="utf-8")
+    shared = tmp_path / "shared" / "notes"
+    shared.mkdir(parents=True)
+    (runtime_dir / "notes").symlink_to(shared)
+
+    destination = tmp_path / "destination"
+    _copy_candidate_workspace(source, destination)
+
+    assert (destination / ".codex" / "config.toml").is_file()
+    assert not (destination / ".codex" / "notes").exists()
+
+
+def test_candidate_copy_rejects_symlink_that_escapes_repository(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "escape").symlink_to("../outside")
+
+    with pytest.raises(ValueError, match="symlink escapes"):
+        _copy_candidate_workspace(source, tmp_path / "destination")
+
+
+def test_public_summary_shape_does_not_include_private_trial_path(tmp_path: Path) -> None:
+    summary = {
+        "runtime_version": HARBOR_RUNTIME_VERSION,
+        "schema_version": "1.4",
+        "task_name": "example/hello",
+        "rewards": {"reward": 1},
+    }
+    path = tmp_path / "summary.json"
+    path.write_text(json.dumps(summary), encoding="utf-8")
+
+    assert "private" not in path.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(
+    os.environ.get("CORAL_HARBOR_E2E") != "1",
+    reason="set CORAL_HARBOR_E2E=1 when Docker and network are available",
+)
+def test_harbor_task_grader_end_to_end(tmp_path: Path) -> None:
+    task_dir = _write_harbor_task(tmp_path)
+    (task_dir / "tests" / "test.sh").write_text(
+        "#!/bin/sh\n"
+        'if [ "$(cat /app/hello.txt)" = "Hello, world!" ]; then\n'
+        "  echo 1 > /logs/verifier/reward.txt\n"
+        "else\n"
+        "  echo 0 > /logs/verifier/reward.txt\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    descriptor = inspect_local_harbor_task(task_dir)
+    private_dir = tmp_path / "run" / ".coral" / "private"
+    private_dir.mkdir(parents=True)
+    stage_local_harbor_task(
+        task_dir,
+        base_dir=tmp_path,
+        private_dir=private_dir,
+        expected_digest=descriptor.digest,
+    )
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / "hello.txt").write_text("Hello, world!\n", encoding="utf-8")
+
+    grader = HarborTaskGrader(
+        GraderConfig(
+            timeout=600,
+            args={
+                "harbor_adapter": HARBOR_ADAPTER_MARKER,
+                "harbor_runtime_version": HARBOR_RUNTIME_VERSION,
+                "harbor_schema_version": descriptor.schema_version,
+                "harbor_task_name": descriptor.name,
+                "harbor_task_subdir": "harbor_task",
+                "harbor_task_digest": descriptor.digest,
+                "primary_reward": "reward",
+            },
+        )
+    )
+    grader.private_dir = str(private_dir)
+    grader.codebase_path = str(candidate)
+
+    bundle = grader.evaluate()
+
+    assert bundle.aggregated == 1.0
+    assert bundle.scores["reward"].value == 1.0
+    summary = private_dir.parent / "public" / "eval_logs" / "candidate" / "harbor-summary.json"
+    assert json.loads(summary.read_text(encoding="utf-8"))["rewards"] == {"reward": 1.0}
+    attempt_runs = list((private_dir / "harbor_runs" / "candidate").iterdir())
+    assert all(not (run / "candidate").exists() for run in attempt_runs)


### PR DESCRIPTION
## Motivation

Refs #225.

Issue #225 proposes using Harbor's standard task directory as CORAL's portable task and evaluation contract while keeping CORAL-specific orchestration in `task.yaml`. The RFC in this PR established the ownership boundary, and a Maintainer asked for an implementation in the same PR.

This update adds a deliberately bounded Gate B spike. It proves that CORAL can resolve one local Harbor task, keep verifier-owned content private, upload a CORAL candidate into a fresh Harbor environment without a second optimization agent, and translate Harbor rewards back into `ScoreBundle`.

This PR does not close #225. Registry resolution, datasets, multi-step tasks, pre-populated workdir export, declared public artifacts, provider selection, representative parity, example migration, and deprecation remain later gates.

## Changes

- Add an opt-in Harbor-backed `task.source` form with explicit `task.reward.primary` and `direction`; reject mixed legacy task/grader ownership instead of guessing precedence.
- Support exactly one local Harbor `0.22.0`, schema `1.4`, single-step Linux Docker task whose dedicated workdir starts empty.
- Derive the CORAL task name and instruction from Harbor files, match Harbor's leading canary removal, record a stable content digest, and stage the complete task under `.coral/private/`.
- Start Harbor-backed CORAL runs from an empty Git workspace so `solution/`, `tests/`, verifier inputs, and task configuration never enter agent worktrees.
- Run exact `harbor==0.22.0` in an isolated Python 3.12 environment, transfer only a filtered candidate snapshot, retain raw trial logs privately, and publish only named rewards plus a sanitized summary.
- Preserve every numeric Harbor reward, select the configured primary key as `ScoreBundle.aggregated`, and leave maximize/minimize handling to CORAL without negating raw values.
- Fail closed for unsupported sources/capabilities, unsafe symlinks, non-empty or protected workdirs, missing/non-numeric rewards, and Docker-in-Docker. Give timeout cancellation a cleanup window before force-kill fallback.
- Update the RFC, configuration reference, developer guide, focused regression tests, and opt-in Docker E2E coverage.

Compatibility and migration: existing inline `task.yaml` files serialize and behave unchanged when `task.source` is absent. Harbor support is explicit and narrow; unsupported profiles return actionable validation errors rather than partial behavior. No dependency is added to CORAL's host environment or lockfile.

## Test plan

- `UV_PROJECT_ENVIRONMENT=/private/tmp/coral251-test-venv UV_CACHE_DIR=/private/tmp/uv-cache-coral uv run pytest tests/ -v` — 741 passed, 2 skipped, 8 existing deprecation warnings.
- `CORAL_HARBOR_E2E=1 UV_CACHE_DIR=/private/tmp/uv-cache-coral uv run --extra dev pytest tests/test_harbor_task.py::test_harbor_task_grader_end_to_end -q` — 1 passed using Harbor's Docker trial path.
- `UV_CACHE_DIR=/private/tmp/uv-cache-coral uv run --extra dev pytest tests/test_harbor_task.py -q` — 26 passed, 1 opt-in E2E skipped.
- `UV_CACHE_DIR=/private/tmp/uv-cache-coral uv run --extra dev ruff check .` — passed.
- `UV_CACHE_DIR=/private/tmp/uv-cache-coral uv run --extra dev ruff format --check .` — 144 files already formatted.
- `UV_CACHE_DIR=/private/tmp/uv-cache-coral uv run --extra dev mypy --follow-imports=skip --disable-error-code=misc coral/harbor_task.py coral/grader/harbor.py` — passed. Full-repository mypy remains outside the gate because the unchanged upstream baseline is not green.
- `UV_CACHE_DIR=/private/tmp/uv-cache-coral uv build` — sdist and wheel built; the wheel contains the adapter and isolated runner.
- `git diff --check upstream/dev...HEAD` — passed.
- `coral validate <local-harbor-hello-world> --json` — succeeded through config resolution, private staging, grader venv, Docker verifier, and reward mapping; the empty baseline produced reward `0.0`, while the positive candidate E2E produced `1.0`.
- Confirmed no `coral-eval` Docker container remained after E2E completion.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [x] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [x] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: `coral/config.py`, `coral/harbor_task.py`, and the Harbor compatibility RFC

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [x] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`. (Not applicable; no example task added.)
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).

Authored with assistance from OpenAI Codex. The submitting human completed the repository-required line-by-line review and can defend the design. The AI-assisted checklist item remains intentionally unchecked at the submitter's request.
