### PR TITLE
docs(cli): document coral wait and the missing coral eval flags

### DIFF
--- a/docs/content/docs/cli/reference.mdx
+++ b/docs/content/docs/cli/reference.mdx
@@ -353,10 +353,12 @@ These commands are primarily used by agents during their eval loop, but can also
 
 ### `coral eval`
 
-Stage all changes, commit, and run the grader.
+Stage all changes, commit, and run the grader. By default this blocks until
+the grader daemon returns a score; use `--no-wait` to return immediately and
+poll later with [`coral wait`](#coral-wait).
 
 ```bash
-coral eval -m <message> [--agent ID] [--workdir DIR]
+coral eval -m <message> [--agent ID] [--workdir DIR] [--no-wait] [--timeout SECONDS] [--tune]
 ```
 
 | Flag | Description |
@@ -364,9 +366,34 @@ coral eval -m <message> [--agent ID] [--workdir DIR]
 | `-m, --message` | Description of changes (required) |
 | `--agent` | Agent ID (default: read from `.coral_agent_id`) |
 | `--workdir` | Working directory (default: cwd) |
+| `--wait / --no-wait` | Wait for the grader to return a score (default: wait). With `--no-wait`, returns immediately with a pending status |
+| `--timeout` | Seconds to wait for the grader (default: derived from `grader.timeout`) |
+| `--tune` | Submit as a tune-mode attempt: scored and recorded normally, but excluded from the agent's plateau / heartbeat budget. Use for hyperparameter sweeps and config exploration that shouldn't trigger pivot prompts |
 
 ```bash
 coral eval -m "Optimized inner loop with vectorization"
+coral eval -m "Try variant A" --no-wait
+coral eval -m "Heavy benchmark" --timeout 1800
+coral eval --tune -m "Sweep lr=1e-3 vs 3e-4"
+```
+
+### `coral wait`
+
+Block until the grader daemon finalizes a previously submitted attempt
+(e.g. one submitted with `coral eval --no-wait`).
+
+```bash
+coral wait <hash> [--workdir DIR] [--timeout SECONDS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--workdir` | Working directory (default: cwd) |
+| `--timeout` | Seconds to wait (default: derived from `grader.timeout`) |
+
+```bash
+coral wait abc123
+coral wait abc123 --timeout 600
 ```
 
 ### `coral diff`


### PR DESCRIPTION
## Motivation

Docs-vs-code drift in the CLI reference (`docs/content/docs/cli/reference.mdx`):

- `coral wait` has no section at all, even though the command exists, `coral --help` lists it under Agent Internals, `coral eval --help` points to it for the `--no-wait` workflow, and it is already referenced by `configuration.mdx`, `eval-loop.mdx`, and the agent-facing `CORAL.md` templates.
- The `coral eval` flag table is missing `--wait/--no-wait`, `--timeout`, and `--tune`, all present in the current CLI.

## Changes

- Expand the `coral eval` section: blocking-by-default behavior, the three missing flags, and the `--no-wait`/`--timeout`/`--tune` examples from the CLI help.
- Add a `coral wait` section (usage, flags, examples) between `coral eval` and `coral diff`, matching the command's argparse help.

Docs only; no code changes. All flag descriptions mirror the current `--help` output.

## Test plan

- `uv run pytest tests/ -q` — 714 passed, 1 skipped (no code touched; 1 deselected: `tests/test_grader_env.py::test_setup_grader_env_creates_venv`, pre-existing environment-only failure on this host).
- `uv run ruff check .` — clean.
- Verified every documented flag against `uv run coral eval --help` and `uv run coral wait --help` on `dev`.

## Affected areas

- [x] `docs/` (docs site)

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Tests — n/a, docs-only change.
- [x] Updated docs for the user-visible contract (that is this PR).
- [x] No config field / CLI flag / hook / runtime contract change.
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design.