### PR TITLE
feat(cli): add JSON task validation output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ uv sync --all-extras       # Everything
 # Authoring
 coral init my-task                                # Scaffold task.yaml + grader/ package + seed/
 coral validate my-task                            # Type-check task structure and dry-run grader against seed/
+coral validate my-task --json                     # Emit one structured validation result for tools/frontends
 
 # User-level agent bindings (~/.config/coral/agents.yaml)
 coral setup                                       # Scan PATH + numbered wizard (one runtime can yield N bindings)

--- a/coral/cli/__init__.py
+++ b/coral/cli/__init__.py
@@ -167,10 +167,15 @@ Run 'coral <command> --help' for details on any command."""
         "validate",
         help="Test your grader against seed code",
         description="Validate task structure and dry-run the grader against seed code.",
-        epilog="Examples:\n  coral validate my-task",
+        epilog="Examples:\n  coral validate my-task\n  coral validate my-task --json",
         formatter_class=_CommandHelpFormatter,
     )
     p_validate.add_argument("path", help="Path to the task directory")
+    p_validate.add_argument(
+        "--json",
+        action="store_true",
+        help="Output one machine-readable validation result",
+    )
     # Hidden alias: test-eval -> validate
     sub.add_parser("test-eval", help=argparse.SUPPRESS)
 

--- a/coral/cli/author.py
+++ b/coral/cli/author.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -188,7 +189,15 @@ def cmd_validate(args: argparse.Namespace) -> None:
     from coral.task.validation import run_validation
 
     task_dir = Path(args.path).resolve()
-    result = run_validation(task_dir, on_event=_render_validation_progress)
+    json_output = getattr(args, "json", False)
+    on_event = None if json_output else _render_validation_progress
+    result = run_validation(task_dir, on_event=on_event)
+
+    if json_output:
+        print(json.dumps(result.to_dict()))
+        if not result.successful:
+            sys.exit(1)
+        return
 
     if result.failure is not None:
         if result.failure.stage == "structure" and result.report.error_messages:

--- a/docs/content/docs/cli/reference.mdx
+++ b/docs/content/docs/cli/reference.mdx
@@ -31,15 +31,17 @@ Produces a self-contained layout: `task.yaml` wired to a packaged grader (`grade
 Validate task structure and dry-run the grader against seed code.
 
 ```bash
-coral validate <path>
+coral validate <path> [--json]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `path` | Path to the task directory |
+| `--json` | Emit one JSON result containing diagnostics, progress events, the baseline score, and any failure; exits with status 1 when validation fails |
 
 ```bash
 coral validate my-task
+coral validate my-task --json
 ```
 
 ---

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -525,6 +528,88 @@ def test_cmd_validate_renders_shared_runner_result(tmp_path, monkeypatch, capsys
         "  eval: baseline ok",
         "==================================================",
     ]
+
+
+def test_validate_help_documents_json_output() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "coral.cli", "validate", "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--json" in result.stdout
+
+
+def test_cmd_validate_json_outputs_one_machine_readable_document(tmp_path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    result = task_validation.ValidationRunResult(
+        report=ValidationReport(task_dir=task_dir.resolve(), diagnostics=()),
+        events=(),
+        baseline=ScoreBundle(
+            scores={"eval": Score(value=1.25, name="eval", explanation="baseline ok")},
+            aggregated=1.25,
+        ),
+    )
+
+    def fake_run_validation(path, *, on_event=None):
+        assert path == task_dir.resolve()
+        assert on_event is None
+        return result
+
+    monkeypatch.setattr(task_validation, "run_validation", fake_run_validation)
+
+    cmd_validate(argparse.Namespace(path=str(task_dir), json=True))
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["successful"] is True
+    assert payload["report"] == {
+        "task_dir": str(task_dir.resolve()),
+        "valid": True,
+        "diagnostics": [],
+    }
+    assert payload["events"] == []
+    assert payload["baseline"]["aggregated"] == 1.25
+    assert payload["failure"] is None
+
+
+def test_cmd_validate_json_failure_is_structured_and_exits_nonzero(tmp_path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    failure = task_validation.ValidationFailure(
+        stage="baseline",
+        code="grader.baseline.failed",
+        message="Grader crashed: boom",
+    )
+    result = task_validation.ValidationRunResult(
+        report=ValidationReport(task_dir=task_dir.resolve(), diagnostics=()),
+        events=(),
+        failure=failure,
+    )
+
+    def fake_run_validation(path, *, on_event=None):
+        assert path == task_dir.resolve()
+        assert on_event is None
+        return result
+
+    monkeypatch.setattr(task_validation, "run_validation", fake_run_validation)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_validate(argparse.Namespace(path=str(task_dir), json=True))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["successful"] is False
+    assert payload["baseline"] is None
+    assert payload["failure"] == {
+        "stage": "baseline",
+        "code": "grader.baseline.failed",
+        "message": "Grader crashed: boom",
+    }
 
 
 def test_cmd_validate_prints_structure_failure_without_diagnostics(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Motivation

Issue #242 proposes frontend-independent task validation that CLI, TUI, and
future web clients can share. PRs #249 and #250 added structured diagnostics
and a reusable validation runner, but scripts still have to parse the
human-oriented `coral validate` output.

This PR exposes the existing structured result through an additive `--json`
flag so tools and future frontends can consume validation results directly.

Refs #242.

## Changes

- Add `coral validate <path> --json` and document it in CLI help.
- Emit one serialized `ValidationRunResult` containing diagnostics, progress
  events, the baseline score, and any structured failure.
- Suppress human-oriented progress rendering in JSON mode while preserving
  the existing text output when the flag is absent.
- Preserve exit status `0` for successful validation and `1` for validation
  failures in both output modes.
- Add regression coverage for CLI help, successful JSON output, failed JSON
  output, and legacy text-output compatibility.
- Update the CLI reference and developer command examples.

Migration: this is an additive optional flag. Existing `coral validate`
commands and their text output are unchanged, so no migration is required.

This PR does not add a TUI framework, change the validation result schema, or
modify the validation runner.

Authored with assistance from Codex. The submitting human reviewed the changed
files and confirmed the behavior before publication.

## Test plan

- `uv run pytest tests/test_validation.py -v` — 26 passed.
- `uv run pytest tests/ -v` — 715 passed, 1 skipped.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — 139 files already formatted.
- `uv run mypy --follow-imports=skip coral/cli/author.py` — passed.
- `git diff --check upstream/dev...HEAD` — passed.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [x] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [x] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`. (Not applicable; no new example.)
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
