### PR TITLE
fix(gateway): warn when an unrecognized proxy key is attributed to the sole agent

### DIFF
--- a/coral/gateway/middleware.py
+++ b/coral/gateway/middleware.py
@@ -33,6 +33,7 @@ class CoralGatewayMiddleware:
         self.master_key = master_key
         self._agent_map: dict[str, AgentInfo] = {}  # proxy_key -> agent info
         self._hash_cache: dict[str, tuple[str, float]] = {}  # worktree -> (hash, timestamp)
+        self._warned_unknown_keys: set[str] = set()  # keys already warned about
 
         # Ensure log directory exists
         self.log_dir.mkdir(parents=True, exist_ok=True)
@@ -65,9 +66,21 @@ class CoralGatewayMiddleware:
         info = self._agent_map.get(token)
         if info:
             return info
-        # Key not recognized — fall back to sole agent if only one registered
+        # Key present but not recognized — fall back to sole agent if only one
+        # is registered, but warn: unlike a missing key, a mismatched key
+        # usually means a stale or misconfigured proxy key, and silently
+        # attributing the traffic would mask that.
         if len(self._agent_map) == 1:
-            return next(iter(self._agent_map.values()))
+            fallback = next(iter(self._agent_map.values()))
+            if token not in self._warned_unknown_keys:
+                self._warned_unknown_keys.add(token)
+                logger.warning(
+                    "Gateway received a bearer key that does not match any "
+                    f"registered proxy key; attributing traffic to the sole "
+                    f"registered agent '{fallback.agent_id}'. This may "
+                    "indicate a stale or misconfigured key."
+                )
+            return fallback
         return None
 
     def _get_commit_hash(self, worktree_path: Path) -> str:

--- a/tests/test_gateway_agent_auth.py
+++ b/tests/test_gateway_agent_auth.py
@@ -1,0 +1,84 @@
+"""Tests for agent identification from auth headers in the gateway middleware."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from coral.gateway.middleware import CoralGatewayMiddleware
+
+
+@pytest.fixture
+def middleware(tmp_path: Path) -> CoralGatewayMiddleware:
+    async def dummy_app(scope, receive, send):  # pragma: no cover - never called
+        raise AssertionError("app should not be called in these tests")
+
+    return CoralGatewayMiddleware(dummy_app, log_dir=tmp_path, master_key="master")
+
+
+def test_matching_key_returns_agent(middleware: CoralGatewayMiddleware, tmp_path: Path) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+    middleware.register_agent("agent-2", tmp_path, "key-2")
+
+    info = middleware._get_agent_info("Bearer key-2")
+
+    assert info is not None
+    assert info.agent_id == "agent-2"
+
+
+def test_missing_header_falls_back_to_sole_agent_without_warning(
+    middleware: CoralGatewayMiddleware,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        info = middleware._get_agent_info("")
+
+    assert info is not None
+    assert info.agent_id == "agent-1"
+    assert not caplog.records
+
+
+def test_mismatched_key_falls_back_to_sole_agent_with_warning(
+    middleware: CoralGatewayMiddleware,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        info = middleware._get_agent_info("Bearer stale-key")
+
+    assert info is not None
+    assert info.agent_id == "agent-1"
+    assert len(caplog.records) == 1
+    assert "does not match any registered proxy key" in caplog.records[0].message
+    # The unrecognized key itself must not leak into the log
+    assert "stale-key" not in caplog.records[0].message
+
+
+def test_mismatched_key_warns_only_once_per_key(
+    middleware: CoralGatewayMiddleware,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        middleware._get_agent_info("Bearer stale-key")
+        middleware._get_agent_info("Bearer stale-key")
+        middleware._get_agent_info("Bearer other-stale-key")
+
+    assert len(caplog.records) == 2
+
+
+def test_mismatched_key_with_multiple_agents_returns_none(
+    middleware: CoralGatewayMiddleware, tmp_path: Path
+) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+    middleware.register_agent("agent-2", tmp_path, "key-2")
+
+    assert middleware._get_agent_info("Bearer stale-key") is None
+    assert middleware._get_agent_info("") is None


### PR DESCRIPTION
## Motivation

`CoralGatewayMiddleware._get_agent_info` falls back to the sole registered agent when the presented bearer key doesn't match any registered proxy key. The docstring says this is intentional (OpenCode sends a static `apiKey` from `opencode.json`), and this PR keeps that behavior. The problem is that the same code path also silently swallows genuinely wrong keys — e.g. a stale proxy key left over from a previous run — so traffic gets attributed to the agent with no signal that identification actually failed.

## Changes

- Distinguish "no key presented" from "key presented but unrecognized" in `_get_agent_info`. The missing-key fallback stays silent (that's the supported OpenCode-style path); the mismatched-key fallback now logs a warning naming the agent the traffic is being attributed to.
- The warning fires once per distinct unknown key (tracked in a small in-memory set) so a stale key doesn't flood the log on every request.
- The key material itself is never written to the log.

No behavior change for which agent gets returned — only observability.

## Test plan

- `uv run pytest tests/test_gateway_agent_auth.py -v` — 5 passed (new file: matching key, missing key silent fallback, mismatched key warns, warn-once-per-key, multi-agent returns None; asserts the key never appears in the log record).
- `uv run pytest tests/ -q` — 719 passed, 1 skipped. (One pre-existing, unrelated env-only failure deselected on my machine: `test_setup_grader_env_creates_venv` fails on AL2/glibc-2.26 because tiktoken has no compatible wheel there.)
- `uv run ruff check .` and `uv run ruff format --check .` — clean.

## Affected areas

- [x] `coral/gateway/` (LiteLLM gateway)

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs — none needed: log-only change, no config/CLI/contract change.
- [ ] Config/CLI/hook/runtime contract change — n/a.
- [ ] New `examples/<task>/` — n/a.
- [x] AI-assisted PR: a human author has read every changed line and can defend the design.
