### PR TITLE
fix(task): report validation baseline target consistently for empty seed dirs

### DIFF
--- a/coral/task/validation.py
+++ b/coral/task/validation.py
@@ -299,7 +299,12 @@ async def run_validation_async(
         try:
             workspace.mkdir()
             seed_dir = task_dir / "seed"
-            has_seed = seed_dir.is_dir() and any(seed_dir.iterdir())
+            # Mirror the copy loop below: a seed/ that exists but contributes
+            # nothing to the workspace (empty, or only __pycache__) is treated
+            # as absent so the progress messages describe what actually runs.
+            has_seed = seed_dir.is_dir() and any(
+                item.name != "__pycache__" for item in seed_dir.iterdir()
+            )
             if has_seed:
                 for item in seed_dir.iterdir():
                     if item.name == "__pycache__":
@@ -369,7 +374,7 @@ async def run_validation_async(
             name=config.task.name,
             description=config.task.description,
         )
-        target = "seed code" if seed_dir.is_dir() else "empty workspace"
+        target = "seed code" if has_seed else "empty workspace"
         emit("baseline", "started", f"Running grader against {target}...")
         try:
             baseline = await grader.grade(str(workspace), [task])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -196,6 +196,51 @@ def test_run_validation_returns_baseline_and_progress_events(tmp_path, monkeypat
     ]
 
 
+@pytest.mark.parametrize(
+    "seed_contents",
+    [
+        pytest.param(None, id="no-seed-dir"),
+        pytest.param([], id="empty-seed-dir"),
+        pytest.param(["__pycache__"], id="pycache-only-seed-dir"),
+    ],
+)
+def test_run_validation_reports_empty_workspace_consistently(tmp_path, monkeypatch, seed_contents):
+    """When nothing lands in the workspace, both the workspace warning and the
+    baseline-target message must say so — previously a seed/ dir that existed
+    but contributed nothing produced the 'No seed/' warning and then claimed
+    to run the grader 'against seed code'."""
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+    if seed_contents is not None:
+        seed_dir = task_dir / "seed"
+        seed_dir.mkdir()
+        for name in seed_contents:
+            (seed_dir / name).mkdir()
+
+    class FakeGrader:
+        async def grade(self, codebase_path, tasks):
+            assert list(Path(codebase_path).iterdir()) == []
+            return ScoreBundle(
+                scores={"eval": Score(value=0.0, name="eval", explanation="empty")},
+                aggregated=0.0,
+            )
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: None,
+    )
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: FakeGrader(),
+    )
+
+    result = task_validation.run_validation(task_dir)
+
+    assert result.successful
+    events = {(event.stage, event.status): event.message for event in result.events}
+    assert "No seed/ directory" in events[("workspace", "completed")]
+    assert events[("baseline", "started")] == "Running grader against empty workspace..."
+
+
 async def test_run_validation_async_runs_inside_existing_event_loop(tmp_path, monkeypatch):
     task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
 


### PR DESCRIPTION
## Motivation

Found while reading the new structured validation runner (#249/#250): when `seed/` exists but contributes nothing to the validation workspace, `coral validate` contradicts itself. The workspace stage warns

```
Warning: No seed/ directory — grader will run against an empty workspace.
```

and the baseline stage then announces

```
Running grader against seed code...
```

because the baseline-target message keys off `seed_dir.is_dir()` while the workspace message keys off "did anything get copied". A related edge: a `seed/` containing only `__pycache__` (which the copy loop deliberately skips) reports `Seed: copied seed/ into workspace` even though the workspace stays empty.

## Changes

- `coral/task/validation.py`: base the baseline-target message on the same `has_seed` decision the workspace message uses, and treat a `__pycache__`-only `seed/` as empty (mirroring the copy loop) so both stages describe what the grader actually runs against.

## Test plan

New parametrized test `test_run_validation_reports_empty_workspace_consistently` (no seed dir / empty seed dir / `__pycache__`-only seed dir) asserting the workspace warning and the baseline-target message agree. The empty-dir and `__pycache__`-only cases fail on `dev` and pass with this change; the no-seed-dir case pins the already-correct path.

```
uv run pytest tests/test_validation.py -q   # 29 passed
uv run pytest tests/ -q                     # 717 passed, 1 skipped
uv run ruff check . && uv run ruff format --check .   # clean
```

(1 deselected: `tests/test_grader_env.py::test_setup_grader_env_creates_venv` — pre-existing environment-only failure on this host, unrelated.)

## Affected areas

- [x] Other: `coral/task/` (validation runner)

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs — n/a (progress-message fix; no documented contract changes).
- [x] No config field / CLI flag / hook / runtime contract change.
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design.