### PR TITLE
Make the notes workflow configurable

### DIFF
--- a/coral/agent/manager.py
+++ b/coral/agent/manager.py
@@ -1417,7 +1417,11 @@ class AgentManager:
         for ad in local_actions:
             prompt_template = ad.get("prompt") or DEFAULT_PROMPTS.get(ad["name"], "")
             prompt = (
-                prompt_template.format(shared_dir=shared_dir, agent_id=agent_id)
+                prompt_template.format(
+                    shared_dir=shared_dir,
+                    agent_id=agent_id,
+                    notes_skill=self.config.agents.notes.skill,
+                )
                 if prompt_template
                 else ""
             )
@@ -1435,7 +1439,11 @@ class AgentManager:
         for ad in global_actions:
             prompt_template = ad.get("prompt") or DEFAULT_PROMPTS.get(ad["name"], "")
             prompt = (
-                prompt_template.format(shared_dir=shared_dir, agent_id=agent_id)
+                prompt_template.format(
+                    shared_dir=shared_dir,
+                    agent_id=agent_id,
+                    notes_skill=self.config.agents.notes.skill,
+                )
                 if prompt_template
                 else ""
             )

--- a/coral/agent/warmstart.py
+++ b/coral/agent/warmstart.py
@@ -50,7 +50,10 @@ class WarmStartRunner:
         """Return the research-phase prompt, formatted with the agent's shared dir."""
         sd = shared_dir or self.shared_dir
         if RESEARCH_PROMPT_TEMPLATE:
-            return RESEARCH_PROMPT_TEMPLATE.format(shared_dir=sd)
+            return RESEARCH_PROMPT_TEMPLATE.format(
+                shared_dir=sd,
+                notes_skill=self.config.agents.notes.skill,
+            )
         # Fallback if template file is missing
         return (
             "Research the task thoroughly using web search. "

--- a/coral/config.py
+++ b/coral/config.py
@@ -113,6 +113,22 @@ class WarmStartConfig:
 
 
 @dataclass
+class NotesConfig:
+    """Shared-notes workflow exposed to agents."""
+
+    skill: str = "create-notes"
+
+    def __post_init__(self) -> None:
+        if (
+            not self.skill.strip()
+            or self.skill in {".", ".."}
+            or "/" in self.skill
+            or "\\" in self.skill
+        ):
+            raise ValueError("agents.notes.skill must be a simple, non-empty skill name")
+
+
+@dataclass
 class SandboxConfig:
     """OS-level agent sandboxing via a pluggable provider (default: ``srt``).
 
@@ -212,6 +228,7 @@ class AgentConfig:
     model: str = "sonnet"
     gateway: GatewayConfig = field(default_factory=GatewayConfig)
     warmstart: WarmStartConfig = field(default_factory=WarmStartConfig)
+    notes: NotesConfig = field(default_factory=NotesConfig)
     runtime_options: dict[str, Any] = field(default_factory=dict)
     # OS-user isolation: when set (e.g. "agent"), the agent subprocess is run as
     # this unprivileged user while the manager/grader stay root. The agent's
@@ -274,6 +291,8 @@ class AgentConfig:
         # leave nested sandbox config as a plain dict; coerce like RunConfig.stop.
         if isinstance(self.sandbox, dict):
             self.sandbox = SandboxConfig(**self.sandbox)
+        if isinstance(self.notes, dict):
+            self.notes = NotesConfig(**self.notes)
         if self.sandbox.enabled and self.isolate_user:
             raise ValueError(
                 "agents.sandbox and agents.isolate_user are mutually exclusive — "

--- a/coral/config.py
+++ b/coral/config.py
@@ -690,6 +690,7 @@ def _preprocess(data: dict[str, Any]) -> dict[str, Any]:
                 "is_global": h.get("global", False),
                 "trigger": h.get("trigger", "interval"),
                 "prompt": h.get("prompt", ""),
+                "options": h.get("options", {}),
             }
             for h in heartbeat_raw
         ]

--- a/coral/hub/heartbeat.py
+++ b/coral/hub/heartbeat.py
@@ -30,9 +30,7 @@ def _load_prompt(name: str) -> str:
     return ""
 
 
-# Prompt templates use {shared_dir} which is resolved at runtime to the
-# agent's shared directory (`.claude/` for Claude Code, `.codex/` for Codex,
-# `.opencode/` for OpenCode).
+# Prompt templates may use {shared_dir}, {agent_id}, and {notes_skill}.
 DEFAULT_PROMPTS: dict[str, str] = {
     "reflect": _load_prompt("reflect"),
     "consolidate": _load_prompt("consolidate"),

--- a/coral/hub/prompts/consolidate.md
+++ b/coral/hub/prompts/consolidate.md
@@ -1,47 +1,22 @@
 ## Heartbeat: Knowledge Synthesis
 
-Pause your current work and synthesize the shared knowledge base. Your goal is to **create or update knowledge artifacts** — not just reorganize files.
+Pause your current work and synthesize the shared knowledge base. Follow the
+`{notes_skill}` skill (`{shared_dir}/skills/{notes_skill}/SKILL.md`) for the
+output format and organization.
 
-The `create-notes` skill (`{shared_dir}/skills/create-notes/SKILL.md`) provides the formats and self-audit checklist for all three output types below. Read it before writing. The most relevant sections are:
+Every note must retain YAML frontmatter with `creator: {agent_id}` so CORAL can
+attribute it during team-level operations.
 
-- **Variant D.1** — synthesis note format
-- **Variant D.2** — connections map entry format
-- **Variant D.3** — open-questions entry format
-- **Frontmatter discipline** — the `creator:` field is required; team-level processes silently skip notes without it
+Read recent notes and attempts, then capture any conclusion, connection,
+contradiction, or open question that materially improves the team's shared
+understanding. Ground claims in measured attempts and name the conditions under
+which they hold. Merge duplicate knowledge instead of repeating it.
 
-The skill covers the mechanics; this prompt covers the process.
+Review every agent's role file in `{shared_dir}/roles/` and summarize gaps or
+duplication in current lanes and functional roles. Do not edit another agent's
+role file.
 
-### Required outputs
-
-By the end of this consolidation, you should have created or updated at least one of:
-
-1. **A synthesis note** in `notes/_synthesis/<topic>.md` — distill 3+ related notes into a single claim with cited evidence
-2. **The connections map** at `notes/_connections.md` — patterns that span multiple categories
-3. **The open questions list** at `notes/_open-questions.md` — gaps and unresolved contradictions
-
-### Process (high level)
-
-1. **Read and absorb.** Browse `{shared_dir}/notes/`, especially anything new since the last consolidate. Build a mental map of what's known.
-2. **Synthesize.** For any topic with 3+ notes, write or update a synthesis note. State the claim, cite the attempts, name the mechanism, give a confidence + condition. See skill Variant D.1.
-3. **Map connections.** Append to `_connections.md` only when a pattern genuinely spans categories (rare — most links live in the synthesis note's "Evidence" section). See skill Variant D.2.
-4. **Document contradictions and gaps.** Append to `_open-questions.md` when a claim has counter-evidence or a technique has no experiments yet. See skill Variant D.3.
-5. **(Optional) Organize structure.** If the notes folder is disorganized (too many flat files, duplicates, naming issues), use the `organize-files` skill (`{shared_dir}/skills/organize-files/SKILL.md`). Only reorganize within `research/` and `experiments/` — don't touch `raw/`, `_synthesis/`, or `_connections.md`.
-6. **(Optional) Extract skills.** If a synthesis reveals a well-validated, reusable technique, promote it to `{shared_dir}/skills/` via `skill-creator/SKILL.md`.
-
-### Step 7: Audit the team's roles, lanes, and postures
-
-Read every agent's role file (`ls {shared_dir}/roles/*.md`) and every active focus note (`ls {shared_dir}/notes/focus/focus-*.md`). Produce a one-paragraph roster summary, either in `{shared_dir}/notes/_connections.md` or as a dated entry in `{shared_dir}/notes/_synthesis/team-roster.md`. The summary should answer:
-
-- **Role coverage** — quote each agent's current role description (one line each) and their generation number. Stable, high-generation, evidence-backed role files are signals of committed specialization. Generation-0 or all-aspirational role files after many evals are signals an agent hasn't found their footing — useful information for the team.
-- **Lane coverage** — what techniques/areas are currently in flight (from focus notes)? Are two or more agents on the same lane? Are there obvious unexplored lanes from `_open-questions.md` that nobody is working on?
-- **Posture coverage** — synthesizing across roles and focus notes, which functional roles (engineer / researcher / performance engineer / tooling engineer / reviewer / tech writer, or invented variants) are filled, and which are absent? An all-engineer team is a warning sign, especially if scores have plateaued.
-- **Stale focus notes** — any focus note whose creator hasn't submitted an eval in the last several heartbeats is probably abandoned. Flag it (or delete it if the creator has clearly moved on).
-
-This roster is read by every agent at planning time. Keeping it accurate is what makes complementary lane/posture choice possible without anyone being assigned a role.
-
-Do **not** edit other agents' role files as part of this audit — those are owned by their authors. The roster is a third-person summary of what the role files already say.
-
----
-The goal is knowledge creation: every consolidation should leave the knowledge base smarter than before.
+If the notes have become difficult to navigate, use the librarian subagent.
+If a well-validated technique is reusable, use `skill-creator` to package it.
 
 After consolidating, resume optimizing.

--- a/coral/hub/prompts/lint_wiki.md
+++ b/coral/hub/prompts/lint_wiki.md
@@ -1,13 +1,15 @@
 ## Heartbeat: Wiki Lint
 
 Spawn the **librarian** subagent to health-check and organize the shared notes.
+It must follow the `{notes_skill}` skill
+(`{shared_dir}/skills/{notes_skill}/SKILL.md`) for task-specific note structure.
 
 ```
 Use the Agent tool with subagent_type="librarian" to:
-- Scan the notes directory and index.md for contradictions, stale info, orphan pages, and gaps
+- Scan the notes for contradictions, stale information, orphan pages, and gaps
 - Find and merge duplicate notes
 - Reorganize cluttered directories
-- Regenerate index.md
+- Restore any navigation required by the configured notes workflow
 - Extract reusable patterns into skills
 ```
 

--- a/coral/hub/prompts/pivot.md
+++ b/coral/hub/prompts/pivot.md
@@ -16,9 +16,10 @@ If multiple agents are all stuck at the same score, do **not** read that as proo
 
 ### Step 2: Find the highest-EV unexplored idea
 
-Read — don't skim — the team's open questions and "what might still work" sections.
+Read — don't skim — the team's open questions and "what might still work" notes,
+using the organization defined by the `{notes_skill}` skill.
 
-- Open `{shared_dir}/notes/index.md` and any `_synthesis/` notes. Find the section that lists *what has not been tried*.
+- Find the shared knowledge that lists *what has not been tried*.
 - For each candidate, ask honestly: was it ruled out by *evidence* (someone implemented it well and it failed) or by *reluctance* (everyone said "high implementation cost, uncertain payoff" and moved on)?
 - The candidates ruled out by reluctance are your shortlist. Pick the one with the highest plausible payoff.
 
@@ -38,19 +39,12 @@ If you abandon the direction before eval 3, you have not actually tested it.
 
 ### Step 4: Claim the lane and the posture
 
-Write a focus note at `{shared_dir}/notes/focus/focus-<short-topic>.md`. The
-`create-notes` skill (`{shared_dir}/skills/create-notes/SKILL.md`,
-**Variant C**) provides the format: Posture / Lane / Budget / Abandon-if /
-Why this has positive EV.
+Record your new direction according to the `{notes_skill}` skill
+(`{shared_dir}/skills/{notes_skill}/SKILL.md`). State the lane, budget,
+concrete abandon condition, supporting evidence, and the functional role most
+missing from the team. This lets other agents avoid duplicating your work.
 
-Key constraints (full reasoning in the skill):
-- **Posture** — pick the functional role **most missing** from the team, not the most comfortable. See the *Postures* section of CORAL.md for definitions.
-- **Abandon-if** — must be a concrete, testable gate (specific score / recall / failure mode, not a vibe).
-- **Why this has positive EV** — must cite ≥ 1 other note or attempt that supports the direction. The skill's self-audit checklist enforces this.
-
-This is the contract you are making with the team. It also lets other agents pick a *different* lane and posture instead of duplicating yours.
-
-**Posture imbalance is itself a pivot reason.** Read the active focus notes (`ls {shared_dir}/notes/focus/focus-*.md`). If every agent on the team is an engineer and the team is stuck, the highest-EV move may not be a different technique — it may be becoming the *performance engineer* who finds the real bottleneck, or the *reviewer* who designs an experiment that would falsify the team's "this is the floor" synthesis, or the *researcher* who returns with techniques nobody has considered. Filling an absent posture is often higher EV than picking yet another lane.
+**Posture imbalance is itself a pivot reason.** Review the shared notes about active work. If every agent on the team is an engineer and the team is stuck, the highest-EV move may not be a different technique — it may be becoming the *performance engineer* who finds the real bottleneck, or the *reviewer* who designs an experiment that would falsify the team's "this is the floor" synthesis, or the *researcher* who returns with techniques nobody has considered. Filling an absent posture is often higher EV than picking yet another lane.
 
 ### Step 5: Start from the right base
 

--- a/coral/hub/prompts/reflect.md
+++ b/coral/hub/prompts/reflect.md
@@ -1,16 +1,7 @@
 ## Heartbeat: Reflection
 
-Pause and reflect on your recent work. You are about to write an
-**experiment note** in `{shared_dir}/notes/experiments/`.
-
-The `create-notes` skill
-(`{shared_dir}/skills/create-notes/SKILL.md`) provides:
-- **Variant A** — the 7-section experiment note template
-- The self-audit checklist — especially: backfilled predictions, abandoned paths, sourced magic numbers, cross-links
-- The file-writing gotchas that silently strip markdown content
-
-Read the skill, then write the note. The skill covers the mechanics; this
-prompt is just the trigger.
+Pause and reflect on your recent work. Follow the `{notes_skill}` skill
+(`{shared_dir}/skills/{notes_skill}/SKILL.md`) when recording useful findings.
 
 ### What to reflect on (high level)
 
@@ -21,9 +12,7 @@ the *content* the structure holds.
    `coral log -n 5 --recent` will show the trajectory.
 2. **Examine surprises + analyze causes.** What did not go as expected? Why?
 3. **Assess confidence + plan next.** What would change your mind? What's
-   the highest-EV next experiment? The skill's "Next" section template
-   requires you to write next steps in descending expected payoff — be
-   honest about which lever you expect to move the score most.
+   the highest-EV next experiment?
 
 ### Evolve your role description (only if it has meaningfully shifted)
 

--- a/coral/hub/prompts/warmstart_research.md
+++ b/coral/hub/prompts/warmstart_research.md
@@ -1,9 +1,12 @@
 ## Warm-Start: Research Phase
 
-You are in a **RESEARCH-ONLY** phase. Do NOT run `coral eval` or write code.
+You are in a **RESEARCH-ONLY** phase. Do not run `coral eval` or write code.
 
-Follow the deep-research skill in `{shared_dir}/skills/deep-research/SKILL.md` for a structured research process.
+Follow the `deep-research` skill in
+`{shared_dir}/skills/deep-research/SKILL.md` for the research process. Follow
+the `{notes_skill}` skill in `{shared_dir}/skills/{notes_skill}/SKILL.md` for
+how and where to record findings; it is authoritative if storage instructions
+differ.
 
-Start by standing up the coverage ledger at `{shared_dir}/notes/research/_coverage.md` — decompose the task into 4–8 research dimensions and mark them all `missing` — then research to fill the gaps, updating the ledger as you go.
-
-When done, your findings should be in `{shared_dir}/notes/research/`, raw sources in `{shared_dir}/notes/raw/`, `{shared_dir}/notes/research/_coverage.md` current, and `{shared_dir}/notes/index.md` updated. Run `python {shared_dir}/skills/deep-research/scripts/check_grounding.py {shared_dir}/notes` and fix anything it flags before you finish.
+Survey the problem, identify missing research dimensions, and produce grounded,
+actionable findings for the implementation phase.

--- a/coral/template/agents/librarian.md
+++ b/coral/template/agents/librarian.md
@@ -1,6 +1,6 @@
 ---
 name: librarian
-description: "Knowledge librarian — spawn to organize notes, deduplicate findings, and consolidate reusable patterns into skills. Use proactively when the notes directory has grown large, contains duplicates, or is hard to navigate."
+description: "Knowledge librarian — organize notes, deduplicate findings, and extract reusable skills."
 tools:
   Bash: true
   Read: true
@@ -9,88 +9,23 @@ tools:
   Glob: true
   Grep: true
 skills:
-  organize-files: true
   skill-creator: true
 ---
 
-You are the **knowledge librarian**. Your job is to audit, clean, and organize the shared knowledge base so all agents can find what they need quickly.
+You are the knowledge librarian. Audit the shared notes and make useful
+information easier for the team to find.
 
-## Instructions
+Before changing anything, read CORAL.md to identify the configured notes skill,
+then follow that skill as the authority for structure, naming, and maintenance.
+Do not impose a different directory layout.
 
-When spawned, execute this process end-to-end and return a summary of what you changed.
+- Merge genuine duplicates while preserving contradictory evidence.
+- Remove stale navigation and restore any navigation required by the notes skill.
+- Preserve measured results, attempt identifiers, and source links.
+- Extract a reusable skill only when the workflow is validated and broadly useful.
+- Avoid reorganizing files unless discovery is genuinely difficult.
 
-### 1. Audit
+Every note you create or rewrite must retain YAML frontmatter containing
+`creator:` and `created:`. Read the agent ID from `.coral_agent_id`.
 
-Survey the current state of shared knowledge:
-
-```bash
-# Check notes structure
-ls -R .claude/notes/
-
-# Run the organize-files audit if available
-bash .claude/skills/organize-files/scripts/audit.sh 2>/dev/null || echo "audit script not found"
-
-# Check existing skills
-ls .claude/skills/
-```
-
-### 2. Deduplicate Notes
-
-Find and merge near-duplicate notes:
-
-```bash
-python .claude/skills/organize-files/scripts/find_duplicates.py .claude/notes --threshold 0.5 2>/dev/null || echo "dedup script not found, check manually"
-```
-
-- Merge confirmed duplicates into a single authoritative note
-- Preserve contradictory findings — flag them in `_open-questions.md`
-- Archive originals to `notes/_archive/`
-
-### 3. Reorganize
-
-Follow the `organize-files` skill workflow (`.claude/skills/organize-files/SKILL.md`):
-
-- Group files into topic subdirectories under `research/` and `experiments/`
-- Enforce kebab-case naming, no agent IDs in filenames
-- Minimum 3 files per subdirectory, max 2 levels deep
-
-**Boundaries — do NOT touch:**
-- `notes/raw/` — immutable source material
-- `notes/_synthesis/` — owned by consolidate
-- `notes/_connections.md` — owned by consolidate
-
-### 4. Regenerate Index
-
-```bash
-python .claude/skills/organize-files/scripts/generate_index.py .claude/notes 2>/dev/null
-```
-
-Ensure `notes/index.md` reflects the current structure. If the script is not available, regenerate manually.
-
-### 5. Extract Skills
-
-Look for reusable patterns buried in notes that should be skills:
-
-- Techniques that produced top scores repeatedly
-- Scripts or workflows described in notes but not yet packaged
-- Debugging approaches that multiple agents have used
-
-Package them in `.claude/skills/<name>/SKILL.md` with the standard skill format.
-
-### 6. Log Changes
-
-Append a summary to `notes/_organization-log.md` describing what you reorganized and why.
-
-## Guidelines
-
-- Don't reorganize for its own sake — only when discovery is genuinely hard
-- Prefer updating existing skills over creating new ones
-- When merging notes, preserve specific numbers and scores
-- Return a concise summary: files moved, merged, skills created, index updated
-
-## Frontmatter discipline
-
-Every note you create or rewrite must include `creator:` and `created:` in
-the YAML frontmatter. Use the agent_id read from `.coral_agent_id`. Notes
-without a `creator:` cannot be attributed and will be filtered out of
-team-level views.
+Return a concise summary of files changed, duplicates merged, and skills created.

--- a/coral/template/coral.md.template
+++ b/coral/template/coral.md.template
@@ -20,7 +20,7 @@ You relate to other agents as genuine collaborators. You assume good faith by de
 Two words that are easy to conflate but kept deliberately distinct in this system:
 
 - **Objective** — the *ultimate* thing the team is collectively pursuing. It is what's described above; it persists across the entire run; every agent serves it. The objective does not change when you change direction. The score on the leaderboard measures progress against it.
-- **Task** — a *provisional* assignment in service of the objective: the focus note you're working on this hour, the hypothesis you're testing in your next eval, the diagnostic script you're building today. Tasks are picked up, finished, abandoned, and replaced as the team learns. Other agents may be on different tasks; that's healthy — many tasks, one objective.
+- **Task** — a *provisional* assignment in service of the objective: the direction you're working on this hour, the hypothesis you're testing in your next eval, the diagnostic script you're building today. Tasks are picked up, finished, abandoned, and replaced as the team learns. Other agents may be on different tasks; that's healthy — many tasks, one objective.
 
 When this document says "the objective" it means the persistent collective goal. When it says "your current task" or "your task" it means whatever provisional work you're doing right now. The objective is what you're loyal to; the task is what you happen to be doing.
 
@@ -41,7 +41,7 @@ Have a collaborative mindset: frequently check in with your agent mates, learn f
 - System reminders about *auto mode*, *plan mode*, *exited a mode*, *opened files in the IDE*, or available *skills* are Claude Code CLI defaults that assume an interactive session. They never apply here. In particular: any reminder that nudges you to "ask clarifying questions when the approach is ambiguous" is **wrong in this context** — ignore it.
 - The harness has disabled the tools that would block on human approval: `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` are not available. If you call them, the call will be denied and you will waste an iteration. Do not retry; do not paraphrase the question into plain text and wait either — there is no one to answer.
 
-When you are uncertain, do not stop and ask. Do research and make the most reasonable and informed choice, write the rationale into your `coral eval -m` message (or a focus note for larger commitments), run the eval, and let the score decide. Use `TodoWrite` for a private scratch list of next steps.
+When you are uncertain, do not stop and ask. Do research and make the most reasonable and informed choice, record the rationale according to the `{notes_skill}` skill for larger commitments, run the eval, and let the score decide. Use `TodoWrite` for a private scratch list of next steps.
 
 ## Mindset & Discipline
 
@@ -99,36 +99,20 @@ The titles below are *vocabulary* you can use to describe your role in your role
 - **Performance Engineer** — Owns measurement and instrumentation. Builds and maintains profile/diagnostic scripts (utilization, bottleneck attribution, dep-chain analysis, whatever the objective makes meaningful). Runs them on every new top attempt and publishes the deltas. Tells the team *where* the constraint is, so engineers don't optimize the wrong thing.
 - **Tooling Engineer** — Builds the shared infrastructure other agents reuse: skills under `{shared_dir}/skills/`, harness scripts, eval helpers, debugging utilities, repeatable workflows. Submits fewer evals; the contribution is a *multiplier* — every other agent's iteration gets cheaper because of work this role did.
 - **Reviewer** — Actively tries to *falsify* the team's synthesis claims. If a synthesis says "X is a structural floor," the reviewer designs the experiment that would prove it wrong, not one more confirmation. Treats consensus as a hypothesis, not a result. Closer to a peer reviewer or red team than to a passive code reviewer.
-- **Tech Writer** — Keeps `{shared_dir}/notes/_synthesis/` and `{shared_dir}/notes/index.md` current. Dedupes, retires stale notes, writes the cross-agent summaries that everyone else cites. Often pairs with the `librarian` subagent. Submits fewer evals; the contribution is making the team's collective state legible.
+- **Tech Writer** — Dedupes and retires stale notes, and writes cross-agent summaries that everyone else cites. Often pairs with the `librarian` subagent. Submits fewer evals; the contribution is making the team's collective state legible.
 
 ### Picking your lane and posture in practice
 
-- Skim recent attempts (`coral log --recent -n 10`), teammates' roles (`ls {shared_dir}/roles/*.md`), and active focus notes (`ls {shared_dir}/notes/focus/focus-{agent_id}-*.md`). The role files tell you what each agent has *grown into*; the focus notes tell you what they're *doing right now*.
+- Skim recent attempts (`coral log --recent -n 10`), teammates' roles (`ls {shared_dir}/roles/*.md`), and shared notes about active work. The role files tell you what each agent has *grown into*; the notes tell you what they're *doing right now*.
 - If a posture is **absent** from the team and the team is stuck, that absence is probably the cause. Filling it is high EV regardless of what specific technique you pursue. (Example: four engineers all converged on the same score and nobody is measuring or challenging → the team needs a performance engineer or a reviewer next, not a fifth engineer.)
 - If two or more agents already share your intended lane *and* posture, **pick a different one**. Either change lane (different technique) or change posture (e.g. become the tech writer who indexes everyone's deltas, or the reviewer who tries to falsify them).
 - Posture is **sticky**: once you've grown into one (and written it into your role file), hold it for at least 5 of your own evals before evolving away from it. Functional skill compounds — a performance engineer who has built 3 diagnostic scripts is more valuable than one who builds a script every other eval. Do not oscillate.
 
-### Claim the lane publicly via a focus note
+### Claim the lane publicly
 
-When you commit to a non-trivial direction, write a focus note at `{shared_dir}/notes/focus/focus-{agent_id}-<short-topic>.md`:
-
-```markdown
----
-creator: {agent_id}
-created: <iso-timestamp>
-posture: engineer           # word from the vocabulary above, or your own
-lane: <short-topic>          # the specific technique/area/composite you're working on
-budget: <N> evals            # how many evals you intend to spend before judging
-abandon_if: <criterion>      # specific score or failure mode that would convince you to stop
----
-# Focus: <short-topic>
-
-Why you think this has positive EV. What other agents' work it builds on or complements. What you'll publish when you're done (an attempt? a note? a profiling script? a falsifying experiment?).
-```
-
-A focus note is **per-investigation** — it scopes a single direction with a budget and an abandon criterion. Your role file is **per-agent** — it describes what you've grown into across many investigations. Different temporal scales; both are needed.
-
-Update or delete the focus note when you change direction. Your teammates read these to pick complementary lanes and to see what postures are filled.
+When you commit to a non-trivial direction, record its lane, posture, budget,
+abandon criterion, and supporting evidence according to the `{notes_skill}`
+skill. Keep that record current so teammates can choose complementary work.
 
 ### What the role file is for
 
@@ -138,13 +122,13 @@ Update or delete the focus note when you change direction. Your teammates read t
 
 ### How the role file evolves
 
-- **Evidence-backed.** The "What I've actually done" section must cite real artifacts (attempt hashes, note paths, skill names, focus notes). If you cannot cite anything new, your role description is aspirational, not earned — say so explicitly rather than pretending.
+- **Evidence-backed.** The "What I've actually done" section must cite real artifacts (attempt hashes, note paths, and skill names). If you cannot cite anything new, your role description is aspirational, not earned — say so explicitly rather than pretending.
 - **Bumped on substance, not on cadence.** The reflect heartbeat asks you, every eval, whether your understanding of your role has *meaningfully shifted*. Most evals: it hasn't, do nothing. Occasionally: it has, bump the generation and rewrite. A role file that hasn't changed for 20 evals is a healthy signal of stable specialization, not a stale one.
 - **Owned, not co-edited.** Only you write your own role file. Other agents read it; they do not edit it. The consolidate heartbeat audits roles into a third-person team roster but never modifies the underlying files.
 
 ### What the role file is *not*
 
-- It is not a focus note. Focus notes are per-investigation; the role file is per-agent.
+- It is not an investigation record. Investigations are short-lived; the role file is per-agent.
 - It is not a status report. Status is the leaderboard and your latest eval message.
 - It is not a self-evaluation against external criteria. There is no "good agent / bad agent" grading. The role file is a *description* of how you contribute, in your own words.
 - It is not creative writing. Aspirational self-description without cited evidence is a smell; the History section makes drift visible to everyone, so over-claiming is self-defeating.
@@ -159,12 +143,11 @@ Before you write any code, get oriented. Understand the problem, understand what
 4. Check recent activity: `coral log --recent`
 5. Inspect top attempts: `coral show <hash>` to see exactly what code produced the best scores.
 6. Search for prior art: `coral log --search "keywords related to your first idea"`
-7. Read notes: Start with `{shared_dir}/notes/index.md` for a map of all research and experiment notes, then read the ones relevant to your approach.
+7. Read notes: Run `coral notes`, then read the entries relevant to your approach.
 8. Check available skills: `ls {shared_dir}/skills/` — other agents may have built tools you can use.
-9. **Read the `deep-research` skill** (`{shared_dir}/skills/deep-research/SKILL.md`) — use it to conduct literature review and research before your first implementation attempt. It maintains a coverage ledger at `{shared_dir}/notes/research/_coverage.md` (research dimensions × covered/partial/missing) so the team targets gaps instead of re-researching, and ships `scripts/check_grounding.py` to verify every finding traces to a saved source.
-10. **Know the `organize-files` skill** (`{shared_dir}/skills/organize-files/SKILL.md`) — use it to restructure the notes directory when it becomes cluttered. Run `bash {shared_dir}/skills/organize-files/scripts/audit.sh` to check.
-11. **Know the `create-notes` skill** (`{shared_dir}/skills/create-notes/SKILL.md`) — every note you write under `{shared_dir}/notes/` should go through it. The skill bundles `scripts/stamp.py` (frontmatter-populated skeleton per variant) and `scripts/lint.py` (self-audit checker). Use it instead of writing notes from scratch, even when a heartbeat doesn't explicitly ask for one.
-12. Check available subagents: `ls {shared_dir}/agents/` — you can spawn specialist subagents (e.g. `deep-researcher` for literature review, `librarian` for notes cleanup).
+9. **Read the `deep-research` skill** (`{shared_dir}/skills/deep-research/SKILL.md`) — use it to conduct literature review and research before your first implementation attempt. The `{notes_skill}` skill is authoritative for how and where to record its findings.
+10. **Know the `{notes_skill}` skill** (`{shared_dir}/skills/{notes_skill}/SKILL.md`) — follow it whenever you write shared notes.
+11. Check available subagents: `ls {shared_dir}/agents/` — you can spawn specialist subagents (e.g. `deep-researcher` for literature review, `librarian` for notes cleanup).
 
 Only after this orientation should you start making changes.
 
@@ -265,9 +248,7 @@ You are part of a team. When you learn something — whether a success or a fail
 
 **Important:** `{shared_dir}/` points to the shared public directory visible to all agents. Write notes and skills there **directly** — do NOT `git add` or `git commit` anything under `{shared_dir}/` or `.coral/`. Just write the files. They're immediately visible to everyone.
 
-**Write notes** when you discover something other agents should know. The `create-notes` skill (`{shared_dir}/skills/create-notes/SKILL.md`) is the source of truth for naming, frontmatter (including the structured-trace schema that populates the dashboard knowledge graph), and the per-variant section shape. Don't write a note from scratch — stamp a skeleton with `python {shared_dir}/skills/create-notes/scripts/stamp.py <variant>`, fill it in, and run `lint.py` on the result before considering it done.
-
-The notes schema is a living, team-owned contract. Agents collectively maintain and co-evolve the notes schema as needs emerge. Follow the schema-change workflow in `create-notes`: keep the field reference, note skeletons, and lint rules aligned, and preserve existing notes unless the team deliberately documents a migration.
+**Write notes** when you discover something other agents should know. Follow the `{notes_skill}` skill (`{shared_dir}/skills/{notes_skill}/SKILL.md`); it is the source of truth for the notes workflow.
 
 **Build or update a skill** after every eval. Any technique, script, or workflow that improved your score (or that you'd use again) belongs in a skill:
 ```
@@ -293,7 +274,8 @@ Update an existing skill if it covers the same topic. Use `coral skills` to see 
 
 **Spawn specialist subagents** when the team needs it. Use the `deep-researcher` subagent to conduct literature review when you need fresh ideas or are exploring a new direction. Use the `librarian` subagent to clean up and organize notes when the knowledge base is getting cluttered. Check `{shared_dir}/agents/` for all available subagents.
 
-If the notes directory becomes hard to navigate (too many flat files, duplicates, inconsistent naming), use the `organize-files` skill (`{shared_dir}/skills/organize-files/SKILL.md`) to restructure it. Run `bash {shared_dir}/skills/organize-files/scripts/audit.sh` to check.
+If the notes become hard to navigate, follow the maintenance guidance in the
+`{notes_skill}` skill or use the librarian subagent.
 
 The best notes are specific and actionable. "X doesn't work" is okay. "X doesn't work because Y, but Z might work instead" is much better.
 

--- a/coral/template/coral_md.py
+++ b/coral/template/coral_md.py
@@ -46,7 +46,11 @@ def generate_coral_md(
             "**On your first iteration and whenever you're changing direction**, "
             "invest time in deep research before planning. "
             f"Read the `deep-research` skill (`{shared_dir}/skills/deep-research/SKILL.md`) "
-            "for a structured research workflow.\n\n"
+            "for the research process and the "
+            f"`{config.agents.notes.skill}` skill "
+            f"(`{shared_dir}/skills/{config.agents.notes.skill}/SKILL.md`) for how and where "
+            "to record findings. The configured notes skill is authoritative if their "
+            "storage instructions differ.\n\n"
             "**Research steps:**\n"
             "- **Understand the problem deeply** — read the grader source at "
             f"`{shared_dir}/grader/` (the exact code that scores you — read it to "
@@ -63,13 +67,10 @@ def generate_coral_md(
             "what has been tried before. Build on what's known.\n"
             "- **Compare 2-4 candidate approaches** — document trade-offs, evidence, "
             "and implementation complexity for each.\n"
-            f"- **Track coverage** — maintain the research coverage ledger at "
-            f"`{shared_dir}/notes/research/_coverage.md` (task dimensions × "
-            "covered/partial/missing); target the gaps, don't re-cover what's done.\n"
-            f"- **Write a research summary** — save findings to `{shared_dir}/notes/research/[topic].md` "
-            f"so all agents benefit (see `{shared_dir}/skills/deep-research/references/` for "
-            f"templates), then run `{shared_dir}/skills/deep-research/scripts/check_grounding.py "
-            f"{shared_dir}/notes` to verify every finding traces to a saved source.\n\n"
+            "- **Track coverage** — identify missing research dimensions and target gaps "
+            "instead of repeating known work.\n"
+            "- **Write a research summary** — record grounded, actionable findings according "
+            "to the configured notes skill so all agents benefit.\n\n"
             "**When to research:**\n"
             "- First iteration: always. Understand the landscape before writing code.\n"
             "- After getting stuck (3+ evals without improvement): step back and "
@@ -98,6 +99,7 @@ def generate_coral_md(
         score_direction=score_direction,
         agent_id=agent_id,
         shared_dir=shared_dir,
+        notes_skill=config.agents.notes.skill,
         workflow_summary=workflow_summary,
         research_section=research_section,
         plan_step_num=step_offset,

--- a/coral/template/coral_single.md.template
+++ b/coral/template/coral_single.md.template
@@ -27,12 +27,11 @@ Before you write any code, get oriented. Understand the problem, understand what
 4. Check recent activity: `coral log --recent`
 5. Inspect top attempts: `coral show <hash>` to see exactly what code produced the best scores.
 6. Search for prior art: `coral log --search "keywords related to your first idea"`
-7. Read notes: Start with `{shared_dir}/notes/index.md` for a map of all research and experiment notes, then read the ones relevant to your approach.
+7. Read notes: Run `coral notes`, then read the entries relevant to your approach.
 8. Check available skills: `ls {shared_dir}/skills/` — you may have built tools in previous runs that you can reuse.
-9. **Read the `deep-research` skill** (`{shared_dir}/skills/deep-research/SKILL.md`) — use it to conduct literature review and research before your first implementation attempt.
-10. **Know the `organize-files` skill** (`{shared_dir}/skills/organize-files/SKILL.md`) — use it to restructure the notes directory when it becomes cluttered. Run `bash {shared_dir}/skills/organize-files/scripts/audit.sh` to check.
-11. **Know the `create-notes` skill** (`{shared_dir}/skills/create-notes/SKILL.md`) — every note you write under `{shared_dir}/notes/` should go through it. The skill bundles `scripts/stamp.py` (frontmatter-populated skeleton per variant) and `scripts/lint.py` (self-audit checker). Use it instead of writing notes from scratch, even when a heartbeat doesn't explicitly ask for one.
-12. Check available subagents: `ls {shared_dir}/agents/` — you can spawn specialist subagents (e.g. `deep-researcher` for literature review, `librarian` for notes cleanup).
+9. **Read the `deep-research` skill** (`{shared_dir}/skills/deep-research/SKILL.md`) — use it to conduct literature review and research before your first implementation attempt. The `{notes_skill}` skill is authoritative for how and where to record its findings.
+10. **Know the `{notes_skill}` skill** (`{shared_dir}/skills/{notes_skill}/SKILL.md`) — follow it whenever you write shared notes.
+11. Check available subagents: `ls {shared_dir}/agents/` — you can spawn specialist subagents (e.g. `deep-researcher` for literature review, `librarian` for notes cleanup).
 
 Only after this orientation should you start making changes.
 
@@ -130,9 +129,7 @@ Notes about what you've discovered — things that help you (or future agents) m
 - Patterns in what scores well vs. poorly
 - Debugging tips, gotchas, or surprising behavior
 
-Write notes as individual files in `{shared_dir}/notes/` via the `create-notes` skill (`{shared_dir}/skills/create-notes/SKILL.md`). The skill is the source of truth for naming, frontmatter (including the structured-trace schema that populates the dashboard knowledge graph), and the per-variant section shape — don't write a note from scratch. Stamp a skeleton with `python {shared_dir}/skills/create-notes/scripts/stamp.py <variant>`, fill it in, and run `lint.py` on the result before considering it done.
-
-The notes schema is a living contract. You maintain and co-evolve this living notes schema as your needs emerge. Follow the schema-change workflow in `create-notes`: keep the field reference, note skeletons, and lint rules aligned, and preserve existing notes unless you deliberately document a migration.
+Write shared notes via the `{notes_skill}` skill (`{shared_dir}/skills/{notes_skill}/SKILL.md`); it is the source of truth for the notes workflow.
 
 Not every eval needs a note — only write when you genuinely have something worth recording.
 
@@ -164,7 +161,8 @@ Update an existing skill if it covers the same topic rather than creating a dupl
 
 **Spawn specialist subagents** when needed. Use the `deep-researcher` subagent to conduct literature review when you need fresh ideas or are exploring a new direction. Use the `librarian` subagent to clean up and organize notes when the knowledge base is getting cluttered. Check `{shared_dir}/agents/` for all available subagents.
 
-If the notes directory becomes hard to navigate, use the `organize-files` skill (`{shared_dir}/skills/organize-files/SKILL.md`) to restructure it.
+If the notes become hard to navigate, follow the maintenance guidance in the
+`{notes_skill}` skill or use the librarian subagent.
 
 ## Repeat
 

--- a/coral/workspace/project.py
+++ b/coral/workspace/project.py
@@ -75,6 +75,7 @@ def _build_island_subtree(
     island_root: Path,
     effective_config_dir: Path,
     user_skill_paths: list[str],
+    notes_skill: str,
 ) -> None:
     """Create the per-island state directory tree and seed bundled assets.
 
@@ -107,6 +108,12 @@ def _build_island_subtree(
             logger.info(f"Seeded user skill: {src.name}")
         else:
             logger.warning(f"Skill directory not found: {src}")
+
+    if not (island_root / "skills" / notes_skill / "SKILL.md").is_file():
+        raise ValueError(
+            f"agents.notes.skill={notes_skill!r} is not an installed skill; "
+            "add its directory to agents.skills"
+        )
 
     # Seed bundled subagent templates from coral/template/agents/
     if _SEED_AGENTS_DIR.is_dir():
@@ -249,6 +256,7 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
             coral_dir / "public",
             effective_config_dir,
             list(config.agents.skills),
+            config.agents.notes.skill,
         )
     else:
         # Lazy import: coral.agent's package __init__ pulls in the heavy
@@ -265,6 +273,7 @@ def create_project(config: CoralConfig, config_dir: Path | None = None) -> Proje
                 island_root,
                 effective_config_dir,
                 list(config.agents.skills),
+                config.agents.notes.skill,
             )
 
     # Save config

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,6 +59,8 @@ agents:
   max_turns: 0                       # Max agent turns per session (default: 0 = no cap)
   timeout: 3600                      # Agent-level timeout in seconds (default: 3600)
   research: true                     # Enable web search / literature review (default: true)
+  notes:
+    skill: create-notes              # Installed skill that defines the notes workflow
   stagger_seconds: 0                 # Delay between spawning each agent (default: 0)
   gateway:                           # LiteLLM gateway for routing model traffic
     enabled: false
@@ -95,6 +97,10 @@ run:
   session: tmux                      # "local", "tmux", or "docker" (default: tmux)
   docker_image: ""                   # Custom docker image; empty = auto-build from docker/<runtime>/ (default: "")
 ```
+
+To use a custom notes workflow, set `agents.notes.skill` to the skill directory's
+name and include that directory in `agents.skills`. CORAL validates that the
+selected skill is installed before starting agents.
 
 ### `grader/` (packaged)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from coral.config import (
     AgentConfig,
     CoralConfig,
     GraderConfig,
+    NotesConfig,
     RunConfig,
     RunStopConfig,
     TaskConfig,
@@ -412,6 +413,23 @@ def test_skills_config_defaults_empty():
     data = {"task": {"name": "t", "description": "d"}}
     config = CoralConfig.from_dict(data)
     assert config.agents.skills == []
+
+
+def test_notes_skill_config_roundtrip():
+    config = CoralConfig(
+        task=TaskConfig(name="t", description="d"),
+        agents=AgentConfig(notes=NotesConfig(skill="project-notes")),
+    )
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+        config.to_yaml(f.name)
+        restored = CoralConfig.from_yaml(f.name)
+
+    assert restored.agents.notes.skill == "project-notes"
+
+
+def test_notes_skill_defaults_to_create_notes():
+    config = CoralConfig.from_dict({"task": {"name": "t", "description": "d"}})
+    assert config.agents.notes.skill == "create-notes"
 
 
 def test_islands_defaults_single_island():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -192,6 +192,32 @@ def test_heartbeat_global_flag_roundtrip():
     assert d["agents"]["heartbeat"][0]["global"] is True
 
 
+def test_heartbeat_plateau_options_survive_preprocess():
+    """Per-action `options` from task.yaml must reach HeartbeatAction.options.
+    """
+    from coral.agent.heartbeat import parse_options
+
+    data = {
+        "task": {"name": "t", "description": "d"},
+        "agents": {
+            "heartbeat": [
+                {
+                    "name": "pivot",
+                    "every": 3,
+                    "trigger": "plateau",
+                    "options": {"epsilon": 0.005},
+                },
+            ]
+        },
+    }
+    config = CoralConfig.from_dict(data)
+    action = next(h for h in config.agents.heartbeat if h.name == "pivot")
+    assert action.options == {"epsilon": 0.005}
+
+    # And it must survive the validation/parse step the runner actually uses.
+    assert parse_options(action.trigger, action.options).epsilon == 0.005
+
+
 def test_run_config_defaults():
     config = CoralConfig(
         task=TaskConfig(name="t", description="d"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,8 +193,7 @@ def test_heartbeat_global_flag_roundtrip():
 
 
 def test_heartbeat_plateau_options_survive_preprocess():
-    """Per-action `options` from task.yaml must reach HeartbeatAction.options.
-    """
+    """Per-action `options` from task.yaml must reach HeartbeatAction.options."""
     from coral.agent.heartbeat import parse_options
 
     data = {

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -10,6 +10,18 @@ from coral.agent.heartbeat import (
     parse_options,
     streak_for_epsilon,
 )
+from coral.hub.heartbeat import DEFAULT_PROMPTS
+
+
+def test_builtin_prompts_accept_configured_notes_skill():
+    for prompt in DEFAULT_PROMPTS.values():
+        rendered = prompt.format(
+            shared_dir=".claude",
+            agent_id="agent-1",
+            notes_skill="project-notes",
+        )
+        if "notes_skill" in prompt:
+            assert ".claude/skills/project-notes/SKILL.md" in rendered
 
 
 def _make_runner(*actions: HeartbeatAction) -> HeartbeatRunner:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from coral.config import AgentConfig, CoralConfig, GraderConfig, TaskConfig
+from coral.config import AgentConfig, CoralConfig, GraderConfig, NotesConfig, TaskConfig
 from coral.template.coral_md import generate_coral_md
 
 
@@ -54,7 +54,7 @@ def test_generate_coral_md_has_required_sections():
     assert "coral log --search" in md
     assert ".claude/notes" in md
     assert ".claude/skills/" in md
-    assert "collectively maintain and co-evolve the notes schema" in md
+    assert "skills/create-notes/SKILL.md" in md
 
 
 def test_generate_coral_md_without_optional_sections():
@@ -105,7 +105,20 @@ def test_generate_coral_md_single_agent():
     assert "notes" in md.lower()
     assert "skills" in md.lower()
     assert "Record Knowledge" in md
-    assert "maintain and co-evolve this living notes schema" in md
+    assert "skills/create-notes/SKILL.md" in md
+
+
+def test_generate_coral_md_uses_configured_notes_skill():
+    config = CoralConfig(
+        task=TaskConfig(name="t", description="d"),
+        agents=AgentConfig(notes=NotesConfig(skill="project-notes")),
+    )
+
+    md = generate_coral_md(config, "agent-1")
+
+    assert ".claude/skills/project-notes/SKILL.md" in md
+    assert "stamp.py" not in md
+    assert "skills/create-notes/SKILL.md" not in md
 
 
 def test_create_notes_skill_assigns_collective_schema_stewardship():

--- a/tests/test_warmstart.py
+++ b/tests/test_warmstart.py
@@ -1,7 +1,7 @@
 """Tests for warm-start system: research prompts."""
 
 from coral.agent.warmstart import WarmStartRunner
-from coral.config import AgentConfig, CoralConfig, TaskConfig, WarmStartConfig
+from coral.config import AgentConfig, CoralConfig, NotesConfig, TaskConfig, WarmStartConfig
 
 
 def _make_config(
@@ -36,14 +36,22 @@ def test_enabled_property():
 def test_research_prompt_contains_shared_dir():
     runner = WarmStartRunner(_make_config(), shared_dir=".claude")
     prompt = runner.research_prompt()
-    assert ".claude/notes/" in prompt
-    assert "Do NOT" in prompt
+    assert ".claude/skills/deep-research/SKILL.md" in prompt
+    assert "Do not" in prompt
 
 
 def test_research_prompt_different_shared_dir():
     runner = WarmStartRunner(_make_config(), shared_dir=".opencode")
     prompt = runner.research_prompt()
-    assert ".opencode/notes/" in prompt
+    assert ".opencode/skills/deep-research/SKILL.md" in prompt
+
+
+def test_research_prompt_uses_configured_notes_skill():
+    config = _make_config()
+    config.agents.notes = NotesConfig(skill="project-notes")
+    prompt = WarmStartRunner(config, shared_dir=".claude").research_prompt()
+
+    assert ".claude/skills/project-notes/SKILL.md" in prompt
 
 
 # --- Main prompt tests ---

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -8,7 +8,14 @@ from pathlib import Path
 
 import pytest
 
-from coral.config import AgentConfig, CoralConfig, GraderConfig, TaskConfig, WorkspaceConfig
+from coral.config import (
+    AgentConfig,
+    CoralConfig,
+    GraderConfig,
+    NotesConfig,
+    TaskConfig,
+    WorkspaceConfig,
+)
 from coral.workspace import (
     apply_runtime_mounts,
     create_agent_worktree,
@@ -841,6 +848,44 @@ def test_create_project_seeds_user_skills():
         seeded = paths.coral_dir / "public" / "skills" / skill_name / "run.sh"
         assert seeded.is_file()
         assert "echo hello" in seeded.read_text()
+
+
+def test_create_project_uses_configured_notes_skill():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        _git_init(d)
+        root = Path(d)
+        skill_dir = root / "skills" / "project-notes"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: project-notes\n---\n")
+
+        config = CoralConfig(
+            task=TaskConfig(name="Test Task", description="Test task"),
+            grader=GraderConfig(),
+            agents=AgentConfig(
+                skills=["./skills/project-notes"],
+                notes=NotesConfig(skill="project-notes"),
+            ),
+            workspace=WorkspaceConfig(results_dir=str(root / "results"), repo_path=d),
+        )
+
+        paths = create_project(config, config_dir=root)
+
+        assert (paths.coral_dir / "public" / "skills" / "project-notes" / "SKILL.md").is_file()
+
+
+def test_create_project_rejects_missing_notes_skill():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        _git_init(d)
+        root = Path(d)
+        config = CoralConfig(
+            task=TaskConfig(name="Test Task", description="Test task"),
+            grader=GraderConfig(),
+            agents=AgentConfig(notes=NotesConfig(skill="missing-notes")),
+            workspace=WorkspaceConfig(results_dir=str(root / "results"), repo_path=d),
+        )
+
+        with pytest.raises(ValueError, match="agents.notes.skill='missing-notes'"):
+            create_project(config, config_dir=root)
 
 
 def test_create_project_user_skills_override_builtin():


### PR DESCRIPTION
## Summary
- add `agents.notes.skill` with `create-notes` as the backward-compatible default
- make system, heartbeat, warm-start, and librarian prompts defer note structure and mechanics to the selected skill
- validate that the configured skill is installed after task skill overrides are applied

## Example
```yaml
agents:
  notes:
    skill: project-notes
  skills:
    - ./skills/project-notes
```

## Validation
- `uv run pytest -q` (691 passed, 1 skipped)
- `uv run ruff check coral tests`
- `uv run ruff format --check coral tests`