### PR TITLE
fix(ci): restrict Vercel builds to main

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  }
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Vercel currently creates preview builds for non-production branches. The documentation site and web dashboard should only build after changes land on the production branch.

## Changes

- Add project-level Vercel configuration for both `docs/` and `web/`.
- Disable automatic deployments for all branches by default.
- Explicitly enable automatic deployments for `main`.

## Test plan

- Parsed both `docs/vercel.json` and `web/vercel.json` with Node.js and asserted that `*` is disabled and `main` is enabled.
- Ran `git diff --check` successfully.
- Full Python test and Ruff suites were not run because this change only adds Vercel JSON configuration.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [x] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [x] CI / tooling / packaging
- [ ] Other:

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See `AGENTS.md`.

Authored with assistance from Codex. The change is limited to Vercel branch deployment configuration; please review every changed line before merge.