### PR TITLE
chore: promote dev to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Key concepts:
 |-----------|---------|
 | `coral/types.py` | Core types: `Task`, `Score`, `ScoreBundle`, `Attempt` |
 | `coral/config.py` | OmegaConf-backed YAML configuration (`CoralConfig`, `GraderConfig`, `AgentConfig`, `GatewayConfig`, `WarmStartConfig`, `HeartbeatActionConfig`, ...) |
-| `coral/task/` | Frontend-independent task validation with structured reports and diagnostics |
+| `coral/task/` | Frontend-independent task validation with structured reports, progress events, and baseline grading |
 | `coral/agent/` | Agent lifecycle: `manager.py` (multi-agent supervisor), `runtime.py` (abstract), `state.py`, `heartbeat.py`, `exit_classifier.py`, `warmstart.py`, `process.py`, `registry.py` |
 | `coral/sandbox/` | Pluggable agent sandboxing (`agents.sandbox`): `protocol.py` (`SandboxProvider` + spec/context types), `registry.py` (name or `module:Class` entrypoint resolution), `srt.py` (built-in srt provider: OS-level FS/network enforcement + allow-all proxy) |
 | `coral/agent/builtin/` | Concrete runtimes: `claude_code`, `codex`, `cursor_agent`, `kiro`, `opencode` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Key concepts:
 |-----------|---------|
 | `coral/types.py` | Core types: `Task`, `Score`, `ScoreBundle`, `Attempt` |
 | `coral/config.py` | OmegaConf-backed YAML configuration (`CoralConfig`, `GraderConfig`, `AgentConfig`, `GatewayConfig`, `WarmStartConfig`, `HeartbeatActionConfig`, ...) |
+| `coral/task/` | Frontend-independent task validation with structured reports and diagnostics |
 | `coral/agent/` | Agent lifecycle: `manager.py` (multi-agent supervisor), `runtime.py` (abstract), `state.py`, `heartbeat.py`, `exit_classifier.py`, `warmstart.py`, `process.py`, `registry.py` |
 | `coral/sandbox/` | Pluggable agent sandboxing (`agents.sandbox`): `protocol.py` (`SandboxProvider` + spec/context types), `registry.py` (name or `module:Class` entrypoint resolution), `srt.py` (built-in srt provider: OS-level FS/network enforcement + allow-all proxy) |
 | `coral/agent/builtin/` | Concrete runtimes: `claude_code`, `codex`, `cursor_agent`, `kiro`, `opencode` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ uv sync --all-extras       # Everything
 # Authoring
 coral init my-task                                # Scaffold task.yaml + grader/ package + seed/
 coral validate my-task                            # Type-check task structure and dry-run grader against seed/
+coral validate my-task --json                     # Emit one structured validation result for tools/frontends
 
 # User-level agent bindings (~/.config/coral/agents.yaml)
 coral setup                                       # Scan PATH + numbered wizard (one runtime can yield N bindings)

--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ Skills: `coral-quickstart` (install → setup → `.coral_workspace/`), `setting
 |-------|------------------|
 | [Claude Code](https://github.com/anthropics/claude-code) — default | `claude_code` |
 | [Codex](https://github.com/openai/codex) | `codex` |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | `dsh` |
 | [Cursor Agent](https://cursor.com/docs/cli/overview) | `cursor` |
 | [Kiro](https://kiro.dev) | `kiro` |
 | [OpenCode](https://github.com/opencode-ai/opencode) | `opencode` |
+| [Pi](https://pi.dev) | `pi` |
 
 Each agent must be installed and authenticated separately. Per-runtime config — including the [LiteLLM gateway](https://coral.compounding-intelligence.ai/docs/guides/gateway) for custom models — is documented at [Agent Runtimes](https://coral.compounding-intelligence.ai/docs/guides/agent-runtimes).
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -90,9 +90,11 @@ codex plugin add coral@coral-marketplace
 |-------|------------------|
 | [Claude Code](https://github.com/anthropics/claude-code) —— 默认 | `claude_code` |
 | [Codex](https://github.com/openai/codex) | `codex` |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | `dsh` |
 | [Cursor Agent](https://cursor.com/docs/cli/overview) | `cursor` |
 | [Kiro](https://kiro.dev) | `kiro` |
 | [OpenCode](https://github.com/opencode-ai/opencode) | `opencode` |
+| [Pi](https://pi.dev) | `pi` |
 
 每个 Agent 需自行安装并完成认证。各运行时的详细配置（含[ LiteLLM Gateway](https://coral.compounding-intelligence.ai/docs/guides/gateway) 自定义模型代理）见 [Agent 运行时文档](https://coral.compounding-intelligence.ai/docs/guides/agent-runtimes)。
 
@@ -136,6 +138,9 @@ uv run ruff check .
 uv run ruff format .
 ```
 
+> [!IMPORTANT]
+> **Docker 要求：**部分内置 grader（例如 SWE-bench、terminal-bench）使用 [Harbor](https://github.com/corca-ai/harbor) 在 Docker 容器中执行评估。此时 CORAL 本身**不能**运行在 Docker 中，因为不支持 Docker-in-Docker（DinD）。请直接在宿主机上运行 CORAL。
+
 ### 参与贡献
 
 欢迎社区贡献 —— bug 报告、`examples/` 下的新任务、新的 agent runtime、文档改进，都很欢迎。先看这里：
@@ -159,6 +164,16 @@ uv run ruff format .
   year={2026}
 }
 ```
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=Human-Agent-Society%2FCORAL&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Human-Agent-Society/CORAL&type=date&theme=dark&legend=top-left&sealed_token=_Mr1XWVeoHdhN5RB0i4Fz-C0qC_ci1us7BViejAd73QFLQB7w_FW2o-3uWeM_nqAmLucjkLC8pNTEHRR1MVZ7LKGHYmhes0XBWUMTHuAWyJUJeYjB5XCNw" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Human-Agent-Society/CORAL&type=date&legend=top-left&sealed_token=_Mr1XWVeoHdhN5RB0i4Fz-C0qC_ci1us7BViejAd73QFLQB7w_FW2o-3uWeM_nqAmLucjkLC8pNTEHRR1MVZ7LKGHYmhes0XBWUMTHuAWyJUJeYjB5XCNw" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Human-Agent-Society/CORAL&type=date&legend=top-left&sealed_token=_Mr1XWVeoHdhN5RB0i4Fz-C0qC_ci1us7BViejAd73QFLQB7w_FW2o-3uWeM_nqAmLucjkLC8pNTEHRR1MVZ7LKGHYmhes0XBWUMTHuAWyJUJeYjB5XCNw" />
+ </picture>
+</a>
 
 ### 致谢
 

--- a/coral/agent/builtin/deepseek_harness.py
+++ b/coral/agent/builtin/deepseek_harness.py
@@ -1,0 +1,226 @@
+"""DeepSeek Harness (``dsh``) CLI subprocess lifecycle."""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+from coral.agent.exit_classifier import classify_by_uptime
+from coral.agent.process import open_agent_stderr_for_log_dir
+from coral.agent.runtime import (
+    AgentHandle,
+    apply_run_as_user,
+    apply_sandbox,
+    apply_sandbox_env,
+    write_coral_log_entry,
+)
+from coral.sandbox.protocol import AgentSandboxSpec
+from coral.workspace.repo import _clean_env
+
+logger = logging.getLogger(__name__)
+
+_DEEPSEEK_HARNESS_RUNTIME_OPTION_KEYS = {
+    "command",
+    "profile",
+    "patch",
+    "provider",
+    "permission_mode",
+    "tools_mode",
+}
+
+
+class DeepSeekHarnessRuntime:
+    """Spawn and manage the official DeepSeek Harness headless CLI."""
+
+    @property
+    def instruction_filename(self) -> str:
+        return "AGENTS.md"
+
+    @property
+    def shared_dir_name(self) -> str:
+        return ".dsh"
+
+    def extract_session_id(self, log_path: Path) -> str | None:
+        # The shipped headless profile creates a fresh persisted Agent, but its
+        # stdout contract exposes only the final assistant text (not a session
+        # id). Keep this explicit rather than guessing from user-facing output.
+        return None
+
+    def classify_exit(
+        self,
+        log_path: Path,
+        exit_code: int | None,
+        uptime_seconds: float | None,
+        min_clean_runtime_seconds: int = 60,
+    ) -> str:
+        return classify_by_uptime(exit_code, uptime_seconds, min_clean_runtime_seconds)
+
+    def start(
+        self,
+        worktree_path: Path,
+        coral_md_path: Path,
+        model: str = "deepseek-v4-flash",
+        runtime_options: dict[str, Any] | None = None,
+        max_turns: int = 0,
+        log_dir: Path | None = None,
+        verbose: bool = False,
+        resume_session_id: str | None = None,
+        prompt: str | None = None,
+        prompt_source: str | None = None,
+        task_name: str | None = None,
+        task_description: str | None = None,
+        gateway_url: str | None = None,
+        gateway_api_key: str | None = None,
+        run_as_user: dict[str, Any] | None = None,
+        sandbox: AgentSandboxSpec | None = None,
+    ) -> AgentHandle:
+        """Start ``dsh --profile headless`` in the given worktree.
+
+        DeepSeek Harness currently exposes no session-resume flag from its
+        headless profile. A CORAL restart therefore starts a new dsh session
+        and supplies the normal continuation prompt.
+        """
+        agent_id_file = worktree_path / ".coral_agent_id"
+        agent_id = agent_id_file.read_text().strip() if agent_id_file.exists() else "unknown"
+
+        if log_dir is None:
+            log_dir = worktree_path / ".dsh" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_idx = len(list(log_dir.glob(f"{agent_id}*.log")))
+        log_path = log_dir / f"{agent_id}.{log_idx}.log"
+
+        if prompt is None:
+            if resume_session_id:
+                prompt = "Session restarted. Inspect the workspace and continue the task where it left off."
+            else:
+                prompt = "Begin working on your task and iterating on the seed solution."
+
+        opts = runtime_options or {}
+        for key in opts:
+            if key not in _DEEPSEEK_HARNESS_RUNTIME_OPTION_KEYS:
+                logger.warning(f"Ignoring unsupported deepseek_harness runtime option: {key}")
+
+        command = str(opts.get("command") or "dsh")
+        profile = str(opts.get("profile") or "headless")
+        cmd = [command, "--profile", profile]
+        patches = opts.get("patch")
+        if isinstance(patches, (str, Path)):
+            patches = [patches]
+        if isinstance(patches, list):
+            for patch in patches:
+                cmd.extend(["--patch", str(patch)])
+
+        # The headless CLI has no --model flag. A final Cordis overlay keeps
+        # CORAL's agents.model contract authoritative over profile defaults and
+        # any user-supplied patches.
+        dsh_home = worktree_path / ".dsh"
+        dsh_home.mkdir(parents=True, exist_ok=True)
+        model_patch_path = dsh_home / "coral-model.patch.yml"
+        provider = str(opts.get("provider") or "deepseek-official")
+        model_patch_path.write_text(
+            "- id: agent-default-model\n"
+            "  config:\n"
+            f"    provider: {json.dumps(provider)}\n"
+            f"    model: {json.dumps(model)}\n"
+        )
+        cmd.extend(["--patch", str(model_patch_path)])
+        cmd.append(prompt)
+        cmd = apply_sandbox(cmd, sandbox)
+
+        logger.info(f"Starting DeepSeek Harness agent {agent_id} in {worktree_path}")
+        logger.info(f"Command: {' '.join(cmd)}")
+
+        agent_env = _clean_env()
+        worktree_venv = str(worktree_path / ".venv")
+        agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
+        agent_env["VIRTUAL_ENV"] = worktree_venv
+        agent_env["PATH"] = str(worktree_path / ".venv" / "bin") + ":" + agent_env.get("PATH", "")
+        agent_env["DSH_HOME"] = str(dsh_home)
+
+        permission_mode = opts.get("permission_mode")
+        if permission_mode:
+            agent_env["DSH_PERMISSION_MODE"] = str(permission_mode)
+        tools_mode = opts.get("tools_mode")
+        if tools_mode:
+            agent_env["DSH_TOOLS_MODE"] = str(tools_mode)
+        if gateway_url:
+            agent_env["DEEPSEEK_BASE_URL"] = gateway_url
+        if gateway_api_key:
+            agent_env["DEEPSEEK_API_KEY"] = gateway_api_key
+
+        apply_sandbox_env(agent_env, sandbox)
+        user_kwargs = apply_run_as_user(agent_env, run_as_user)
+
+        log_file = open(log_path, "w", buffering=1)
+        err_path: Path | None = None
+        err_file: Any = None
+        stderr_target: Any = subprocess.STDOUT
+        opened = open_agent_stderr_for_log_dir(log_dir, agent_id)
+        if opened is not None:
+            err_path, err_file = opened
+            stderr_target = err_file
+
+        write_coral_log_entry(
+            log_file,
+            prompt=prompt,
+            source=prompt_source or ("restart" if resume_session_id else "start"),
+            agent_id=agent_id,
+            session_id=None,
+            task_name=task_name,
+            task_description=task_description,
+        )
+
+        if verbose:
+            process = subprocess.Popen(
+                cmd,
+                cwd=str(worktree_path),
+                stdout=subprocess.PIPE,
+                stderr=stderr_target,
+                start_new_session=True,
+                env=agent_env,
+                **user_kwargs,
+            )
+
+            def _tee_output(proc: subprocess.Popen, log_f: Any, agent: str) -> None:
+                try:
+                    if proc.stdout is None:
+                        return
+                    for line in iter(proc.stdout.readline, b""):
+                        decoded = line.decode("utf-8", errors="replace")
+                        sys.stdout.write(f"[{agent}] {decoded}")
+                        sys.stdout.flush()
+                        log_f.write(decoded)
+                        log_f.flush()
+                finally:
+                    log_f.close()
+
+            threading.Thread(
+                target=_tee_output, args=(process, log_file, agent_id), daemon=True
+            ).start()
+            log_file_ref = None
+        else:
+            process = subprocess.Popen(
+                cmd,
+                cwd=str(worktree_path),
+                stdout=log_file,
+                stderr=stderr_target,
+                start_new_session=True,
+                env=agent_env,
+                **user_kwargs,
+            )
+            log_file_ref = log_file
+
+        return AgentHandle(
+            agent_id=agent_id,
+            process=process,
+            worktree_path=worktree_path,
+            log_path=log_path,
+            _log_file=log_file_ref,
+            err_file=err_file,
+            err_path=err_path,
+        )

--- a/coral/agent/registry.py
+++ b/coral/agent/registry.py
@@ -8,6 +8,7 @@ import shutil
 from coral.agent.builtin.claude_code import ClaudeCodeRuntime
 from coral.agent.builtin.codex import CodexRuntime
 from coral.agent.builtin.cursor_agent import CursorAgentRuntime
+from coral.agent.builtin.deepseek_harness import DeepSeekHarnessRuntime
 from coral.agent.builtin.kiro import KiroRuntime
 from coral.agent.builtin.opencode import OpenCodeRuntime
 from coral.agent.builtin.pi_agent import PiAgentRuntime
@@ -17,6 +18,7 @@ _RUNTIMES: dict[str, type] = {
     "claude_code": ClaudeCodeRuntime,
     "codex": CodexRuntime,
     "cursor_agent": CursorAgentRuntime,
+    "dsh": DeepSeekHarnessRuntime,
     "kiro": KiroRuntime,
     "opencode": OpenCodeRuntime,
     "pi": PiAgentRuntime,
@@ -32,6 +34,9 @@ _ALIASES: dict[str, str] = {
     "kiro-cli": "kiro",
     "cursor": "cursor_agent",
     "cursor-agent": "cursor_agent",
+    "deepseek": "dsh",
+    "deepseek-harness": "dsh",
+    "deepseek_harness": "dsh",
     "pi-agent": "pi",
 }
 
@@ -40,6 +45,7 @@ _DEFAULT_MODELS: dict[str, str] = {
     "claude_code": "sonnet",
     "codex": "gpt-5.4",
     "cursor_agent": "auto",
+    "dsh": "deepseek-v4-flash",
     "kiro": "auto",
     "opencode": "openai/gpt-5",
     "pi": "zai/glm-5.1",
@@ -52,6 +58,7 @@ _RUNTIME_COMMANDS: dict[str, str] = {
     "claude_code": "claude",
     "codex": "codex",
     "cursor_agent": "cursor-agent",
+    "dsh": "dsh",
     "kiro": "kiro-cli",
     "opencode": "opencode",
     "pi": "pi",

--- a/coral/cli/__init__.py
+++ b/coral/cli/__init__.py
@@ -167,10 +167,15 @@ Run 'coral <command> --help' for details on any command."""
         "validate",
         help="Test your grader against seed code",
         description="Validate task structure and dry-run the grader against seed code.",
-        epilog="Examples:\n  coral validate my-task",
+        epilog="Examples:\n  coral validate my-task\n  coral validate my-task --json",
         formatter_class=_CommandHelpFormatter,
     )
     p_validate.add_argument("path", help="Path to the task directory")
+    p_validate.add_argument(
+        "--json",
+        action="store_true",
+        help="Output one machine-readable validation result",
+    )
     # Hidden alias: test-eval -> validate
     sub.add_parser("test-eval", help=argparse.SUPPRESS)
 

--- a/coral/cli/author.py
+++ b/coral/cli/author.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -188,7 +189,15 @@ def cmd_validate(args: argparse.Namespace) -> None:
     from coral.task.validation import run_validation
 
     task_dir = Path(args.path).resolve()
-    result = run_validation(task_dir, on_event=_render_validation_progress)
+    json_output = getattr(args, "json", False)
+    on_event = None if json_output else _render_validation_progress
+    result = run_validation(task_dir, on_event=on_event)
+
+    if json_output:
+        print(json.dumps(result.to_dict()))
+        if not result.successful:
+            sys.exit(1)
+        return
 
     if result.failure is not None:
         if result.failure.stage == "structure" and result.report.error_messages:

--- a/coral/cli/author.py
+++ b/coral/cli/author.py
@@ -6,6 +6,10 @@ import argparse
 import re
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from coral.task.validation import ValidationProgressEvent
 
 
 def _module_identifier(name: str) -> str:
@@ -163,101 +167,47 @@ def cmd_init(args: argparse.Namespace) -> None:
     print("  coral start -c task.yaml  # launch agents")
 
 
+def _render_validation_progress(event: ValidationProgressEvent) -> None:
+    """Render shared validation progress with the legacy CLI wording."""
+    if event.stage == "structure" and event.status == "completed":
+        print("Validation: OK")
+    elif event.stage == "workspace" and event.status == "completed":
+        print(event.message)
+    elif event.stage == "grader_environment" and event.status == "started":
+        print(event.message)
+    elif event.stage == "baseline" and event.status == "started":
+        print(f"\n{event.message}")
+
+
 def cmd_validate(args: argparse.Namespace) -> None:
     """Test your grader against seed code.
 
     Examples:
       coral validate my-task        Dry-run the grader in my-task/
     """
-    import shutil
-    import tempfile
-
-    from coral.cli.validation import validate_task
-    from coral.config import CoralConfig
+    from coral.task.validation import run_validation
 
     task_dir = Path(args.path).resolve()
+    result = run_validation(task_dir, on_event=_render_validation_progress)
 
-    errors = validate_task(task_dir)
-    if errors:
-        print("Validation errors:", file=sys.stderr)
-        for err in errors:
-            print(f"  - {err}", file=sys.stderr)
-        sys.exit(1)
-    print("Validation: OK")
-
-    config = CoralConfig.from_yaml(task_dir / "task.yaml")
-
-    with tempfile.TemporaryDirectory(prefix="coral_test_eval_") as tmpdir:
-        tmpdir = Path(tmpdir)
-        workspace = tmpdir / "workspace"
-        workspace.mkdir()
-
-        seed_dir = task_dir / "seed"
-        if seed_dir.is_dir() and any(seed_dir.iterdir()):
-            for item in seed_dir.iterdir():
-                if item.name == "__pycache__":
-                    continue
-                dst = workspace / item.name
-                if item.is_dir():
-                    shutil.copytree(item, dst)
-                else:
-                    shutil.copy2(item, dst)
-            print(f"Seed: copied {seed_dir.name}/ into workspace")
+    if result.failure is not None:
+        if result.failure.stage == "structure" and result.report.error_messages:
+            print("Validation errors:", file=sys.stderr)
+            for error in result.report.error_messages:
+                print(f"  - {error}", file=sys.stderr)
+        elif result.failure.stage == "baseline":
+            print(f"\n{result.failure.message}", file=sys.stderr)
         else:
-            print("Warning: No seed/ directory — grader will run against an empty workspace.")
-            print("  This is fine if your task expects agents to build from scratch.")
+            print(result.failure.message, file=sys.stderr)
+        sys.exit(1)
 
-        coral_dir = tmpdir / ".coral"
-        private_dir = coral_dir / "private"
-        private_dir.mkdir(parents=True)
+    if result.baseline is None:
+        print("Validation failed: no baseline result", file=sys.stderr)
+        sys.exit(1)
 
-        for private_path_str in config.grader.private:
-            src = Path(private_path_str)
-            if not src.is_absolute():
-                src = (task_dir / src).resolve()
-            if src.exists():
-                dst = private_dir / src.name
-                if src.is_dir():
-                    shutil.copytree(src, dst)
-                else:
-                    shutil.copy2(src, dst)
-
-        # Bootstrap the grader's isolated venv where the entrypoint runs.
-        from coral.workspace.grader_env import setup_grader_env
-
-        print("Setting up grader venv (.coral/private/grader_venv)...")
-        setup_grader_env(coral_dir, config.grader, task_dir)
-
-        from coral.grader.loader import load_grader
-        from coral.types import Task
-
-        try:
-            grader = load_grader(config, coral_dir)
-        except Exception as e:
-            print(f"Error loading grader: {e}", file=sys.stderr)
-            sys.exit(1)
-
-        task = Task(
-            id=config.task.name,
-            name=config.task.name,
-            description=config.task.description,
-        )
-
-        print(
-            f"\nRunning grader against {'seed code' if seed_dir.is_dir() else 'empty workspace'}..."
-        )
-        import asyncio
-
-        try:
-            result = asyncio.run(grader.grade(str(workspace), [task]))
-            score = result.aggregated
-            print(f"\n{'=' * 50}")
-            print(f"Score: {score}")
-            if result.scores:
-                for name, s in result.scores.items():
-                    if s.explanation:
-                        print(f"  {name}: {s.explanation}")
-            print(f"{'=' * 50}")
-        except Exception as e:
-            print(f"\nGrader crashed: {e}", file=sys.stderr)
-            sys.exit(1)
+    print(f"\n{'=' * 50}")
+    print(f"Score: {result.baseline.aggregated}")
+    for name, score in result.baseline.scores.items():
+        if score.explanation:
+            print(f"  {name}: {score.explanation}")
+    print(f"{'=' * 50}")

--- a/coral/cli/validation.py
+++ b/coral/cli/validation.py
@@ -7,67 +7,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from coral.config import CoralConfig
+from coral.task.validation import validate_task as validate_task_report
 
 
 def validate_task(task_dir: Path) -> list[str]:
     """Validate a task directory. Returns a list of error strings (empty = valid)."""
-    errors: list[str] = []
-
-    # 1. task.yaml exists and parses
-    task_yaml = task_dir / "task.yaml"
-    if not task_yaml.exists():
-        errors.append(f"task.yaml not found in {task_dir}")
-        return errors  # Can't continue without config
-
-    try:
-        config = CoralConfig.from_yaml(task_yaml)
-    except Exception as e:
-        errors.append(f"task.yaml parse error: {e}")
-        return errors
-
-    # 2. grader.entrypoint is set and well-formed.
-    if not config.grader.entrypoint:
-        errors.append(
-            "No grader configured. Set grader.entrypoint = "
-            "'your_pkg.module:Grader' in task.yaml and grader.setup to "
-            "install the package."
-        )
-    elif ":" not in config.grader.entrypoint:
-        errors.append(
-            f"grader.entrypoint must be 'module.path:ClassName', got {config.grader.entrypoint!r}"
-        )
-
-    # 3. direction is valid
-    if config.grader.direction not in ("maximize", "minimize"):
-        errors.append(
-            f"grader.direction must be 'maximize' or 'minimize', got '{config.grader.direction}'"
-        )
-
-    # 4. Extra private files exist, and are NOT inside the grader package.
-    # The grader package (task_dir/grader) is surfaced read-only to agents at
-    # <shared_dir>/grader/, so a grader.private path living inside it would be
-    # both copied to .coral/private/ AND exposed via the surfaced source — a
-    # leak. Hidden inputs must sit outside the grader dir (e.g. a sibling
-    # ``taskdata/`` declared as ``taskdata``).
-    grader_dir = (task_dir / "grader").resolve()
-    for private_path in config.grader.private:
-        p = Path(private_path)
-        if not p.is_absolute():
-            p = task_dir / p
-        if not p.exists():
-            errors.append(f"Private file not found: {private_path}")
-            continue
-        try:
-            p.resolve().relative_to(grader_dir)
-        except ValueError:
-            pass  # outside the grader package — good
-        else:
-            errors.append(
-                f"grader.private path '{private_path}' is inside the grader package "
-                f"(grader/), which is surfaced read-only to agents at "
-                f"<shared_dir>/grader/ — this would leak it. Move it outside grader/ "
-                f"(e.g. a sibling 'taskdata/')."
-            )
-
-    return errors
+    return validate_task_report(task_dir).error_messages

--- a/coral/task/__init__.py
+++ b/coral/task/__init__.py
@@ -1,5 +1,23 @@
 """Task inspection and validation APIs."""
 
-from coral.task.validation import ValidationDiagnostic, ValidationReport, validate_task
+from coral.task.validation import (
+    ValidationDiagnostic,
+    ValidationFailure,
+    ValidationProgressEvent,
+    ValidationReport,
+    ValidationRunResult,
+    run_validation,
+    run_validation_async,
+    validate_task,
+)
 
-__all__ = ["ValidationDiagnostic", "ValidationReport", "validate_task"]
+__all__ = [
+    "ValidationDiagnostic",
+    "ValidationFailure",
+    "ValidationProgressEvent",
+    "ValidationReport",
+    "ValidationRunResult",
+    "run_validation",
+    "run_validation_async",
+    "validate_task",
+]

--- a/coral/task/__init__.py
+++ b/coral/task/__init__.py
@@ -1,0 +1,5 @@
+"""Task inspection and validation APIs."""
+
+from coral.task.validation import ValidationDiagnostic, ValidationReport, validate_task
+
+__all__ = ["ValidationDiagnostic", "ValidationReport", "validate_task"]

--- a/coral/task/validation.py
+++ b/coral/task/validation.py
@@ -1,0 +1,156 @@
+"""Structured validation for CORAL task directories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from coral.config import CoralConfig
+
+
+@dataclass(frozen=True)
+class ValidationDiagnostic:
+    """A machine-readable problem found in a task directory."""
+
+    code: str
+    message: str
+    path: str | None = None
+    severity: Literal["error", "warning"] = "error"
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+            "severity": self.severity,
+        }
+        if self.path is not None:
+            data["path"] = self.path
+        return data
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Structured result of validating one task directory."""
+
+    task_dir: Path
+    diagnostics: tuple[ValidationDiagnostic, ...]
+
+    @property
+    def valid(self) -> bool:
+        return all(diagnostic.severity != "error" for diagnostic in self.diagnostics)
+
+    @property
+    def error_messages(self) -> list[str]:
+        """Return the legacy error representation used by the CLI."""
+        return [
+            diagnostic.message for diagnostic in self.diagnostics if diagnostic.severity == "error"
+        ]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_dir": str(self.task_dir),
+            "valid": self.valid,
+            "diagnostics": [diagnostic.to_dict() for diagnostic in self.diagnostics],
+        }
+
+
+def validate_task(task_dir: Path) -> ValidationReport:
+    """Validate a task directory and return structured diagnostics."""
+    diagnostics: list[ValidationDiagnostic] = []
+
+    task_yaml = task_dir / "task.yaml"
+    if not task_yaml.exists():
+        diagnostics.append(
+            ValidationDiagnostic(
+                code="task.config.missing",
+                message=f"task.yaml not found in {task_dir}",
+                path="task.yaml",
+            )
+        )
+        return ValidationReport(task_dir, tuple(diagnostics))
+
+    try:
+        config = CoralConfig.from_yaml(task_yaml)
+    except Exception as exc:
+        diagnostics.append(
+            ValidationDiagnostic(
+                code="task.config.invalid",
+                message=f"task.yaml parse error: {exc}",
+                path="task.yaml",
+            )
+        )
+        return ValidationReport(task_dir, tuple(diagnostics))
+
+    if not config.grader.entrypoint:
+        diagnostics.append(
+            ValidationDiagnostic(
+                code="grader.entrypoint.missing",
+                message=(
+                    "No grader configured. Set grader.entrypoint = "
+                    "'your_pkg.module:Grader' in task.yaml and grader.setup to "
+                    "install the package."
+                ),
+                path="task.yaml",
+            )
+        )
+    elif ":" not in config.grader.entrypoint:
+        diagnostics.append(
+            ValidationDiagnostic(
+                code="grader.entrypoint.invalid",
+                message=(
+                    "grader.entrypoint must be 'module.path:ClassName', "
+                    f"got {config.grader.entrypoint!r}"
+                ),
+                path="task.yaml",
+            )
+        )
+
+    if config.grader.direction not in ("maximize", "minimize"):
+        diagnostics.append(
+            ValidationDiagnostic(
+                code="grader.direction.invalid",
+                message=(
+                    "grader.direction must be 'maximize' or 'minimize', "
+                    f"got '{config.grader.direction}'"
+                ),
+                path="task.yaml",
+            )
+        )
+
+    # The grader package is surfaced read-only to agents at <shared_dir>/grader/.
+    # Private paths inside it would therefore be copied into .coral/private/ and
+    # exposed through the surfaced source at the same time.
+    grader_dir = (task_dir / "grader").resolve()
+    for private_path in config.grader.private:
+        path = Path(private_path)
+        if not path.is_absolute():
+            path = task_dir / path
+        if not path.exists():
+            diagnostics.append(
+                ValidationDiagnostic(
+                    code="grader.private.missing",
+                    message=f"Private file not found: {private_path}",
+                    path=str(private_path),
+                )
+            )
+            continue
+        try:
+            path.resolve().relative_to(grader_dir)
+        except ValueError:
+            pass
+        else:
+            diagnostics.append(
+                ValidationDiagnostic(
+                    code="grader.private.exposed",
+                    message=(
+                        f"grader.private path '{private_path}' is inside the grader package "
+                        "(grader/), which is surfaced read-only to agents at "
+                        "<shared_dir>/grader/ — this would leak it. Move it outside grader/ "
+                        "(e.g. a sibling 'taskdata/')."
+                    ),
+                    path=str(private_path),
+                )
+            )
+
+    return ValidationReport(task_dir, tuple(diagnostics))

--- a/coral/task/validation.py
+++ b/coral/task/validation.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+import shutil
+import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
 from coral.config import CoralConfig
+from coral.types import ScoreBundle, Task
 
 
 @dataclass(frozen=True)
@@ -52,6 +57,71 @@ class ValidationReport:
             "task_dir": str(self.task_dir),
             "valid": self.valid,
             "diagnostics": [diagnostic.to_dict() for diagnostic in self.diagnostics],
+        }
+
+
+ValidationStage = Literal[
+    "structure",
+    "workspace",
+    "grader_environment",
+    "grader_load",
+    "baseline",
+]
+ValidationProgressStatus = Literal["started", "completed", "failed"]
+
+
+@dataclass(frozen=True)
+class ValidationProgressEvent:
+    """One frontend-neutral progress update from a validation run."""
+
+    stage: ValidationStage
+    status: ValidationProgressStatus
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "stage": self.stage,
+            "status": self.status,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationFailure:
+    """A structured failure that stopped a validation run."""
+
+    stage: ValidationStage
+    code: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "stage": self.stage,
+            "code": self.code,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationRunResult:
+    """Structural diagnostics, progress, and baseline output from one run."""
+
+    report: ValidationReport
+    events: tuple[ValidationProgressEvent, ...]
+    baseline: ScoreBundle | None = None
+    failure: ValidationFailure | None = None
+
+    @property
+    def successful(self) -> bool:
+        return self.report.valid and self.failure is None and self.baseline is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "successful": self.successful,
+            "report": self.report.to_dict(),
+            "events": [event.to_dict() for event in self.events],
+            "baseline": self.baseline.to_dict() if self.baseline is not None else None,
+            "failure": self.failure.to_dict() if self.failure is not None else None,
         }
 
 
@@ -154,3 +224,166 @@ def validate_task(task_dir: Path) -> ValidationReport:
             )
 
     return ValidationReport(task_dir, tuple(diagnostics))
+
+
+async def run_validation_async(
+    task_dir: Path,
+    *,
+    on_event: Callable[[ValidationProgressEvent], None] | None = None,
+) -> ValidationRunResult:
+    """Run structural checks and asynchronously grade a task baseline."""
+    events: list[ValidationProgressEvent] = []
+
+    def emit(stage: ValidationStage, status: ValidationProgressStatus, message: str) -> None:
+        event = ValidationProgressEvent(stage=stage, status=status, message=message)
+        events.append(event)
+        if on_event is not None:
+            on_event(event)
+
+    emit("structure", "started", "Checking task structure")
+    try:
+        report = validate_task(task_dir)
+    except Exception as exc:
+        message = f"Failed to validate task structure: {exc}"
+        report = ValidationReport(
+            task_dir=task_dir,
+            diagnostics=(
+                ValidationDiagnostic(
+                    code="task.structure.failed",
+                    message=message,
+                ),
+            ),
+        )
+        failure = ValidationFailure(
+            stage="structure",
+            code="task.structure.failed",
+            message=message,
+        )
+        emit(failure.stage, "failed", failure.message)
+        return ValidationRunResult(report=report, events=tuple(events), failure=failure)
+
+    def stop(stage: ValidationStage, code: str, message: str) -> ValidationRunResult:
+        failure = ValidationFailure(stage=stage, code=code, message=message)
+        emit(stage, "failed", message)
+        return ValidationRunResult(report=report, events=tuple(events), failure=failure)
+
+    if not report.valid:
+        return stop(
+            "structure",
+            "task.structure.invalid",
+            "Task structure validation failed",
+        )
+    try:
+        config = CoralConfig.from_yaml(task_dir / "task.yaml")
+    except Exception as exc:
+        return stop(
+            "structure",
+            "task.config.load_failed",
+            f"Failed to load task configuration: {exc}",
+        )
+    emit("structure", "completed", "Task structure is valid")
+
+    emit("workspace", "started", "Preparing validation workspace")
+    try:
+        tempdir = tempfile.TemporaryDirectory(prefix="coral_test_eval_")
+    except Exception as exc:
+        return stop(
+            "workspace",
+            "task.workspace.failed",
+            f"Failed to prepare validation workspace: {exc}",
+        )
+
+    with tempdir as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+        workspace = tmpdir / "workspace"
+        try:
+            workspace.mkdir()
+            seed_dir = task_dir / "seed"
+            has_seed = seed_dir.is_dir() and any(seed_dir.iterdir())
+            if has_seed:
+                for item in seed_dir.iterdir():
+                    if item.name == "__pycache__":
+                        continue
+                    dst = workspace / item.name
+                    if item.is_dir():
+                        shutil.copytree(item, dst)
+                    else:
+                        shutil.copy2(item, dst)
+                workspace_message = f"Seed: copied {seed_dir.name}/ into workspace"
+            else:
+                workspace_message = (
+                    "Warning: No seed/ directory — grader will run against an empty workspace.\n"
+                    "  This is fine if your task expects agents to build from scratch."
+                )
+
+            coral_dir = tmpdir / ".coral"
+            private_dir = coral_dir / "private"
+            private_dir.mkdir(parents=True)
+
+            for private_path_str in config.grader.private:
+                src = Path(private_path_str)
+                if not src.is_absolute():
+                    src = (task_dir / src).resolve()
+                if src.exists():
+                    dst = private_dir / src.name
+                    if src.is_dir():
+                        shutil.copytree(src, dst)
+                    else:
+                        shutil.copy2(src, dst)
+        except Exception as exc:
+            return stop(
+                "workspace",
+                "task.workspace.failed",
+                f"Failed to prepare validation workspace: {exc}",
+            )
+        emit("workspace", "completed", workspace_message)
+
+        from coral.workspace.grader_env import setup_grader_env
+
+        emit(
+            "grader_environment",
+            "started",
+            "Setting up grader venv (.coral/private/grader_venv)...",
+        )
+        try:
+            setup_grader_env(coral_dir, config.grader, task_dir)
+        except Exception as exc:
+            return stop(
+                "grader_environment",
+                "grader.environment.failed",
+                f"Failed to set up grader environment: {exc}",
+            )
+        emit("grader_environment", "completed", "Grader environment is ready")
+
+        from coral.grader.loader import load_grader
+
+        emit("grader_load", "started", "Loading grader entrypoint")
+        try:
+            grader = load_grader(config, coral_dir)
+        except Exception as exc:
+            return stop("grader_load", "grader.load.failed", f"Error loading grader: {exc}")
+        emit("grader_load", "completed", "Grader entrypoint loaded")
+
+        task = Task(
+            id=config.task.name,
+            name=config.task.name,
+            description=config.task.description,
+        )
+        target = "seed code" if seed_dir.is_dir() else "empty workspace"
+        emit("baseline", "started", f"Running grader against {target}...")
+        try:
+            baseline = await grader.grade(str(workspace), [task])
+        except Exception as exc:
+            return stop("baseline", "grader.baseline.failed", f"Grader crashed: {exc}")
+        emit("baseline", "completed", "Baseline grading completed")
+
+    return ValidationRunResult(report=report, events=tuple(events), baseline=baseline)
+
+
+def run_validation(
+    task_dir: Path,
+    *,
+    on_event: Callable[[ValidationProgressEvent], None] | None = None,
+) -> ValidationRunResult:
+    """Run validation synchronously for CLI and other non-async callers."""
+    return asyncio.run(run_validation_async(task_dir, on_event=on_event))

--- a/docs/content/docs/api/config.mdx
+++ b/docs/content/docs/api/config.mdx
@@ -69,7 +69,7 @@ class GraderConfig:
 @dataclass
 class AgentConfig:
     count: int             # Number of agents (default: 1)
-    runtime: str           # "claude_code", "codex", "opencode"
+    runtime: str           # "claude_code", "codex", "dsh", "opencode", ...
     model: str             # Model name or ID (default: "sonnet")
     max_turns: int         # Max conversation turns (default: 200)
     timeout: int           # Session timeout in seconds (default: 3600)

--- a/docs/content/docs/cli/reference.mdx
+++ b/docs/content/docs/cli/reference.mdx
@@ -31,15 +31,17 @@ Produces a self-contained layout: `task.yaml` wired to a packaged grader (`grade
 Validate task structure and dry-run the grader against seed code.
 
 ```bash
-coral validate <path>
+coral validate <path> [--json]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `path` | Path to the task directory |
+| `--json` | Emit one JSON result containing diagnostics, progress events, the baseline score, and any failure; exits with status 1 when validation fails |
 
 ```bash
 coral validate my-task
+coral validate my-task --json
 ```
 
 ---

--- a/docs/content/docs/cli/reference.mdx
+++ b/docs/content/docs/cli/reference.mdx
@@ -54,7 +54,7 @@ model. No credentials are ever stored.
 
 ### `coral setup`
 
-Scan `PATH` for installed agent runtime CLIs (`claude`, `codex`,
+Scan `PATH` for installed agent runtime CLIs (`claude`, `codex`, `dsh`,
 `cursor-agent`, `opencode`, `kiro-cli`, `pi`) and, in an interactive terminal,
 launch a numbered-selection wizard to create bindings. Pick one or more
 runtimes (`1`, `1,3`, `1-3`, or `all`) and the wizard prompts for binding
@@ -89,7 +89,7 @@ coral setup agent [--name NAME] [--runtime RUNTIME] [--command PATH]
 | Flag | Description |
 |------|-------------|
 | `--name` | Binding name (e.g. `claude-opus`) |
-| `--runtime` | Runtime: `claude_code`, `codex`, `opencode`, `cursor_agent`, `kiro`, `pi`, or a `module.path:ClassName` entrypoint |
+| `--runtime` | Runtime: `claude_code`, `codex`, `dsh`, `opencode`, `cursor_agent`, `kiro`, `pi`, or a `module.path:ClassName` entrypoint |
 | `--command` | CLI binary (defaults to the runtime's command) |
 | `--model` | Default model for this binding |
 | `--role-file` | Path to a role seed `.md` file |
@@ -100,6 +100,7 @@ coral setup agent [--name NAME] [--runtime RUNTIME] [--command PATH]
 ```bash
 coral setup agent --name claude-opus --runtime claude_code --model opus
 coral setup agent --name codex-high --runtime codex --option model_reasoning_effort=high
+coral setup agent --name deepseek --runtime dsh --model deepseek-v4-flash
 ```
 
 ### `coral agents`

--- a/docs/content/docs/concepts/agents.mdx
+++ b/docs/content/docs/concepts/agents.mdx
@@ -12,6 +12,7 @@ Agents are the optimizers in CORAL. Each agent is an autonomous coding subproces
 |---------|-------------|-------------|
 | Claude Code | `claude_code` | Anthropic's CLI agent (default) |
 | Codex | `codex` | OpenAI's coding agent |
+| DeepSeek Harness | `dsh` | DeepSeek's official agent harness |
 | OpenCode | `opencode` | Open-source alternative |
 
 Set the runtime in your `task.yaml`:
@@ -93,4 +94,3 @@ Each agent gets:
 - Access to all other agents' attempts (scores and diffs)
 - Shared notes for communicating insights
 - Shared skills for reusable tools
-

--- a/docs/content/docs/getting-started/configuration.mdx
+++ b/docs/content/docs/getting-started/configuration.mdx
@@ -147,7 +147,7 @@ packaged-grader layout.
 |-------|------|---------|-------------|
 | `count` | int | `1` | Number of agents to spawn |
 | `binding` | string | – | Name of a user-level [agent binding](/docs/guides/agent-bindings) to expand into `runtime`/`model`/`runtime_options`. Explicit fields here override the binding. |
-| `runtime` | string | `"claude_code"` | Agent runtime: `claude_code`, `codex`, `opencode` |
+| `runtime` | string | `"claude_code"` | Agent runtime: `claude_code`, `codex`, `dsh`, `opencode`, `cursor_agent`, `kiro`, or `pi` |
 | `model` | string | `"sonnet"` | Model to use (e.g. `opus`, `sonnet`, `haiku`, or full model ID) |
 | `max_turns` | int | `200` | Maximum conversation turns per agent |
 | `timeout` | int | `3600` | Agent session timeout in seconds |

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -52,6 +52,7 @@ At least one supported agent runtime:
 
 - **Claude Code** (default) — requires an Anthropic API key
 - **Codex** — OpenAI's coding agent
+- **DeepSeek Harness** — the official `dsh` CLI; requires `DEEPSEEK_API_KEY`
 - **OpenCode** — open-source alternative
 
 For Harbor-based benchmarks (SWE-bench, terminal-bench):

--- a/docs/content/docs/guides/agent-bindings.mdx
+++ b/docs/content/docs/guides/agent-bindings.mdx
@@ -59,8 +59,8 @@ agents:
 ## Creating a binding
 
 The fastest path is `coral setup` with no subcommand — it scans `PATH` for
-every supported runtime CLI (`claude`, `codex`, `cursor-agent`, `opencode`,
-`kiro-cli`, `pi`) and offers an interactive numbered-selection wizard:
+every supported runtime CLI (`claude`, `codex`, `dsh`, `cursor-agent`,
+`opencode`, `kiro-cli`, `pi`) and offers an interactive numbered-selection wizard:
 
 ```bash
 coral setup

--- a/docs/content/docs/guides/agent-runtimes.mdx
+++ b/docs/content/docs/guides/agent-runtimes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Runtimes
-description: Configure OpenCode, Cursor Agent, and Kiro as CORAL agent runtimes.
+description: Configure DeepSeek Harness, OpenCode, Cursor Agent, and Kiro as CORAL agent runtimes.
 ---
 
 
@@ -10,9 +10,47 @@ CORAL works with any coding agent that can run as a subprocess. Pick the runtime
 |-----------------|--------------------------------|---------------------------|
 | Claude Code     | `claude_code` (default)        | Anthropic API key         |
 | Codex           | `codex`                        | OpenAI auth               |
+| DeepSeek Harness | `dsh`                         | `DEEPSEEK_API_KEY`        |
 | OpenCode        | `opencode`                     | `opencode.json` in seed   |
 | Cursor Agent    | `cursor` (alias: `cursor_agent`) | `cursor-agent login` once |
 | Kiro            | `kiro`                         | `kiro-cli` setup          |
+
+## DeepSeek Harness
+
+Install the official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) CLI and make sure `dsh` is on `PATH`:
+
+```bash
+npm install --global @deepseek-ai/dsh
+export DEEPSEEK_API_KEY=your-key
+```
+
+Select its canonical runtime name in the task config:
+
+```yaml
+agents:
+  runtime: dsh
+  model: deepseek-v4-flash
+```
+
+CORAL invokes `dsh --profile headless <prompt>`, points `DSH_HOME` at the agent's shared `.dsh/` directory, and writes the task instructions to `AGENTS.md` at the worktree root. It emits a final Cordis overlay so `agents.model` overrides the profile default. The aliases `deepseek`, `deepseek-harness`, and `deepseek_harness` are accepted for compatibility, but new configurations should use `dsh`.
+
+When the CORAL LiteLLM gateway is enabled, `gateway_url` and `gateway_api_key` are exposed to DSH as `DEEPSEEK_BASE_URL` and `DEEPSEEK_API_KEY`. Direct runs inherit the same environment variables from the shell.
+
+Optional `runtime_options`:
+
+```yaml
+agents:
+  runtime: dsh
+  runtime_options:
+    command: /usr/local/bin/dsh       # override binary path
+    profile: headless                 # override the DSH profile
+    provider: deepseek-official       # provider for agents.model
+    patch: [./dsh.cordis.yml]         # repeatable --patch overlays
+    permission_mode: workspace-write  # DSH_PERMISSION_MODE
+    tools_mode: native                # DSH_TOOLS_MODE
+```
+
+> **Note:** The current DSH headless profile creates a fresh persisted session but does not expose its session ID or a resume argument. After a CORAL-managed restart, DSH starts a new session with a continuation prompt and recovers context from the worktree and shared `.dsh/` state.
 
 ## OpenCode
 

--- a/docs/content/docs/guides/gateway.mdx
+++ b/docs/content/docs/guides/gateway.mdx
@@ -46,7 +46,7 @@ All generated routes use `MINIMAX_API_KEY`:
 
 ```yaml
 agents:
-  runtime: opencode           # or claude_code, codex (cursor and kiro use their own auth, not the gateway)
+  runtime: opencode           # or claude_code, codex, dsh (cursor and kiro use their own auth)
   model: claude/claude-opus-4-6
   gateway:
     enabled: true
@@ -54,7 +54,7 @@ agents:
     config: "./litellm_config.yaml"  # path relative to task.yaml
 ```
 
-**3. Point your agent at the gateway.** For OpenCode, set `baseURL` in `opencode.json` to `http://localhost:<port>/v1` (see [Agent Runtimes → OpenCode](/docs/guides/agent-runtimes#opencode)). For Claude Code, the gateway URL is automatically injected.
+**3. Point your agent at the gateway.** For OpenCode, set `baseURL` in `opencode.json` to `http://localhost:<port>/v1` (see [Agent Runtimes → OpenCode](/docs/guides/agent-runtimes#opencode)). For Claude Code and DeepSeek Harness, the gateway URL and per-agent key are injected automatically; DSH receives them as `DEEPSEEK_BASE_URL` and `DEEPSEEK_API_KEY`.
 
 When you run `coral start`, the gateway starts before agents are spawned, and all agent API requests are routed through it. The gateway automatically assigns each agent a unique proxy key for per-agent request tracking.
 

--- a/docs/content/docs/guides/index.mdx
+++ b/docs/content/docs/guides/index.mdx
@@ -9,7 +9,7 @@ Step-by-step guides for common tasks.
 1. [Writing a Custom Grader](/docs/guides/custom-grader) — Build your own evaluation logic
 2. [Rubric Judges](/docs/guides/rubric-judge) — Score open-ended output with an LLM judge agent
 3. [Multi-Agent Runs](/docs/guides/multi-agent) — Knowledge sharing and collaboration
-4. [Agent Runtimes](/docs/guides/agent-runtimes) — Configure OpenCode, Cursor Agent, and Kiro
+4. [Agent Runtimes](/docs/guides/agent-runtimes) — Configure DeepSeek Harness, OpenCode, Cursor Agent, and Kiro
 5. [LiteLLM Gateway](/docs/guides/gateway) — Route agent traffic through a unified proxy
 6. [Web Dashboard](/docs/guides/web-dashboard) — Real-time monitoring with `coral ui`
 7. [Benchmarks](/docs/guides/benchmarks) — Running CORAL on standard benchmarks

--- a/tests/test_deepseek_harness.py
+++ b/tests/test_deepseek_harness.py
@@ -1,0 +1,153 @@
+"""Unit tests for the DeepSeek Harness runtime."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from coral.agent.builtin.deepseek_harness import DeepSeekHarnessRuntime
+from coral.agent.registry import (
+    default_command_for_runtime,
+    default_model_for_runtime,
+    get_runtime,
+)
+
+
+class _FakePopen:
+    captured: list[dict[str, Any]] = []
+
+    def __init__(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        type(self).captured.append({"cmd": list(cmd), "kwargs": dict(kwargs)})
+        self.pid = 4242
+        self.returncode: int | None = None
+        self.stdout = None
+        self.stderr = None
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_popen() -> None:
+    _FakePopen.captured = []
+
+
+def _make_worktree(tmp_path: Path) -> Path:
+    worktree = tmp_path / "agent-1"
+    worktree.mkdir()
+    (worktree / ".coral_agent_id").write_text("agent-1")
+    return worktree
+
+
+@pytest.mark.parametrize("name", ["dsh", "deepseek", "deepseek-harness", "deepseek_harness"])
+def test_registry_resolves_runtime_and_aliases(name: str) -> None:
+    assert isinstance(get_runtime(name), DeepSeekHarnessRuntime)
+
+
+def test_registry_defaults() -> None:
+    assert default_model_for_runtime("dsh") == "deepseek-v4-flash"
+    assert default_command_for_runtime("deepseek") == "dsh"
+
+
+def test_runtime_conventions() -> None:
+    runtime = DeepSeekHarnessRuntime()
+    assert runtime.instruction_filename == "AGENTS.md"
+    assert runtime.shared_dir_name == ".dsh"
+    assert runtime.extract_session_id(Path("unused")) is None
+
+
+def test_start_builds_headless_command_and_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    worktree = _make_worktree(tmp_path)
+
+    handle = DeepSeekHarnessRuntime().start(
+        worktree_path=worktree,
+        coral_md_path=worktree / "AGENTS.md",
+        log_dir=tmp_path / "logs",
+        prompt="solve this",
+        gateway_url="https://gateway.example/v1",
+        gateway_api_key="secret",
+    )
+
+    assert handle.agent_id == "agent-1"
+    call = _FakePopen.captured[0]
+    model_patch = worktree / ".dsh" / "coral-model.patch.yml"
+    assert call["cmd"] == [
+        "dsh",
+        "--profile",
+        "headless",
+        "--patch",
+        str(model_patch),
+        "solve this",
+    ]
+    assert 'provider: "deepseek-official"' in model_patch.read_text()
+    assert 'model: "deepseek-v4-flash"' in model_patch.read_text()
+    assert call["kwargs"]["cwd"] == str(worktree)
+    env = call["kwargs"]["env"]
+    assert env["DSH_HOME"] == str(worktree / ".dsh")
+    assert env["DEEPSEEK_BASE_URL"] == "https://gateway.example/v1"
+    assert env["DEEPSEEK_API_KEY"] == "secret"
+
+
+def test_start_honors_runtime_options(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    worktree = _make_worktree(tmp_path)
+
+    DeepSeekHarnessRuntime().start(
+        worktree_path=worktree,
+        coral_md_path=worktree / "AGENTS.md",
+        log_dir=tmp_path / "logs",
+        prompt="task",
+        runtime_options={
+            "command": "/opt/dsh",
+            "profile": "coral",
+            "provider": "private-deepseek",
+            "patch": ["one.yml", "two.yml"],
+            "permission_mode": "workspace-write",
+            "tools_mode": "native",
+        },
+    )
+
+    call = _FakePopen.captured[0]
+    assert call["cmd"] == [
+        "/opt/dsh",
+        "--profile",
+        "coral",
+        "--patch",
+        "one.yml",
+        "--patch",
+        "two.yml",
+        "--patch",
+        str(worktree / ".dsh" / "coral-model.patch.yml"),
+        "task",
+    ]
+    assert (
+        'provider: "private-deepseek"' in (worktree / ".dsh" / "coral-model.patch.yml").read_text()
+    )
+    assert call["kwargs"]["env"]["DSH_PERMISSION_MODE"] == "workspace-write"
+    assert call["kwargs"]["env"]["DSH_TOOLS_MODE"] == "native"
+
+
+def test_restart_does_not_invent_unsupported_resume_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    worktree = _make_worktree(tmp_path)
+
+    DeepSeekHarnessRuntime().start(
+        worktree_path=worktree,
+        coral_md_path=worktree / "AGENTS.md",
+        log_dir=tmp_path / "logs",
+        resume_session_id="not-exposed-by-headless",
+        prompt="continue",
+    )
+
+    cmd = _FakePopen.captured[0]["cmd"]
+    assert cmd[:3] == ["dsh", "--profile", "headless"]
+    assert cmd[-1] == "continue"
+    assert "--resume" not in cmd

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,6 +6,8 @@ import tempfile
 from pathlib import Path
 
 from coral.cli.validation import validate_task
+from coral.task import validation as task_validation
+from coral.task.validation import ValidationDiagnostic, ValidationReport
 
 _TASK_YAML = """\
 task:
@@ -38,6 +40,44 @@ def test_validate_rejects_missing_entrypoint():
         assert any("No grader configured" in e for e in errors)
 
 
+def test_structured_validation_report_is_serializable():
+    with tempfile.TemporaryDirectory() as d:
+        task_dir = _make_task(Path(d), "  timeout: 60")
+
+        report = task_validation.validate_task(task_dir)
+
+        assert not report.valid
+        assert report.error_messages == validate_task(task_dir)
+        assert report.to_dict() == {
+            "task_dir": str(task_dir),
+            "valid": False,
+            "diagnostics": [
+                {
+                    "code": "grader.entrypoint.missing",
+                    "message": report.error_messages[0],
+                    "path": "task.yaml",
+                    "severity": "error",
+                }
+            ],
+        }
+
+
+def test_warning_diagnostic_does_not_fail_report():
+    report = ValidationReport(
+        task_dir=Path("task"),
+        diagnostics=(
+            ValidationDiagnostic(
+                code="task.example.warning",
+                message="Example warning",
+                severity="warning",
+            ),
+        ),
+    )
+
+    assert report.valid
+    assert report.error_messages == []
+
+
 def test_validate_rejects_malformed_entrypoint():
     with tempfile.TemporaryDirectory() as d:
         task_dir = _make_task(Path(d), "  entrypoint: my_pkg.grader.Grader")
@@ -53,6 +93,17 @@ def _make_task_with_dirs(base: Path, grader_body: str, dirs: list[str]) -> Path:
     for rel in dirs:
         (task_dir / rel).mkdir(parents=True, exist_ok=True)
     return task_dir
+
+
+def test_structured_validation_reports_private_path():
+    body = '  entrypoint: "p.g:G"\n  private:\n    - "missing-data"'
+    with tempfile.TemporaryDirectory() as d:
+        task_dir = _make_task_with_dirs(Path(d), body, [])
+
+        report = task_validation.validate_task(task_dir)
+
+        assert [diagnostic.code for diagnostic in report.diagnostics] == ["grader.private.missing"]
+        assert report.diagnostics[0].path == "missing-data"
 
 
 def test_validate_accepts_private_sibling_of_grader():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import argparse
+import asyncio
 import tempfile
 from pathlib import Path
 
+import pytest
+
+from coral.cli.author import cmd_validate
 from coral.cli.validation import validate_task
 from coral.task import validation as task_validation
 from coral.task.validation import ValidationDiagnostic, ValidationReport
+from coral.types import Score, ScoreBundle
 
 _TASK_YAML = """\
 task:
@@ -123,3 +129,438 @@ def test_validate_rejects_private_inside_grader_package():
         errors = validate_task(task_dir)
         assert any("inside the grader package" in e for e in errors)
         assert any("grader/taskdata" in e for e in errors)
+
+
+def test_run_validation_returns_baseline_and_progress_events(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+    seed_dir = task_dir / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "solution.txt").write_text("baseline", encoding="utf-8")
+
+    def fake_setup_grader_env(coral_dir, grader_config, config_dir):
+        assert (coral_dir / "private").is_dir()
+        assert grader_config.entrypoint == "p.g:G"
+        assert config_dir == task_dir
+
+    class FakeGrader:
+        async def grade(self, codebase_path, tasks):
+            assert (Path(codebase_path) / "solution.txt").read_text(encoding="utf-8") == "baseline"
+            assert [(task.id, task.name, task.description) for task in tasks] == [("t", "t", "d")]
+            return ScoreBundle(
+                scores={"eval": Score(value=1.25, name="eval", explanation="baseline ok")},
+                aggregated=1.25,
+            )
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        fake_setup_grader_env,
+    )
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: FakeGrader(),
+    )
+
+    observed_events = []
+    result = task_validation.run_validation(task_dir, on_event=observed_events.append)
+
+    assert result.successful
+    assert result.report.valid
+    assert result.baseline.to_dict() == {
+        "scores": {
+            "eval": {
+                "value": 1.25,
+                "name": "eval",
+                "explanation": "baseline ok",
+                "metadata": {},
+            }
+        },
+        "aggregated": 1.25,
+        "is_public": True,
+    }
+    assert result.failure is None
+    assert observed_events == list(result.events)
+    assert [(event.stage, event.status) for event in result.events] == [
+        ("structure", "started"),
+        ("structure", "completed"),
+        ("workspace", "started"),
+        ("workspace", "completed"),
+        ("grader_environment", "started"),
+        ("grader_environment", "completed"),
+        ("grader_load", "started"),
+        ("grader_load", "completed"),
+        ("baseline", "started"),
+        ("baseline", "completed"),
+    ]
+
+
+async def test_run_validation_async_runs_inside_existing_event_loop(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    class FakeGrader:
+        async def grade(self, codebase_path, tasks):
+            assert asyncio.get_running_loop().is_running()
+            return ScoreBundle(
+                scores={"eval": Score(value=2.0, name="eval", explanation="async baseline")},
+                aggregated=2.0,
+            )
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: None,
+    )
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: FakeGrader(),
+    )
+
+    observed_events = []
+    result = await task_validation.run_validation_async(
+        task_dir,
+        on_event=observed_events.append,
+    )
+
+    assert result.successful
+    assert result.baseline.aggregated == 2.0
+    assert observed_events == list(result.events)
+    assert (result.events[-1].stage, result.events[-1].status) == ("baseline", "completed")
+
+
+def test_run_validation_returns_structured_grader_environment_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    def fail_setup(coral_dir, grader_config, config_dir):
+        raise RuntimeError("install failed")
+
+    monkeypatch.setattr("coral.workspace.grader_env.setup_grader_env", fail_setup)
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: pytest.fail("grader loading must not run after setup fails"),
+    )
+
+    observed_events = []
+    result = task_validation.run_validation(task_dir, on_event=observed_events.append)
+
+    assert not result.successful
+    assert result.baseline is None
+    assert result.failure.stage == "grader_environment"
+    assert result.failure.code == "grader.environment.failed"
+    assert result.failure.message == "Failed to set up grader environment: install failed"
+    assert observed_events[-1] == result.events[-1]
+    assert (result.events[-1].stage, result.events[-1].status) == (
+        "grader_environment",
+        "failed",
+    )
+
+
+def test_run_validation_returns_structured_baseline_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    class FailingGrader:
+        async def grade(self, codebase_path, tasks):
+            raise ValueError("invalid baseline output")
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: None,
+    )
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: FailingGrader(),
+    )
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.baseline is None
+    assert result.failure.stage == "baseline"
+    assert result.failure.code == "grader.baseline.failed"
+    assert result.failure.message == "Grader crashed: invalid baseline output"
+    assert (result.events[-1].stage, result.events[-1].status) == ("baseline", "failed")
+
+
+def test_run_validation_returns_structured_grader_load_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    def fail_load(config, coral_dir):
+        raise ImportError("grader package missing")
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: None,
+    )
+    monkeypatch.setattr("coral.grader.loader.load_grader", fail_load)
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.failure.stage == "grader_load"
+    assert result.failure.code == "grader.load.failed"
+    assert result.failure.message == "Error loading grader: grader package missing"
+    assert (result.events[-1].stage, result.events[-1].status) == ("grader_load", "failed")
+
+
+def test_validation_run_result_is_serializable():
+    report = ValidationReport(task_dir=Path("task"), diagnostics=())
+    event = task_validation.ValidationProgressEvent(
+        stage="grader_load",
+        status="failed",
+        message="Error loading grader: missing",
+    )
+    failure = task_validation.ValidationFailure(
+        stage="grader_load",
+        code="grader.load.failed",
+        message="Error loading grader: missing",
+    )
+    result = task_validation.ValidationRunResult(
+        report=report,
+        events=(event,),
+        failure=failure,
+    )
+
+    assert result.to_dict() == {
+        "successful": False,
+        "report": {
+            "task_dir": "task",
+            "valid": True,
+            "diagnostics": [],
+        },
+        "events": [
+            {
+                "stage": "grader_load",
+                "status": "failed",
+                "message": "Error loading grader: missing",
+            }
+        ],
+        "baseline": None,
+        "failure": {
+            "stage": "grader_load",
+            "code": "grader.load.failed",
+            "message": "Error loading grader: missing",
+        },
+    }
+
+
+def test_run_validation_returns_structured_workspace_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+    seed_dir = task_dir / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "solution.txt").write_text("baseline", encoding="utf-8")
+
+    def fail_copy(source, destination):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(task_validation.shutil, "copy2", fail_copy)
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: pytest.fail(
+            "grader setup must not run after workspace preparation fails"
+        ),
+    )
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.failure.stage == "workspace"
+    assert result.failure.code == "task.workspace.failed"
+    assert result.failure.message == "Failed to prepare validation workspace: disk full"
+    assert (result.events[-1].stage, result.events[-1].status) == ("workspace", "failed")
+
+
+def test_run_validation_structures_temp_workspace_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+
+    def fail_tempdir(*args, **kwargs):
+        raise OSError("no temporary space")
+
+    monkeypatch.setattr(task_validation.tempfile, "TemporaryDirectory", fail_tempdir)
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.failure.stage == "workspace"
+    assert result.failure.code == "task.workspace.failed"
+    assert result.failure.message == ("Failed to prepare validation workspace: no temporary space")
+    assert [(event.stage, event.status) for event in result.events[-2:]] == [
+        ("workspace", "started"),
+        ("workspace", "failed"),
+    ]
+
+
+def test_task_package_exports_validation_runner_api():
+    import coral.task as task_api
+
+    assert task_api.run_validation is task_validation.run_validation
+    assert task_api.run_validation_async is task_validation.run_validation_async
+    assert task_api.ValidationProgressEvent is task_validation.ValidationProgressEvent
+    assert task_api.ValidationFailure is task_validation.ValidationFailure
+    assert task_api.ValidationRunResult is task_validation.ValidationRunResult
+
+
+def test_run_validation_stops_after_structural_failure(tmp_path, monkeypatch):
+    task_dir = _make_task(tmp_path, "  timeout: 60")
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: pytest.fail(
+            "grader setup must not run when structural validation fails"
+        ),
+    )
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert not result.report.valid
+    assert result.report.diagnostics[0].code == "grader.entrypoint.missing"
+    assert result.failure.stage == "structure"
+    assert result.failure.code == "task.structure.invalid"
+    assert [(event.stage, event.status) for event in result.events] == [
+        ("structure", "started"),
+        ("structure", "failed"),
+    ]
+
+
+def test_run_validation_structures_config_reload_failure(tmp_path, monkeypatch):
+    task_dir = tmp_path / "task"
+    report = ValidationReport(task_dir=task_dir, diagnostics=())
+
+    class FailingConfig:
+        @classmethod
+        def from_yaml(cls, path):
+            raise OSError("changed during validation")
+
+    monkeypatch.setattr(task_validation, "validate_task", lambda path: report)
+    monkeypatch.setattr(task_validation, "CoralConfig", FailingConfig)
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.failure.stage == "structure"
+    assert result.failure.code == "task.config.load_failed"
+    assert result.failure.message == (
+        "Failed to load task configuration: changed during validation"
+    )
+    assert [(event.stage, event.status) for event in result.events] == [
+        ("structure", "started"),
+        ("structure", "failed"),
+    ]
+
+
+def test_run_validation_structures_unexpected_static_check_failure(tmp_path, monkeypatch):
+    task_dir = tmp_path / "task"
+
+    def fail_validation(path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(task_validation, "validate_task", fail_validation)
+
+    result = task_validation.run_validation(task_dir)
+
+    assert not result.successful
+    assert result.report.diagnostics[0].code == "task.structure.failed"
+    assert result.report.diagnostics[0].message == (
+        "Failed to validate task structure: permission denied"
+    )
+    assert result.failure.stage == "structure"
+    assert result.failure.code == "task.structure.failed"
+    assert [(event.stage, event.status) for event in result.events] == [
+        ("structure", "started"),
+        ("structure", "failed"),
+    ]
+
+
+def test_cmd_validate_renders_shared_runner_result(tmp_path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    report = ValidationReport(task_dir=task_dir.resolve(), diagnostics=())
+    events = (
+        task_validation.ValidationProgressEvent(
+            stage="structure",
+            status="completed",
+            message="Task structure is valid",
+        ),
+        task_validation.ValidationProgressEvent(
+            stage="workspace",
+            status="completed",
+            message="Seed: copied seed/ into workspace",
+        ),
+        task_validation.ValidationProgressEvent(
+            stage="grader_environment",
+            status="started",
+            message="Setting up grader venv (.coral/private/grader_venv)...",
+        ),
+        task_validation.ValidationProgressEvent(
+            stage="baseline",
+            status="started",
+            message="Running grader against seed code...",
+        ),
+    )
+    baseline = ScoreBundle(
+        scores={"eval": Score(value=1.25, name="eval", explanation="baseline ok")},
+        aggregated=1.25,
+    )
+
+    def fake_run_validation(path, *, on_event=None):
+        assert path == task_dir.resolve()
+        for event in events:
+            on_event(event)
+        return task_validation.ValidationRunResult(
+            report=report,
+            events=events,
+            baseline=baseline,
+        )
+
+    monkeypatch.setattr(task_validation, "run_validation", fake_run_validation)
+
+    cmd_validate(argparse.Namespace(path=str(task_dir)))
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out.splitlines() == [
+        "Validation: OK",
+        "Seed: copied seed/ into workspace",
+        "Setting up grader venv (.coral/private/grader_venv)...",
+        "",
+        "Running grader against seed code...",
+        "",
+        "==================================================",
+        "Score: 1.25",
+        "  eval: baseline ok",
+        "==================================================",
+    ]
+
+
+def test_cmd_validate_prints_structure_failure_without_diagnostics(tmp_path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    failure = task_validation.ValidationFailure(
+        stage="structure",
+        code="task.config.load_failed",
+        message="Failed to load task configuration: changed during validation",
+    )
+    result = task_validation.ValidationRunResult(
+        report=ValidationReport(task_dir=task_dir.resolve(), diagnostics=()),
+        events=(),
+        failure=failure,
+    )
+    monkeypatch.setattr(
+        task_validation,
+        "run_validation",
+        lambda path, on_event=None: result,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_validate(argparse.Namespace(path=str(task_dir)))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "Failed to load task configuration: changed during validation\n"
+
+
+def test_cmd_validate_preserves_static_validation_error_output(tmp_path, capsys):
+    task_dir = _make_task(tmp_path, "  timeout: 60")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_validate(argparse.Namespace(path=str(task_dir)))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("Validation errors:\n  - No grader configured.")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -525,6 +528,88 @@ def test_cmd_validate_renders_shared_runner_result(tmp_path, monkeypatch, capsys
         "  eval: baseline ok",
         "==================================================",
     ]
+
+
+def test_validate_help_documents_json_output() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "coral.cli", "validate", "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--json" in result.stdout
+
+
+def test_cmd_validate_json_outputs_one_machine_readable_document(tmp_path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    result = task_validation.ValidationRunResult(
+        report=ValidationReport(task_dir=task_dir.resolve(), diagnostics=()),
+        events=(),
+        baseline=ScoreBundle(
+            scores={"eval": Score(value=1.25, name="eval", explanation="baseline ok")},
+            aggregated=1.25,
+        ),
+    )
+
+    def fake_run_validation(path, *, on_event=None):
+        assert path == task_dir.resolve()
+        assert on_event is None
+        return result
+
+    monkeypatch.setattr(task_validation, "run_validation", fake_run_validation)
+
+    cmd_validate(argparse.Namespace(path=str(task_dir), json=True))
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["successful"] is True
+    assert payload["report"] == {
+        "task_dir": str(task_dir.resolve()),
+        "valid": True,
+        "diagnostics": [],
+    }
+    assert payload["events"] == []
+    assert payload["baseline"]["aggregated"] == 1.25
+    assert payload["failure"] is None
+
+
+def test_cmd_validate_json_failure_is_structured_and_exits_nonzero(tmp_path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    failure = task_validation.ValidationFailure(
+        stage="baseline",
+        code="grader.baseline.failed",
+        message="Grader crashed: boom",
+    )
+    result = task_validation.ValidationRunResult(
+        report=ValidationReport(task_dir=task_dir.resolve(), diagnostics=()),
+        events=(),
+        failure=failure,
+    )
+
+    def fake_run_validation(path, *, on_event=None):
+        assert path == task_dir.resolve()
+        assert on_event is None
+        return result
+
+    monkeypatch.setattr(task_validation, "run_validation", fake_run_validation)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_validate(argparse.Namespace(path=str(task_dir), json=True))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["successful"] is False
+    assert payload["baseline"] is None
+    assert payload["failure"] == {
+        "stage": "baseline",
+        "code": "grader.baseline.failed",
+        "message": "Grader crashed: boom",
+    }
 
 
 def test_cmd_validate_prints_structure_failure_without_diagnostics(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Motivation

Maintainer-approved promotion of the current `dev` branch to `main`. This is an explicit exception to the normal rule that PRs target `dev`.

## Changes

Promotes the four commits currently ahead on `dev`, including structured task validation and the DeepSeek Harness runtime.

## Test plan

This PR contains no new changes beyond the already-reviewed commits on `dev`. The existing commit-level PR checks apply; no additional test suite was run for this promotion PR.

## Affected areas

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [x] `coral/cli/` (commands, helpers)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [ ] CI / tooling / packaging
- [x] Other: branch promotion

## Checklist

- [ ] PR targets the `dev` branch (not `main`). **Maintainer-approved exception: this PR promotes `dev` to `main`.**
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
