### PR TITLE
fix(agent): use cross-platform venv paths and utf-8 log in DeepSeek Harness runtime

### DIFF
--- a/coral/agent/builtin/deepseek_harness.py
+++ b/coral/agent/builtin/deepseek_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -20,6 +21,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -139,7 +141,10 @@ class DeepSeekHarnessRuntime:
         worktree_venv = str(worktree_path / ".venv")
         agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        agent_env["PATH"] = str(worktree_path / ".venv" / "bin") + ":" + agent_env.get("PATH", "")
+        # Prepend the venv executable dir (bin or Scripts) to PATH, matching
+        # the platform-aware resolution used by the other builtin runtimes.
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
+        agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
         agent_env["DSH_HOME"] = str(dsh_home)
 
         permission_mode = opts.get("permission_mode")
@@ -156,7 +161,7 @@ class DeepSeekHarnessRuntime:
         apply_sandbox_env(agent_env, sandbox)
         user_kwargs = apply_run_as_user(agent_env, run_as_user)
 
-        log_file = open(log_path, "w", buffering=1)
+        log_file = open(log_path, "w", buffering=1, encoding="utf-8", errors="replace")
         err_path: Path | None = None
         err_file: Any = None
         stderr_target: Any = subprocess.STDOUT

--- a/tests/test_deepseek_harness.py
+++ b/tests/test_deepseek_harness.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -151,3 +153,52 @@ def test_restart_does_not_invent_unsupported_resume_flag(
     assert cmd[:3] == ["dsh", "--profile", "headless"]
     assert cmd[-1] == "continue"
     assert "--resume" not in cmd
+
+
+def test_start_prepends_platform_aware_venv_bin_to_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """PATH must use the platform's venv executable dir (bin/ vs Scripts/).
+
+    Guards the cross-platform venv path contract (#231): a hardcoded
+    ``.venv/bin`` would point at a nonexistent directory on Windows.
+    """
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    worktree = _make_worktree(tmp_path)
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    DeepSeekHarnessRuntime().start(
+        worktree_path=worktree,
+        coral_md_path=worktree / "AGENTS.md",
+        log_dir=tmp_path / "logs",
+        prompt="task",
+    )
+
+    path_value = _FakePopen.captured[0]["kwargs"]["env"]["PATH"]
+    first_entry = path_value.split(os.pathsep)[0]
+    assert first_entry == str(worktree / ".venv" / "Scripts")
+
+
+def test_start_opens_log_file_utf8_with_replacement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The agent log must be UTF-8 with errors='replace' like all runtimes.
+
+    Without an explicit encoding, the log file inherits the locale encoding,
+    and the verbose tee (which writes UTF-8-decoded agent output through this
+    handle) raises UnicodeEncodeError under a non-UTF-8 locale.
+    """
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    worktree = _make_worktree(tmp_path)
+
+    handle = DeepSeekHarnessRuntime().start(
+        worktree_path=worktree,
+        coral_md_path=worktree / "AGENTS.md",
+        log_dir=tmp_path / "logs",
+        prompt="task",
+    )
+
+    log_file = handle._log_file
+    assert log_file is not None
+    assert log_file.encoding.lower().replace("-", "") == "utf8"
+    assert log_file.errors == "replace"


### PR DESCRIPTION
## Motivation

The DeepSeek Harness runtime added in #248 predates none of, but diverges from, the cross-platform venv path contract centralized in #231: it hardcodes the POSIX venv layout for the agent `PATH` and opens its log file without an explicit encoding, unlike all six sibling builtin runtimes.

Two concrete failure modes:

- On Windows, `PATH` gets `<worktree>/.venv/bin` (nonexistent; the executables live in `Scripts/`) joined with `':'` instead of `os.pathsep`, so the venv's `python`/`uv` are never found — exactly the bug class #231 fixed for the other runtimes.
- The log file inherits the locale encoding with `errors='strict'`. The verbose tee thread writes UTF-8-decoded agent output through that handle, so any non-ASCII output under a non-UTF-8 locale (e.g. `LC_ALL=C`) raises `UnicodeEncodeError` and kills the tee.

## Changes

- `coral/agent/builtin/deepseek_harness.py`: build the agent `PATH` from `venv_bin_dir(...)` + `os.pathsep` (same as claude_code/codex/cursor/opencode/pi_agent), and open the log with `encoding="utf-8", errors="replace"` (same as all other runtimes).

## Test plan

Two new tests in `tests/test_deepseek_harness.py`; both fail on `dev` and pass with this change:

- `test_start_prepends_platform_aware_venv_bin_to_path` — monkeypatches `sys.platform = "win32"` and asserts the first `PATH` entry is the `Scripts/` dir.
- `test_start_opens_log_file_utf8_with_replacement` — asserts the handle's log file is UTF-8 with `errors='replace'`.

```
uv run pytest tests/test_deepseek_harness.py -q   # 11 passed
uv run pytest tests/ -q                           # 716 passed, 1 skipped
uv run ruff check . && uv run ruff format --check .   # clean
```

(1 deselected: `tests/test_grader_env.py::test_setup_grader_env_creates_venv` — pre-existing environment-only failure on this host, unrelated.)

## Affected areas

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart)

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs — n/a, no user-visible contract change (bug fix restoring the documented cross-platform behavior).
- [x] No config field / CLI flag / hook contract change.
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design.