### PR TITLE
fix(gateway): assemble Anthropic Messages SSE streams in request log

### DIFF
--- a/coral/gateway/middleware.py
+++ b/coral/gateway/middleware.py
@@ -257,8 +257,11 @@ def _assemble_response(data: bytes) -> Any:
 
     raw = data.decode("utf-8", errors="replace")
 
-    # Check if this is an SSE stream (starts with "data: ")
-    if not raw.lstrip().startswith("data:"):
+    # Check if this is an SSE stream. OpenAI-style streams start with a
+    # "data:" field; Anthropic Messages streams start with an "event:" field
+    # (e.g. "event: message_start").
+    stripped = raw.lstrip()
+    if not (stripped.startswith("data:") or stripped.startswith("event:")):
         return _safe_parse_json(data)
 
     # Parse SSE chunks and assemble content
@@ -302,6 +305,29 @@ def _assemble_response(data: bytes) -> Any:
             status = response_obj.get("status")
             if response_obj.get("usage"):
                 usage = response_obj["usage"]
+        # Anthropic Messages API streaming format
+        elif chunk_type == "message_start":
+            message = chunk.get("message", {})
+            if not response_id and message.get("id"):
+                response_id = message["id"]
+            if not model and message.get("model"):
+                model = message["model"]
+            if isinstance(message.get("usage"), dict):
+                usage = {**(usage or {}), **message["usage"]}
+        elif chunk_type == "content_block_delta":
+            delta = chunk.get("delta", {})
+            if delta.get("type") == "text_delta":
+                text = delta.get("text", "")
+                if text:
+                    content_parts.append(text)
+        elif chunk_type == "message_delta":
+            delta = chunk.get("delta", {})
+            if delta.get("stop_reason"):
+                finish_reason = delta["stop_reason"]
+            # message_delta carries cumulative output token usage at the top
+            # level; merge it so input_tokens from message_start is kept.
+            if isinstance(chunk.get("usage"), dict):
+                usage = {**(usage or {}), **chunk["usage"]}
         # Chat Completions streaming format
         else:
             for choice in chunk.get("choices", []):
@@ -312,8 +338,8 @@ def _assemble_response(data: bytes) -> Any:
                 if choice.get("finish_reason"):
                     finish_reason = choice["finish_reason"]
 
-        if chunk.get("usage"):
-            usage = chunk["usage"]
+            if chunk.get("usage"):
+                usage = chunk["usage"]
 
     assembled: dict[str, Any] = {}
     if response_id:

--- a/tests/test_gateway_middleware.py
+++ b/tests/test_gateway_middleware.py
@@ -1,0 +1,159 @@
+"""Tests for SSE response assembly in the gateway middleware."""
+
+import json
+
+from coral.gateway.middleware import _assemble_response
+
+
+def _sse(events: list[dict], with_event_lines: bool = False) -> bytes:
+    """Render events as an SSE stream body."""
+    lines = []
+    for event in events:
+        if with_event_lines:
+            lines.append(f"event: {event.get('type', 'message')}")
+        lines.append(f"data: {json.dumps(event)}")
+        lines.append("")
+    return "\n".join(lines).encode("utf-8")
+
+
+def test_non_sse_json_body_is_parsed() -> None:
+    body = json.dumps({"id": "resp_1", "object": "chat.completion"}).encode()
+    assert _assemble_response(body) == {"id": "resp_1", "object": "chat.completion"}
+
+
+def test_empty_body_returns_none() -> None:
+    assert _assemble_response(b"") is None
+
+
+def test_chat_completions_stream_assembly() -> None:
+    events = [
+        {
+            "id": "chatcmpl-1",
+            "model": "gpt-x",
+            "choices": [{"delta": {"content": "Hello"}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1",
+            "choices": [{"delta": {"content": " world"}, "finish_reason": "stop"}],
+        },
+        {"id": "chatcmpl-1", "choices": [], "usage": {"total_tokens": 7}},
+    ]
+    raw = _sse(events) + b"data: [DONE]\n"
+
+    assembled = _assemble_response(raw)
+
+    assert assembled == {
+        "id": "chatcmpl-1",
+        "model": "gpt-x",
+        "content": "Hello world",
+        "finish_reason": "stop",
+        "usage": {"total_tokens": 7},
+    }
+
+
+def test_responses_api_stream_assembly() -> None:
+    events = [
+        {"type": "response.output_text.delta", "delta": "Hi"},
+        {"type": "response.output_text.delta", "delta": " there"},
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_9",
+                "model": "gpt-x",
+                "status": "completed",
+                "usage": {"total_tokens": 11},
+            },
+        },
+    ]
+
+    assembled = _assemble_response(_sse(events))
+
+    assert assembled == {
+        "id": "resp_9",
+        "model": "gpt-x",
+        "content": "Hi there",
+        "status": "completed",
+        "usage": {"total_tokens": 11},
+    }
+
+
+def test_anthropic_messages_stream_assembly() -> None:
+    events = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "model": "claude-x",
+                "usage": {"input_tokens": 25, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": " world"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 6},
+        },
+        {"type": "message_stop"},
+    ]
+
+    # The Anthropic SDK emits "event: <type>" lines before each data line,
+    # so the stream starts with "event: message_start", not "data:".
+    assembled = _assemble_response(_sse(events, with_event_lines=True))
+
+    assert assembled == {
+        "id": "msg_1",
+        "model": "claude-x",
+        "content": "Hello world",
+        "finish_reason": "end_turn",
+        "usage": {"input_tokens": 25, "output_tokens": 6},
+    }
+
+
+def test_anthropic_non_text_deltas_are_ignored() -> None:
+    events = [
+        {
+            "type": "message_start",
+            "message": {"id": "msg_2", "model": "claude-x", "usage": {"input_tokens": 3}},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '{"city": "SF"}'},
+        },
+        {"type": "ping"},
+        {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {}},
+    ]
+
+    assembled = _assemble_response(_sse(events, with_event_lines=True))
+
+    assert "content" not in assembled
+    assert assembled["finish_reason"] == "tool_use"
+
+
+def test_invalid_json_frames_are_skipped() -> None:
+    raw = (
+        b"data: not-json\n\n"
+        b'data: {"id": "chatcmpl-2", "choices": '
+        b'[{"delta": {"content": "ok"}, "finish_reason": "stop"}]}\n\n'
+        b"data: [DONE]\n"
+    )
+
+    assembled = _assemble_response(raw)
+
+    assert assembled["content"] == "ok"
+    assert assembled["finish_reason"] == "stop"


### PR DESCRIPTION
## Motivation

The gateway middleware intercepts `/v1/messages` (it's in `_is_api_path`), but `_assemble_response` only understands OpenAI Chat Completions and Responses API streaming formats. Streaming responses from the Anthropic Messages API are mishandled in two ways:

1. The SSE sniff checks for a leading `data:` line, but the Anthropic SDK emits `event: <type>` lines before each data line, so the stream starts with `event: message_start`. The whole body falls through to `_safe_parse_json` and gets logged as one raw SSE text blob in `requests.jsonl`.
2. Even past the sniff, the Anthropic event types (`message_start`, `content_block_delta`, `message_delta`) are not handled, so no content, stop reason, or usage would be assembled.

Anyone running an agent through the gateway with the Anthropic SDK (e.g. Claude Code against a `-anthropic` route) gets unreadable response logs.

## Changes

- Recognize `event:`-prefixed bodies as SSE streams in `_assemble_response`.
- Assemble Anthropic Messages streaming events: text from `content_block_delta` (`text_delta` only), `id`/`model`/input usage from `message_start`, `stop_reason` (mapped to the log's `finish_reason` field) and output usage from `message_delta`. Usage dicts are merged so `input_tokens` from `message_start` survives the `message_delta` update.
- Moved the generic top-level `usage` capture into the Chat Completions branch so it no longer clobbers the merged Anthropic usage (Anthropic `message_delta` carries top-level `usage` with only `output_tokens`).
- Non-text deltas (`input_json_delta`, `thinking_delta`) are intentionally left out of `content` — same spirit as the existing OpenAI branches, which only assemble text.

## Test plan

- `uv run pytest tests/test_gateway_middleware.py -v` — 7 passed (new file: Anthropic assembly, non-text delta handling, plus regression tests for Chat Completions, Responses API, non-SSE JSON, and invalid-frame skipping).
- `uv run pytest tests/ -q` — 721 passed, 1 skipped. (One pre-existing, unrelated env-only failure deselected on my machine: `test_setup_grader_env_creates_venv` fails on AL2/glibc-2.26 because tiktoken has no compatible wheel and the test's cleaned env has no Rust toolchain.)
- `uv run ruff check .` and `uv run ruff format --check .` — clean.

## Affected areas

- [x] `coral/gateway/` (LiteLLM gateway)

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs — none needed: log format gains fields for Anthropic streams only; no config/CLI/contract change.
- [ ] Config/CLI/hook/runtime contract change — n/a.
- [ ] New `examples/<task>/` — n/a.
- [x] AI-assisted PR: a human author has read every changed line and can defend the design.
