### PR TITLE
fix(cli): give the hidden test-eval alias the arguments validate expects

### DIFF
--- a/coral/cli/__init__.py
+++ b/coral/cli/__init__.py
@@ -176,8 +176,11 @@ Run 'coral <command> --help' for details on any command."""
         action="store_true",
         help="Output one machine-readable validation result",
     )
-    # Hidden alias: test-eval -> validate
-    sub.add_parser("test-eval", help=argparse.SUPPRESS)
+    # Hidden alias: test-eval -> validate (mirror validate's arguments so the
+    # alias can actually dispatch; cmd_validate reads args.path)
+    p_test_eval = sub.add_parser("test-eval", help=argparse.SUPPRESS)
+    p_test_eval.add_argument("path", help=argparse.SUPPRESS)
+    p_test_eval.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
 
     # --- Running Agents ---
 

--- a/tests/test_cli_test_eval_alias.py
+++ b/tests/test_cli_test_eval_alias.py
@@ -1,0 +1,53 @@
+"""Tests for the hidden ``coral test-eval`` -> ``coral validate`` alias.
+
+The alias parser must accept the same arguments as ``validate``; otherwise it
+cannot dispatch (``cmd_validate`` reads ``args.path``).
+"""
+
+import sys
+
+import pytest
+
+import coral.cli as cli_module
+import coral.cli.author as author_module
+
+
+def _capture_cmd_validate(monkeypatch, captured: dict) -> None:
+    def fake_cmd_validate(args):
+        captured["path"] = args.path
+        captured["json"] = getattr(args, "json", False)
+
+    monkeypatch.setattr(author_module, "cmd_validate", fake_cmd_validate)
+
+
+def test_test_eval_alias_forwards_path(monkeypatch):
+    captured: dict = {}
+    _capture_cmd_validate(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["coral", "test-eval", "my-task"])
+
+    cli_module.main()
+
+    assert captured == {"path": "my-task", "json": False}
+
+
+def test_test_eval_alias_accepts_json_flag(monkeypatch):
+    captured: dict = {}
+    _capture_cmd_validate(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["coral", "test-eval", "my-task", "--json"])
+
+    cli_module.main()
+
+    assert captured == {"path": "my-task", "json": True}
+
+
+def test_test_eval_alias_without_path_exits_with_usage_error(monkeypatch, capsys):
+    """A missing positional must be an argparse usage error, not a traceback."""
+    captured: dict = {}
+    _capture_cmd_validate(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["coral", "test-eval"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_module.main()
+
+    assert excinfo.value.code == 2
+    assert captured == {}


### PR DESCRIPTION
## Motivation

The hidden backward-compatibility alias `coral test-eval` (kept for the pre-rename `validate` workflow) is unusable in both invocation forms, because its subparser declares no arguments while its handler is `cmd_validate`, which reads `args.path`:

```
$ coral test-eval my-task
error: unrecognized arguments: my-task     # exits 2 with usage help

$ coral test-eval
AttributeError: 'Namespace' object has no attribute 'path'   # traceback from cmd_validate
```

The other hidden aliases (`attempts`, `attempt`) mirror the arguments of the commands they forward to; `test-eval` is the only one that doesn't.

## Changes

- `coral/cli/__init__.py`: give the `test-eval` subparser the same arguments as `validate` (`path` positional, `--json` from #253), suppressed from help output. A bare `coral test-eval` now produces a normal argparse usage error instead of a traceback.

## Test plan

New `tests/test_cli_test_eval_alias.py` with three tests (path forwarding, `--json` forwarding, missing-positional usage error) — all three fail on current `dev` and pass with the fix.

- `uv run pytest -q` — 718 passed, 1 skipped
- `uv run ruff check .` and `uv run ruff format --check .` — clean

## Affected areas

- [x] `coral/cli/` (commands, helpers)

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Docs: not needed — the alias is intentionally hidden from help.
- [ ] No config field / flag / contract changes (restores the documented `validate` surface on the alias).
- [ ] Not an example task.
- [x] AI-assisted PR: authored with an AI coding agent; every changed line reviewed.
