### PR TITLE
feat(gateway): optional header_provider hook for stamping extra request headers

### DIFF
--- a/coral/gateway/middleware.py
+++ b/coral/gateway/middleware.py
@@ -7,6 +7,7 @@ import logging
 import subprocess
 import time
 import uuid
+from collections.abc import Callable, Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 # Cache commit hashes briefly to avoid hammering git on every request
 _HASH_CACHE_TTL = 2.0  # seconds
+
+# Optional callback stamping extra request headers: receives the identified
+# agent (or None) and the ASGI scope, returns header name/value byte pairs.
+HeaderProvider = Callable[["AgentInfo | None", dict[str, Any]], Iterable[tuple[bytes, bytes]]]
 
 
 class CoralGatewayMiddleware:
@@ -25,12 +30,25 @@ class CoralGatewayMiddleware:
     2. Reads the agent's current git commit hash (cached briefly)
     3. Adds X-Coral-Agent-Id and X-Coral-Session-Id headers
     4. Logs request and assembled response as linked JSONL entries
+
+    An optional ``header_provider`` callback can stamp additional request
+    headers (e.g. experiment or trace metadata) without forking the
+    middleware. It is called with the identified agent (or ``None``) and the
+    ASGI scope, and must return an iterable of ``(name, value)`` byte pairs.
+    A failing provider is logged and skipped; it never breaks the request.
     """
 
-    def __init__(self, app: Any, log_dir: Path, master_key: str) -> None:
+    def __init__(
+        self,
+        app: Any,
+        log_dir: Path,
+        master_key: str,
+        header_provider: HeaderProvider | None = None,
+    ) -> None:
         self.app = app
         self.log_dir = log_dir
         self.master_key = master_key
+        self.header_provider = header_provider
         self._agent_map: dict[str, AgentInfo] = {}  # proxy_key -> agent info
         self._hash_cache: dict[str, tuple[str, float]] = {}  # worktree -> (hash, timestamp)
 
@@ -174,6 +192,24 @@ class CoralGatewayMiddleware:
         # Add CORAL-specific headers
         new_headers.append((b"x-coral-agent-id", agent_id.encode("latin-1")))
         new_headers.append((b"x-coral-session-id", session_id.encode("latin-1")))
+
+        # Let integrations stamp extra metadata headers. Validate the pairs
+        # before extending so a misbehaving provider can't half-apply or
+        # break the request.
+        if self.header_provider is not None:
+            try:
+                extra_headers = [
+                    (bytes(name), bytes(value))
+                    for name, value in self.header_provider(agent_info, scope)
+                ]
+            except Exception:
+                logger.warning(
+                    "Gateway header_provider raised; skipping extra headers",
+                    exc_info=True,
+                )
+            else:
+                new_headers.extend(extra_headers)
+
         scope["headers"] = new_headers
 
         # Track response

--- a/coral/gateway/server.py
+++ b/coral/gateway/server.py
@@ -16,7 +16,7 @@ import uvicorn
 from litellm.proxy.proxy_server import app as litellm_app
 from litellm.proxy.proxy_server import initialize
 
-from coral.gateway.middleware import CoralGatewayMiddleware
+from coral.gateway.middleware import CoralGatewayMiddleware, HeaderProvider
 
 logger = logging.getLogger(__name__)
 
@@ -37,11 +37,13 @@ class GatewayManager:
         config_path: str,
         api_key: str = "",
         log_dir: Path | None = None,
+        header_provider: HeaderProvider | None = None,
     ) -> None:
         self.port = port
         self.config_path = config_path
         self.api_key = api_key or f"sk-coral-{secrets.token_hex(8)}"
         self.log_dir = log_dir or Path(".coral/gateway")
+        self.header_provider = header_provider
         self._server_thread: threading.Thread | None = None
         self._server: object | None = None  # uvicorn.Server
         self._middleware: object | None = None  # CoralGatewayMiddleware
@@ -88,6 +90,7 @@ class GatewayManager:
             app=litellm_app,
             log_dir=self.log_dir,
             master_key=self.api_key,
+            header_provider=self.header_provider,
         )
         self._middleware = middleware
 

--- a/tests/test_gateway_header_hook.py
+++ b/tests/test_gateway_header_hook.py
@@ -1,0 +1,156 @@
+"""Tests for the optional header_provider hook in the gateway middleware."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from coral.gateway.middleware import CoralGatewayMiddleware
+
+
+class FakeApp:
+    """Minimal ASGI app that captures the scope and returns a JSON body."""
+
+    def __init__(self) -> None:
+        self.captured_scope: dict | None = None
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        self.captured_scope = scope
+        await receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b'{"ok": true}'})
+
+
+def _make_scope() -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "headers": [
+            (b"authorization", b"Bearer key-1"),
+            (b"content-type", b"application/json"),
+        ],
+    }
+
+
+async def _run_request(middleware: CoralGatewayMiddleware, scope: dict) -> list[dict]:
+    sent: list[dict] = []
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b'{"model": "m"}', "more_body": False}
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+def _headers(app: FakeApp) -> dict[bytes, bytes]:
+    assert app.captured_scope is not None
+    return dict(app.captured_scope["headers"])
+
+
+async def test_no_provider_keeps_existing_behavior(tmp_path: Path) -> None:
+    app = FakeApp()
+    middleware = CoralGatewayMiddleware(app, log_dir=tmp_path, master_key="master")
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    sent = await _run_request(middleware, _make_scope())
+
+    headers = _headers(app)
+    assert headers[b"authorization"] == b"Bearer master"
+    assert headers[b"x-coral-agent-id"] == b"agent-1"
+    assert b"x-coral-session-id" in headers
+    assert sent[-1]["body"] == b'{"ok": true}'
+
+
+async def test_provider_headers_are_appended(tmp_path: Path) -> None:
+    app = FakeApp()
+    seen: list[tuple] = []
+
+    def provider(agent_info, scope):
+        seen.append((agent_info, scope))
+        return [(b"x-experiment-id", b"exp-42")]
+
+    middleware = CoralGatewayMiddleware(
+        app, log_dir=tmp_path, master_key="master", header_provider=provider
+    )
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    await _run_request(middleware, _make_scope())
+
+    assert _headers(app)[b"x-experiment-id"] == b"exp-42"
+    assert len(seen) == 1
+    agent_info, scope = seen[0]
+    assert agent_info is not None
+    assert agent_info.agent_id == "agent-1"
+    assert scope["path"] == "/v1/chat/completions"
+
+
+async def test_provider_gets_none_for_unknown_agent(tmp_path: Path) -> None:
+    app = FakeApp()
+    seen: list[Any] = []
+
+    def provider(agent_info, scope):
+        seen.append(agent_info)
+        return []
+
+    middleware = CoralGatewayMiddleware(
+        app, log_dir=tmp_path, master_key="master", header_provider=provider
+    )
+    # Two agents registered and a non-matching key -> no identification
+    middleware.register_agent("agent-1", tmp_path, "key-a")
+    middleware.register_agent("agent-2", tmp_path, "key-b")
+
+    await _run_request(middleware, _make_scope())
+
+    assert seen == [None]
+
+
+async def test_raising_provider_does_not_break_request(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    app = FakeApp()
+
+    def provider(agent_info, scope):
+        raise RuntimeError("boom")
+
+    middleware = CoralGatewayMiddleware(
+        app, log_dir=tmp_path, master_key="master", header_provider=provider
+    )
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        sent = await _run_request(middleware, _make_scope())
+
+    # Request still went through with the standard headers
+    headers = _headers(app)
+    assert headers[b"x-coral-agent-id"] == b"agent-1"
+    assert sent[-1]["body"] == b'{"ok": true}'
+    assert any("header_provider raised" in r.message for r in caplog.records)
+
+
+async def test_invalid_provider_result_is_skipped_atomically(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    app = FakeApp()
+
+    def provider(agent_info, scope):
+        # First pair valid, second is str, which is not a valid header value
+        return [(b"x-good", b"1"), (b"x-bad", "not-bytes")]
+
+    middleware = CoralGatewayMiddleware(
+        app, log_dir=tmp_path, master_key="master", header_provider=provider
+    )
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        await _run_request(middleware, _make_scope())
+
+    # Neither header applied: partial application would be worse than none
+    headers = _headers(app)
+    assert b"x-good" not in headers
+    assert b"x-bad" not in headers
+    assert any("header_provider raised" in r.message for r in caplog.records)


### PR DESCRIPTION
## Motivation

`CoralGatewayMiddleware` hardcodes the headers it injects (`x-coral-agent-id`, `x-coral-session-id`). An integration that wants to stamp extra per-request metadata — an experiment id, a trace id for an observability backend, a rollout tag — has to either fork the middleware or wrap the whole ASGI app and re-implement agent identification to know which agent the request belongs to.

Opening as a **draft proposal** per CONTRIBUTING's discussion-first guidance for design changes — happy to move this to a Discussion or resize the surface (e.g. different callback signature) if you'd prefer.

## Changes

- New optional `header_provider` callback on `CoralGatewayMiddleware`, exposed as a `HeaderProvider` type alias: `(agent_info: AgentInfo | None, scope: dict) -> Iterable[tuple[bytes, bytes]]`. Returned pairs are appended after the built-in CORAL headers.
- Plumbed through `GatewayManager.__init__` so embedders can pass it without touching middleware construction.
- Failure isolation: the provider's result is validated and applied atomically — if it raises or returns non-byte pairs, the request proceeds with only the standard headers and a warning is logged. A hook must never break agent traffic.
- Default is `None`; behavior is byte-for-byte unchanged unless a provider is passed. No config field, CLI flag, or task.yaml surface is added.

## Test plan

- `uv run pytest tests/test_gateway_header_hook.py -v` — 5 passed (fake ASGI app: no provider → unchanged behavior incl. master-key auth swap; provider present → headers stamped and callback sees AgentInfo + scope; provider gets `None` for unidentified agents; raising provider doesn't break the request; invalid output skipped atomically).
- `uv run pytest tests/ -q` — 719 passed, 1 skipped. (One pre-existing, unrelated env-only failure deselected on my machine: `test_setup_grader_env_creates_venv` on AL2/glibc-2.26, tiktoken has no compatible wheel there.)
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run mypy coral/gateway/` — same 10 pre-existing errors as `dev`; this change adds none.

## Affected areas

- [x] `coral/gateway/` (LiteLLM gateway)

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs — the gateway guide (`docs/content/docs/guides/gateway.mdx`) documents the task.yaml surface only; this hook is a programmatic embedder API documented in the class docstring. Can add a docs section if you want it user-facing.
- [x] Config/CLI/hook/runtime contract change — additive keyword argument, default `None`; no migration needed.
- [ ] New `examples/<task>/` — n/a.
- [x] AI-assisted PR: a human author has read every changed line and can defend the design.
