### PR TITLE
chore: promote dev to main

### DIFF
--- a/coral/agent/builtin/deepseek_harness.py
+++ b/coral/agent/builtin/deepseek_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -20,6 +21,7 @@ from coral.agent.runtime import (
     write_coral_log_entry,
 )
 from coral.sandbox.protocol import AgentSandboxSpec
+from coral.venv_paths import venv_bin_dir
 from coral.workspace.repo import _clean_env
 
 logger = logging.getLogger(__name__)
@@ -139,7 +141,10 @@ class DeepSeekHarnessRuntime:
         worktree_venv = str(worktree_path / ".venv")
         agent_env["UV_PROJECT_ENVIRONMENT"] = worktree_venv
         agent_env["VIRTUAL_ENV"] = worktree_venv
-        agent_env["PATH"] = str(worktree_path / ".venv" / "bin") + ":" + agent_env.get("PATH", "")
+        # Prepend the venv executable dir (bin or Scripts) to PATH, matching
+        # the platform-aware resolution used by the other builtin runtimes.
+        venv_bin = str(venv_bin_dir(worktree_path / ".venv"))
+        agent_env["PATH"] = venv_bin + os.pathsep + agent_env.get("PATH", "")
         agent_env["DSH_HOME"] = str(dsh_home)
 
         permission_mode = opts.get("permission_mode")
@@ -156,7 +161,7 @@ class DeepSeekHarnessRuntime:
         apply_sandbox_env(agent_env, sandbox)
         user_kwargs = apply_run_as_user(agent_env, run_as_user)
 
-        log_file = open(log_path, "w", buffering=1)
+        log_file = open(log_path, "w", buffering=1, encoding="utf-8", errors="replace")
         err_path: Path | None = None
         err_file: Any = None
         stderr_target: Any = subprocess.STDOUT

--- a/coral/cli/__init__.py
+++ b/coral/cli/__init__.py
@@ -176,8 +176,11 @@ Run 'coral <command> --help' for details on any command."""
         action="store_true",
         help="Output one machine-readable validation result",
     )
-    # Hidden alias: test-eval -> validate
-    sub.add_parser("test-eval", help=argparse.SUPPRESS)
+    # Hidden alias: test-eval -> validate (mirror validate's arguments so the
+    # alias can actually dispatch; cmd_validate reads args.path)
+    p_test_eval = sub.add_parser("test-eval", help=argparse.SUPPRESS)
+    p_test_eval.add_argument("path", help=argparse.SUPPRESS)
+    p_test_eval.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
 
     # --- Running Agents ---
 

--- a/coral/gateway/middleware.py
+++ b/coral/gateway/middleware.py
@@ -306,8 +306,11 @@ def _assemble_response(data: bytes) -> Any:
 
     raw = data.decode("utf-8", errors="replace")
 
-    # Check if this is an SSE stream (starts with "data: ")
-    if not raw.lstrip().startswith("data:"):
+    # Check if this is an SSE stream. OpenAI-style streams start with a
+    # "data:" field; Anthropic Messages streams start with an "event:" field
+    # (e.g. "event: message_start").
+    stripped = raw.lstrip()
+    if not (stripped.startswith("data:") or stripped.startswith("event:")):
         return _safe_parse_json(data)
 
     # Parse SSE chunks and assemble content
@@ -351,6 +354,29 @@ def _assemble_response(data: bytes) -> Any:
             status = response_obj.get("status")
             if response_obj.get("usage"):
                 usage = response_obj["usage"]
+        # Anthropic Messages API streaming format
+        elif chunk_type == "message_start":
+            message = chunk.get("message", {})
+            if not response_id and message.get("id"):
+                response_id = message["id"]
+            if not model and message.get("model"):
+                model = message["model"]
+            if isinstance(message.get("usage"), dict):
+                usage = {**(usage or {}), **message["usage"]}
+        elif chunk_type == "content_block_delta":
+            delta = chunk.get("delta", {})
+            if delta.get("type") == "text_delta":
+                text = delta.get("text", "")
+                if text:
+                    content_parts.append(text)
+        elif chunk_type == "message_delta":
+            delta = chunk.get("delta", {})
+            if delta.get("stop_reason"):
+                finish_reason = delta["stop_reason"]
+            # message_delta carries cumulative output token usage at the top
+            # level; merge it so input_tokens from message_start is kept.
+            if isinstance(chunk.get("usage"), dict):
+                usage = {**(usage or {}), **chunk["usage"]}
         # Chat Completions streaming format
         else:
             for choice in chunk.get("choices", []):
@@ -361,8 +387,8 @@ def _assemble_response(data: bytes) -> Any:
                 if choice.get("finish_reason"):
                     finish_reason = choice["finish_reason"]
 
-        if chunk.get("usage"):
-            usage = chunk["usage"]
+            if chunk.get("usage"):
+                usage = chunk["usage"]
 
     assembled: dict[str, Any] = {}
     if response_id:

--- a/coral/gateway/middleware.py
+++ b/coral/gateway/middleware.py
@@ -7,6 +7,7 @@ import logging
 import subprocess
 import time
 import uuid
+from collections.abc import Callable, Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 # Cache commit hashes briefly to avoid hammering git on every request
 _HASH_CACHE_TTL = 2.0  # seconds
+
+# Optional callback stamping extra request headers: receives the identified
+# agent (or None) and the ASGI scope, returns header name/value byte pairs.
+HeaderProvider = Callable[["AgentInfo | None", dict[str, Any]], Iterable[tuple[bytes, bytes]]]
 
 
 class CoralGatewayMiddleware:
@@ -25,12 +30,25 @@ class CoralGatewayMiddleware:
     2. Reads the agent's current git commit hash (cached briefly)
     3. Adds X-Coral-Agent-Id and X-Coral-Session-Id headers
     4. Logs request and assembled response as linked JSONL entries
+
+    An optional ``header_provider`` callback can stamp additional request
+    headers (e.g. experiment or trace metadata) without forking the
+    middleware. It is called with the identified agent (or ``None``) and the
+    ASGI scope, and must return an iterable of ``(name, value)`` byte pairs.
+    A failing provider is logged and skipped; it never breaks the request.
     """
 
-    def __init__(self, app: Any, log_dir: Path, master_key: str) -> None:
+    def __init__(
+        self,
+        app: Any,
+        log_dir: Path,
+        master_key: str,
+        header_provider: HeaderProvider | None = None,
+    ) -> None:
         self.app = app
         self.log_dir = log_dir
         self.master_key = master_key
+        self.header_provider = header_provider
         self._agent_map: dict[str, AgentInfo] = {}  # proxy_key -> agent info
         self._hash_cache: dict[str, tuple[str, float]] = {}  # worktree -> (hash, timestamp)
 
@@ -174,6 +192,24 @@ class CoralGatewayMiddleware:
         # Add CORAL-specific headers
         new_headers.append((b"x-coral-agent-id", agent_id.encode("latin-1")))
         new_headers.append((b"x-coral-session-id", session_id.encode("latin-1")))
+
+        # Let integrations stamp extra metadata headers. Validate the pairs
+        # before extending so a misbehaving provider can't half-apply or
+        # break the request.
+        if self.header_provider is not None:
+            try:
+                extra_headers = [
+                    (bytes(name), bytes(value))
+                    for name, value in self.header_provider(agent_info, scope)
+                ]
+            except Exception:
+                logger.warning(
+                    "Gateway header_provider raised; skipping extra headers",
+                    exc_info=True,
+                )
+            else:
+                new_headers.extend(extra_headers)
+
         scope["headers"] = new_headers
 
         # Track response

--- a/coral/gateway/middleware.py
+++ b/coral/gateway/middleware.py
@@ -51,6 +51,7 @@ class CoralGatewayMiddleware:
         self.header_provider = header_provider
         self._agent_map: dict[str, AgentInfo] = {}  # proxy_key -> agent info
         self._hash_cache: dict[str, tuple[str, float]] = {}  # worktree -> (hash, timestamp)
+        self._warned_unknown_keys: set[str] = set()  # keys already warned about
 
         # Ensure log directory exists
         self.log_dir.mkdir(parents=True, exist_ok=True)
@@ -83,9 +84,21 @@ class CoralGatewayMiddleware:
         info = self._agent_map.get(token)
         if info:
             return info
-        # Key not recognized — fall back to sole agent if only one registered
+        # Key present but not recognized — fall back to sole agent if only one
+        # is registered, but warn: unlike a missing key, a mismatched key
+        # usually means a stale or misconfigured proxy key, and silently
+        # attributing the traffic would mask that.
         if len(self._agent_map) == 1:
-            return next(iter(self._agent_map.values()))
+            fallback = next(iter(self._agent_map.values()))
+            if token not in self._warned_unknown_keys:
+                self._warned_unknown_keys.add(token)
+                logger.warning(
+                    "Gateway received a bearer key that does not match any "
+                    f"registered proxy key; attributing traffic to the sole "
+                    f"registered agent '{fallback.agent_id}'. This may "
+                    "indicate a stale or misconfigured key."
+                )
+            return fallback
         return None
 
     def _get_commit_hash(self, worktree_path: Path) -> str:

--- a/coral/gateway/server.py
+++ b/coral/gateway/server.py
@@ -16,7 +16,7 @@ import uvicorn
 from litellm.proxy.proxy_server import app as litellm_app
 from litellm.proxy.proxy_server import initialize
 
-from coral.gateway.middleware import CoralGatewayMiddleware
+from coral.gateway.middleware import CoralGatewayMiddleware, HeaderProvider
 
 logger = logging.getLogger(__name__)
 
@@ -37,11 +37,13 @@ class GatewayManager:
         config_path: str,
         api_key: str = "",
         log_dir: Path | None = None,
+        header_provider: HeaderProvider | None = None,
     ) -> None:
         self.port = port
         self.config_path = config_path
         self.api_key = api_key or f"sk-coral-{secrets.token_hex(8)}"
         self.log_dir = log_dir or Path(".coral/gateway")
+        self.header_provider = header_provider
         self._server_thread: threading.Thread | None = None
         self._server: object | None = None  # uvicorn.Server
         self._middleware: object | None = None  # CoralGatewayMiddleware
@@ -88,6 +90,7 @@ class GatewayManager:
             app=litellm_app,
             log_dir=self.log_dir,
             master_key=self.api_key,
+            header_provider=self.header_provider,
         )
         self._middleware = middleware
 

--- a/coral/task/validation.py
+++ b/coral/task/validation.py
@@ -299,7 +299,12 @@ async def run_validation_async(
         try:
             workspace.mkdir()
             seed_dir = task_dir / "seed"
-            has_seed = seed_dir.is_dir() and any(seed_dir.iterdir())
+            # Mirror the copy loop below: a seed/ that exists but contributes
+            # nothing to the workspace (empty, or only __pycache__) is treated
+            # as absent so the progress messages describe what actually runs.
+            has_seed = seed_dir.is_dir() and any(
+                item.name != "__pycache__" for item in seed_dir.iterdir()
+            )
             if has_seed:
                 for item in seed_dir.iterdir():
                     if item.name == "__pycache__":
@@ -369,7 +374,7 @@ async def run_validation_async(
             name=config.task.name,
             description=config.task.description,
         )
-        target = "seed code" if seed_dir.is_dir() else "empty workspace"
+        target = "seed code" if has_seed else "empty workspace"
         emit("baseline", "started", f"Running grader against {target}...")
         try:
             baseline = await grader.grade(str(workspace), [task])

--- a/docs/content/docs/cli/reference.mdx
+++ b/docs/content/docs/cli/reference.mdx
@@ -353,10 +353,12 @@ These commands are primarily used by agents during their eval loop, but can also
 
 ### `coral eval`
 
-Stage all changes, commit, and run the grader.
+Stage all changes, commit, and run the grader. By default this blocks until
+the grader daemon returns a score; use `--no-wait` to return immediately and
+poll later with [`coral wait`](#coral-wait).
 
 ```bash
-coral eval -m <message> [--agent ID] [--workdir DIR]
+coral eval -m <message> [--agent ID] [--workdir DIR] [--no-wait] [--timeout SECONDS] [--tune]
 ```
 
 | Flag | Description |
@@ -364,9 +366,34 @@ coral eval -m <message> [--agent ID] [--workdir DIR]
 | `-m, --message` | Description of changes (required) |
 | `--agent` | Agent ID (default: read from `.coral_agent_id`) |
 | `--workdir` | Working directory (default: cwd) |
+| `--wait / --no-wait` | Wait for the grader to return a score (default: wait). With `--no-wait`, returns immediately with a pending status |
+| `--timeout` | Seconds to wait for the grader (default: derived from `grader.timeout`) |
+| `--tune` | Submit as a tune-mode attempt: scored and recorded normally, but excluded from the agent's plateau / heartbeat budget. Use for hyperparameter sweeps and config exploration that shouldn't trigger pivot prompts |
 
 ```bash
 coral eval -m "Optimized inner loop with vectorization"
+coral eval -m "Try variant A" --no-wait
+coral eval -m "Heavy benchmark" --timeout 1800
+coral eval --tune -m "Sweep lr=1e-3 vs 3e-4"
+```
+
+### `coral wait`
+
+Block until the grader daemon finalizes a previously submitted attempt
+(e.g. one submitted with `coral eval --no-wait`).
+
+```bash
+coral wait <hash> [--workdir DIR] [--timeout SECONDS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--workdir` | Working directory (default: cwd) |
+| `--timeout` | Seconds to wait (default: derived from `grader.timeout`) |
+
+```bash
+coral wait abc123
+coral wait abc123 --timeout 600
 ```
 
 ### `coral diff`

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -153,6 +153,7 @@ uv pip install -e ./examples/drug_design/grader[ml]
 | [frontier_cs_algo](#frontier_cs_algo) | 172 algorithmic competition problems (C++) | Maximize |
 | [frontier_cs_research](#frontier_cs_research) | 127 research-level CS problems (Python) | Maximize |
 | [frontier_eng](frontier_eng/README.md) | 74 generative-optimization benchmarks ported from EinsiaLab/Frontier-Engineering (KernelEngineering, JobShop, Optics, Cryptographic, ...) | Maximize |
+| [frontier_swe](frontier_swe/README.md) | 4 long-horizon systems ports evaluated by pinned official Frontier-SWE tasks through Harbor | Maximize |
 | [dna_design](#dna_design) | Design cell-type-specific DNA enhancer sequences (SAGA) | Maximize |
 | [drug_design](#drug_design) | Design novel small-molecule antibiotics (SAGA) | Maximize |
 | [swebench-verified](#swebench-verified) | Optimize a solver program across 500 SWE-bench instances | Maximize |
@@ -250,6 +251,22 @@ Predict mRNA degradation rates at each base position. Scored by Mean Columnwise 
 - **Direction**: Maximize (combined_score per upstream contract)
 - **Grader**: `frontier_eng_grader.grader:Grader`
 - **Generator**: `examples/frontier_eng/_scripts/generate_tasks.py` (re-runnable from a fresh upstream checkout)
+
+### frontier_swe
+
+Four long-horizon systems candidates adapted from Frontier-SWE: Git v2.47.0
+in Zig, a Lua 5.4 native compiler, libexpat 2.6.4 in x86-64 assembly, and
+dart_style 3.1.4 in Haskell. Each seed is a non-zero cumulative source bundle.
+The packaged grader fetches a pinned upstream task into `.coral/private/` and
+uses Harbor to materialize the bundle in a digest-pinned official image and
+run its verifier; no upstream tests or task images are vendored in CORAL. See
+[examples/frontier_swe/README.md](frontier_swe/README.md) for prerequisites,
+seed scores, and validation commands.
+
+- **Tasks**: 4
+- **Direction**: Maximize (official Frontier-SWE reward)
+- **Grader**: `frontier_swe_grader.grader:Grader`
+- **Runtime**: Harbor with Docker (default) or Modal
 
 ### dna_design
 

--- a/examples/frontier_swe/LICENSE.seed-candidates
+++ b/examples/frontier_swe/LICENSE.seed-candidates
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 the seed candidate authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/frontier_swe/README.md
+++ b/examples/frontier_swe/README.md
@@ -1,0 +1,86 @@
+# Frontier-SWE tasks
+
+Four long-horizon systems tasks from
+[Proximal-Labs/Frontier-SWE](https://github.com/Proximal-Labs/frontier-swe),
+adapted to CORAL without vendoring the upstream verifier or task images.
+
+Each task starts from a non-zero candidate. The candidate is stored as a
+cumulative text bundle so a CORAL agent can change a multi-file project in
+one artifact:
+
+```text
+=== FILE: relative/path ===
+complete file contents
+=== END FILE ===
+```
+
+The seed candidates retain the source project's MIT terms; see
+[`LICENSE.seed-candidates`](LICENSE.seed-candidates). The Dart-to-Haskell
+bundle also carries its own BSD-3-Clause file as part of the materialized
+candidate.
+
+The packaged grader checks the bundle, fetches the upstream task at commit
+`111464af7933002a9192240798cbcf65d2790296` into `.coral/private/`, pins its
+official container image by manifest digest, and asks
+[Harbor](https://harborframework.com/) to run the official verifier. The
+grader's Harbor agent only materializes the candidate inside the official task
+workspace; it does not use an LLM or alter the verifier.
+
+[`_grader/`](_grader/) is the source-of-truth grader package. Each task carries
+an identical `grader/` copy so the task remains self-contained when copied or
+mounted on its own.
+
+## Tasks
+
+| Task | Candidate target | Validated seed score | Typical verifier time |
+|---|---|---:|---:|
+| [Git to Zig](git-to-zig/task.yaml) | `/app/zig-port` | 0.197833 | ~13 min |
+| [Lua Native Compiler](lua-native-compiler/task.yaml) | `/app/lua-native-compiler` | 0.406593 | ~2 min |
+| [libexpat to x86-64 assembly](libexpat-to-x86asm/task.yaml) | `/app/asm-port` | 1397.818394 | <1 min |
+| [dart_style to Haskell](dart-haskell/task.yaml) | `/app/dart-style` | 0.0546 | ~2 min |
+
+The seed scores above were observed with the pinned task and image. The
+libexpat reward includes a performance component and therefore varies by
+machine; runtime also varies with image pulls and available compute.
+
+## Requirements
+
+- `git` and `uv` on the CORAL host.
+- One of:
+  - Docker with enough capacity for the task's official image (the default), or
+  - a configured Modal account. Set
+    `CORAL_FRONTIER_SWE_HARBOR_ENVIRONMENT=modal` before validation or a run.
+- Network access for the grader to fetch the pinned upstream task and for
+  Harbor to obtain the official image. The task container itself keeps the
+  upstream `allow_internet = false` policy.
+
+Harbor is pinned and launched through `uvx --python 3.12`, so it remains
+separate from both CORAL and the grader venv.
+
+## Validate and run
+
+Validate one baseline end to end:
+
+```bash
+CORAL_FRONTIER_SWE_HARBOR_ENVIRONMENT=modal \
+  uv run coral validate examples/frontier_swe/git-to-zig
+```
+
+Start a normal CORAL run (Docker is used unless the environment variable above
+selects Modal):
+
+```bash
+uv run coral start -c examples/frontier_swe/git-to-zig/task.yaml
+```
+
+Official evaluations are intentionally expensive. The grader uses one Harbor
+trial at a time, stores Harbor output under the attempt's `eval_logs/`, and
+never writes generated artifacts into the candidate checkout.
+
+## Upstream assets and isolation
+
+The CORAL repository contains only the task adapters and the contributed seed
+candidates. It does not copy Frontier-SWE instructions, tests, reference trees,
+or container files. Those assets are resolved from the pinned upstream commit
+at evaluation time and cached only under `.coral/private/`, which agents cannot
+read. This also keeps verifier changes from silently changing scores.

--- a/examples/frontier_swe/_grader/pyproject.toml
+++ b/examples/frontier_swe/_grader/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "frontier-swe-grader"
+version = "0.1.0"
+description = "CORAL grader for pinned Frontier-SWE tasks executed through Harbor."
+requires-python = ">=3.11"
+dependencies = ["coral"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/frontier_swe_grader"]

--- a/examples/frontier_swe/_grader/src/frontier_swe_grader/__init__.py
+++ b/examples/frontier_swe/_grader/src/frontier_swe_grader/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned Frontier-SWE grader for CORAL and its isolated Harbor agent."""

--- a/examples/frontier_swe/_grader/src/frontier_swe_grader/bundle.py
+++ b/examples/frontier_swe/_grader/src/frontier_swe_grader/bundle.py
@@ -1,0 +1,78 @@
+"""Strict parser for the cumulative source-bundle candidate format."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+
+_FILE_HEADER = re.compile(r"^=== FILE: (.+) ===$")
+_FILE_FOOTER = "=== END FILE ==="
+
+
+class BundleError(ValueError):
+    """Raised when a candidate bundle is malformed or unsafe to materialize."""
+
+
+def parse_bundle(text: str) -> list[tuple[PurePosixPath, str]]:
+    """Parse a bundle while rejecting ambiguous or escaping paths."""
+
+    if "\x00" in text:
+        raise BundleError("bundle contains a NUL byte")
+
+    lines = text.splitlines(keepends=True)
+    files: list[tuple[PurePosixPath, str]] = []
+    seen: set[PurePosixPath] = set()
+    index = 0
+
+    while index < len(lines):
+        if not lines[index].strip():
+            index += 1
+            continue
+
+        header = lines[index].rstrip("\r\n")
+        match = _FILE_HEADER.fullmatch(header)
+        if match is None:
+            raise BundleError(f"expected file header at line {index + 1}")
+
+        relative = _safe_relative_path(match.group(1))
+        if relative in seen:
+            raise BundleError(f"duplicate file section: {relative}")
+        seen.add(relative)
+        index += 1
+
+        content: list[str] = []
+        while index < len(lines) and lines[index].rstrip("\r\n") != _FILE_FOOTER:
+            content.append(lines[index])
+            index += 1
+        if index >= len(lines):
+            raise BundleError(f"missing end marker for {relative}")
+
+        files.append((relative, "".join(content)))
+        index += 1
+
+    if not files:
+        raise BundleError("bundle contains no files")
+    return files
+
+
+def materialize_bundle(text: str, destination: Path) -> list[Path]:
+    """Write parsed bundle files below an already isolated destination."""
+
+    written: list[Path] = []
+    for relative, content in parse_bundle(text):
+        output = destination.joinpath(*relative.parts)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content, encoding="utf-8")
+        written.append(output)
+    return written
+
+
+def _safe_relative_path(raw: str) -> PurePosixPath:
+    if not raw or "\\" in raw:
+        raise BundleError(f"invalid bundle path: {raw!r}")
+    path = PurePosixPath(raw)
+    if path.is_absolute() or path.as_posix() != raw:
+        raise BundleError(f"bundle path must be normalized and relative: {raw!r}")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise BundleError(f"bundle path escapes or aliases the workspace: {raw!r}")
+    return path

--- a/examples/frontier_swe/_grader/src/frontier_swe_grader/bundle_agent.py
+++ b/examples/frontier_swe/_grader/src/frontier_swe_grader/bundle_agent.py
@@ -1,0 +1,59 @@
+"""Harbor agent that uploads a deterministic bundle instead of invoking an LLM."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+from .bundle import materialize_bundle
+
+
+class BundleAgent(BaseAgent):
+    """Materialize the CORAL candidate into the official task workspace."""
+
+    def __init__(
+        self,
+        *args: object,
+        candidate_path: str,
+        target_dir: str,
+        prepare_command: str = "",
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._candidate_path = Path(candidate_path)
+        self._target_dir = target_dir
+        self._prepare_command = prepare_command
+
+    @staticmethod
+    def name() -> str:
+        return "frontier-swe-bundle"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        return None
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        del instruction, context
+        candidate = self._candidate_path.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="frontier-swe-candidate-") as temporary:
+            source_dir = Path(temporary)
+            materialize_bundle(candidate, source_dir)
+            await environment.upload_dir(source_dir=source_dir, target_dir=self._target_dir)
+        if self._prepare_command:
+            result = await environment.exec(command=self._prepare_command, timeout_sec=600)
+            if result.return_code != 0:
+                raise RuntimeError(
+                    f"candidate preparation failed with exit {result.return_code}: "
+                    f"{result.stderr[-2000:]}"
+                )

--- a/examples/frontier_swe/_grader/src/frontier_swe_grader/grader.py
+++ b/examples/frontier_swe/_grader/src/frontier_swe_grader/grader.py
@@ -1,0 +1,362 @@
+"""Evaluate a CORAL source bundle with a pinned official Frontier-SWE task."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from coral.grader import TaskGrader
+from coral.types import ScoreBundle
+
+from .bundle import BundleError, parse_bundle
+
+UPSTREAM_URL = "https://github.com/Proximal-Labs/frontier-swe.git"
+UPSTREAM_COMMIT = "111464af7933002a9192240798cbcf65d2790296"
+HARBOR_VERSION = "0.22.0"
+MAX_BUNDLE_BYTES = 10 * 1024 * 1024
+TASK_TARGETS = {
+    "git-to-zig": "/app/zig-port",
+    "lua-native-compiler": "/app/lua-native-compiler",
+    "libexpat-to-x86asm": "/app/asm-port",
+    "dart-style-haskell": "/app/dart-style",
+}
+TASK_IMAGES = {
+    "git-to-zig": "ghcr.io/proximal-labs/frontier-swe/git-to-zig@sha256:04a78190d62e5ab7b396d8cb094f964149531aad5277aa3d98ec833f4ea7eb00",
+    "lua-native-compiler": "ghcr.io/proximal-labs/frontier-swe/lua-native-compiler@sha256:20d39c61f936bec8a6f7e1681a3c78f978a7fd4968913e31fb06a0929a4a9561",
+    "libexpat-to-x86asm": "ghcr.io/proximal-labs/frontier-swe/libexpat-to-x86asm@sha256:c2b36a040add352f7f19ddb1efcb10e2259e4540835b7b480e166b00d41f61bd",
+    "dart-style-haskell": "ghcr.io/proximal-labs/frontier-swe/dart-style-haskell@sha256:c0d816853d0bdbda0761c000edca9e7f10a2c3926e7d7ff66e96ecf38903eb8d",
+}
+TASK_PREPARE_COMMANDS = {
+    "libexpat-to-x86asm": "cd /app/asm-port && make",
+}
+
+
+class Grader(TaskGrader):
+    """Run one official Harbor verifier and return its scalar reward."""
+
+    def evaluate(self) -> ScoreBundle:
+        try:
+            return self._evaluate()
+        except Exception as error:
+            return self.fail(f"Frontier-SWE grader failed: {type(error).__name__}: {error}")
+
+    def _evaluate(self) -> ScoreBundle:
+        task_id = str(self.args.get("task_id", ""))
+        if task_id not in TASK_TARGETS:
+            return self.fail(f"unsupported Frontier-SWE task_id: {task_id!r}")
+
+        program_file = str(self.args.get("program_file", "candidate.bundle"))
+        candidate = Path(self.codebase_path) / program_file
+        bundle_error = _validate_candidate(candidate)
+        if bundle_error is not None:
+            return self.fail(bundle_error)
+
+        task_dir = self._official_task_dir(task_id)
+        harbor_logs = Path(self.eval_logs_dir) / "harbor_logs"
+        harbor_logs.mkdir(parents=True, exist_ok=True)
+        job_name = f"frontier_swe_{task_id}_{int(time.time())}"
+        environment = os.environ.get(
+            "CORAL_FRONTIER_SWE_HARBOR_ENVIRONMENT",
+            str(self.args.get("environment", "docker")),
+        )
+
+        command = _harbor_command(
+            task_dir=task_dir,
+            candidate=candidate,
+            target_dir=TASK_TARGETS[task_id],
+            prepare_command=TASK_PREPARE_COMMANDS.get(task_id, ""),
+            logs_dir=harbor_logs,
+            job_name=job_name,
+            environment=environment,
+        )
+        env = os.environ.copy()
+        grader_src = str(Path(__file__).resolve().parents[1])
+        env["PYTHONPATH"] = os.pathsep.join(
+            path for path in (grader_src, env.get("PYTHONPATH", "")) if path
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=task_dir,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            return self.fail(f"Harbor evaluation timed out after {self.timeout}s: {error}")
+        except OSError as error:
+            return self.fail(f"could not launch Harbor: {error}")
+
+        job_dir = harbor_logs / job_name
+        parsed = _read_trial_score(job_dir)
+        if isinstance(parsed, str):
+            return self.fail(
+                f"Harbor produced no official score (exit {completed.returncode}): {parsed}. "
+                f"{_diagnostic(completed)}"
+            )
+
+        reward, trial = parsed
+        detail = _read_reward_detail(job_dir)
+        feedback = _feedback(
+            task_id,
+            reward,
+            environment,
+            self.eval_logs_worktree_path(job_dir),
+            detail,
+            trial,
+        )
+        explanation = f"official frontier_reward={reward:.12g} ({task_id}, Harbor {environment})"
+        return self.score(
+            reward,
+            explanation=explanation,
+            feedback=feedback,
+            metadata={
+                "task_id": task_id,
+                "upstream_commit": UPSTREAM_COMMIT,
+                "container_image": TASK_IMAGES[task_id],
+                "harbor_environment": environment,
+            },
+        )
+
+    def _official_task_dir(self, task_id: str) -> Path:
+        private_dir = Path(self.private_dir)
+        private_dir.mkdir(parents=True, exist_ok=True)
+        checkout = private_dir / f"frontier-swe-{UPSTREAM_COMMIT[:12]}"
+        task_dir = checkout / "tasks" / task_id
+        if _checkout_matches(checkout, task_dir):
+            _pin_task_image(task_dir, task_id)
+            return task_dir
+
+        if checkout.exists():
+            shutil.rmtree(checkout)
+        with tempfile.TemporaryDirectory(
+            prefix="frontier-swe-checkout-", dir=private_dir
+        ) as temporary:
+            staged = Path(temporary) / "repo"
+            commands = [
+                ["git", "init", str(staged)],
+                ["git", "-C", str(staged), "remote", "add", "origin", UPSTREAM_URL],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "sparse-checkout",
+                    "set",
+                    "--no-cone",
+                    f"/tasks/{task_id}/",
+                    f"!/tasks/{task_id}/solution/",
+                    f"!/tasks/{task_id}/environment/*",
+                    f"/tasks/{task_id}/environment/Dockerfile",
+                ],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "fetch",
+                    "--filter=blob:none",
+                    "--depth",
+                    "1",
+                    "origin",
+                    UPSTREAM_COMMIT,
+                ],
+                ["git", "-C", str(staged), "checkout", "--detach", "FETCH_HEAD"],
+            ]
+            for command in commands:
+                result = subprocess.run(
+                    command,
+                    text=True,
+                    capture_output=True,
+                    timeout=600,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        f"upstream checkout command failed: {' '.join(command)}; "
+                        f"{_diagnostic(result)}"
+                    )
+            staged.replace(checkout)
+
+        if not _checkout_matches(checkout, task_dir):
+            raise RuntimeError("pinned upstream checkout is incomplete or at the wrong commit")
+        _pin_task_image(task_dir, task_id)
+        return task_dir
+
+
+def _validate_candidate(candidate: Path) -> str | None:
+    try:
+        size = candidate.stat().st_size
+    except OSError as error:
+        return f"candidate bundle is unavailable: {error}"
+    if size > MAX_BUNDLE_BYTES:
+        return f"candidate bundle exceeds {MAX_BUNDLE_BYTES} bytes"
+    try:
+        files = parse_bundle(candidate.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, BundleError) as error:
+        return f"invalid candidate bundle: {error}"
+    return None if files else "candidate bundle contains no files"
+
+
+def _harbor_command(
+    *,
+    task_dir: Path,
+    candidate: Path,
+    target_dir: str,
+    prepare_command: str,
+    logs_dir: Path,
+    job_name: str,
+    environment: str,
+) -> list[str]:
+    package = (
+        f"harbor[modal]=={HARBOR_VERSION}"
+        if environment == "modal"
+        else f"harbor=={HARBOR_VERSION}"
+    )
+    agent_args = [
+        "--agent-kwarg",
+        f"candidate_path={candidate}",
+        "--agent-kwarg",
+        f"target_dir={target_dir}",
+    ]
+    if prepare_command:
+        agent_args.extend(["--agent-kwarg", f"prepare_command={prepare_command}"])
+
+    return [
+        "uvx",
+        "--python",
+        "3.12",
+        "--from",
+        package,
+        "harbor",
+        "run",
+        "--path",
+        str(task_dir),
+        "--agent",
+        "frontier_swe_grader.bundle_agent:BundleAgent",
+        *agent_args,
+        "--verifier",
+        "frontier_swe_grader.reward_verifier:FrontierSWEVerifier",
+        "--env",
+        environment,
+        "--jobs-dir",
+        str(logs_dir),
+        "--job-name",
+        job_name,
+        "--n-attempts",
+        "1",
+        "--n-concurrent",
+        "1",
+        "--yes",
+        "--quiet",
+    ]
+
+
+def _checkout_matches(checkout: Path, task_dir: Path) -> bool:
+    if not task_dir.is_dir():
+        return False
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == UPSTREAM_COMMIT
+
+
+def _pin_task_image(task_dir: Path, task_id: str) -> None:
+    task_config = task_dir / "task.toml"
+    text = task_config.read_text(encoding="utf-8")
+    pinned_line = f'docker_image = "{TASK_IMAGES[task_id]}"'
+    if pinned_line in text:
+        return
+    tagged_line = f'docker_image = "ghcr.io/proximal-labs/frontier-swe/{task_id}:v4"'
+    if text.count(tagged_line) != 1:
+        raise RuntimeError(f"could not locate the expected image tag in {task_config}")
+    task_config.write_text(text.replace(tagged_line, pinned_line), encoding="utf-8")
+
+
+def _read_trial_score(job_dir: Path) -> tuple[float, dict[str, Any]] | str:
+    if not job_dir.is_dir():
+        return f"job directory is missing: {job_dir}"
+    errors: list[str] = []
+    for result_path in sorted(job_dir.rglob("result.json")):
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            errors.append(f"{result_path.name}: {error}")
+            continue
+        verifier = payload.get("verifier_result")
+        if not isinstance(verifier, dict):
+            continue
+        rewards = verifier.get("rewards")
+        if not isinstance(rewards, dict):
+            continue
+        try:
+            reward = float(rewards["reward"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        return reward, payload
+    return "; ".join(errors) or "no trial result contained verifier_result.rewards.reward"
+
+
+def _read_reward_detail(job_dir: Path) -> dict[str, Any]:
+    for reward_path in sorted(job_dir.rglob("reward.json")):
+        try:
+            payload = json.loads(reward_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _feedback(
+    task_id: str,
+    reward: float,
+    environment: str,
+    job_dir: Path,
+    detail: dict[str, Any],
+    trial: dict[str, Any],
+) -> str:
+    lines = [
+        f"Official Frontier-SWE result for `{task_id}`: {reward:.12g}",
+        f"Harbor environment: `{environment}`",
+        f"Upstream commit: `{UPSTREAM_COMMIT}`",
+        f"Container image: `{TASK_IMAGES[task_id]}`",
+        f"Logs: `{job_dir}`",
+    ]
+    reason = detail.get("reason")
+    if reason:
+        lines.append(f"Reason: {reason}")
+    for key in (
+        "tests_passed",
+        "tests_total",
+        "total_passed",
+        "total_failed",
+        "total_skipped",
+        "score",
+        "reward",
+    ):
+        if key in detail:
+            lines.append(f"{key}: {detail[key]}")
+    if trial.get("exception_info"):
+        lines.append(f"Trial exception: {trial['exception_info']}")
+    return "\n".join(lines)
+
+
+def _diagnostic(completed: subprocess.CompletedProcess[str]) -> str:
+    pieces = []
+    for label, value in (("stdout", completed.stdout), ("stderr", completed.stderr)):
+        text = (value or "").strip()
+        if text:
+            pieces.append(f"{label}: {text[-2000:]}")
+    return " | ".join(pieces) or "no subprocess output"

--- a/examples/frontier_swe/_grader/src/frontier_swe_grader/reward_verifier.py
+++ b/examples/frontier_swe/_grader/src/frontier_swe_grader/reward_verifier.py
@@ -1,0 +1,22 @@
+"""Harbor verifier adapter that selects the scalar from Frontier-SWE details."""
+
+from __future__ import annotations
+
+import json
+
+from harbor.verifier.verifier import Verifier, VerifierOutputParseError
+
+
+class FrontierSWEVerifier(Verifier):
+    """Run Harbor's verifier unchanged, but return only its primary reward."""
+
+    def _parse_reward_json(self) -> dict[str, float | int]:
+        try:
+            payload = json.loads(self.trial_paths.reward_json_path.read_text())
+            value = payload.get("reward", payload.get("score"))
+            return {"reward": float(value)}
+        except (AttributeError, OSError, TypeError, ValueError) as error:
+            raise VerifierOutputParseError(
+                f"Frontier-SWE reward JSON has no numeric reward or score: "
+                f"{self.trial_paths.reward_json_path}"
+            ) from error

--- a/examples/frontier_swe/dart-haskell/grader/pyproject.toml
+++ b/examples/frontier_swe/dart-haskell/grader/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "frontier-swe-grader"
+version = "0.1.0"
+description = "CORAL grader for pinned Frontier-SWE tasks executed through Harbor."
+requires-python = ">=3.11"
+dependencies = ["coral"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/frontier_swe_grader"]

--- a/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/__init__.py
+++ b/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned Frontier-SWE grader for CORAL and its isolated Harbor agent."""

--- a/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/bundle.py
+++ b/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/bundle.py
@@ -1,0 +1,78 @@
+"""Strict parser for the cumulative source-bundle candidate format."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+
+_FILE_HEADER = re.compile(r"^=== FILE: (.+) ===$")
+_FILE_FOOTER = "=== END FILE ==="
+
+
+class BundleError(ValueError):
+    """Raised when a candidate bundle is malformed or unsafe to materialize."""
+
+
+def parse_bundle(text: str) -> list[tuple[PurePosixPath, str]]:
+    """Parse a bundle while rejecting ambiguous or escaping paths."""
+
+    if "\x00" in text:
+        raise BundleError("bundle contains a NUL byte")
+
+    lines = text.splitlines(keepends=True)
+    files: list[tuple[PurePosixPath, str]] = []
+    seen: set[PurePosixPath] = set()
+    index = 0
+
+    while index < len(lines):
+        if not lines[index].strip():
+            index += 1
+            continue
+
+        header = lines[index].rstrip("\r\n")
+        match = _FILE_HEADER.fullmatch(header)
+        if match is None:
+            raise BundleError(f"expected file header at line {index + 1}")
+
+        relative = _safe_relative_path(match.group(1))
+        if relative in seen:
+            raise BundleError(f"duplicate file section: {relative}")
+        seen.add(relative)
+        index += 1
+
+        content: list[str] = []
+        while index < len(lines) and lines[index].rstrip("\r\n") != _FILE_FOOTER:
+            content.append(lines[index])
+            index += 1
+        if index >= len(lines):
+            raise BundleError(f"missing end marker for {relative}")
+
+        files.append((relative, "".join(content)))
+        index += 1
+
+    if not files:
+        raise BundleError("bundle contains no files")
+    return files
+
+
+def materialize_bundle(text: str, destination: Path) -> list[Path]:
+    """Write parsed bundle files below an already isolated destination."""
+
+    written: list[Path] = []
+    for relative, content in parse_bundle(text):
+        output = destination.joinpath(*relative.parts)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content, encoding="utf-8")
+        written.append(output)
+    return written
+
+
+def _safe_relative_path(raw: str) -> PurePosixPath:
+    if not raw or "\\" in raw:
+        raise BundleError(f"invalid bundle path: {raw!r}")
+    path = PurePosixPath(raw)
+    if path.is_absolute() or path.as_posix() != raw:
+        raise BundleError(f"bundle path must be normalized and relative: {raw!r}")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise BundleError(f"bundle path escapes or aliases the workspace: {raw!r}")
+    return path

--- a/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/bundle_agent.py
+++ b/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/bundle_agent.py
@@ -1,0 +1,59 @@
+"""Harbor agent that uploads a deterministic bundle instead of invoking an LLM."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+from .bundle import materialize_bundle
+
+
+class BundleAgent(BaseAgent):
+    """Materialize the CORAL candidate into the official task workspace."""
+
+    def __init__(
+        self,
+        *args: object,
+        candidate_path: str,
+        target_dir: str,
+        prepare_command: str = "",
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._candidate_path = Path(candidate_path)
+        self._target_dir = target_dir
+        self._prepare_command = prepare_command
+
+    @staticmethod
+    def name() -> str:
+        return "frontier-swe-bundle"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        return None
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        del instruction, context
+        candidate = self._candidate_path.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="frontier-swe-candidate-") as temporary:
+            source_dir = Path(temporary)
+            materialize_bundle(candidate, source_dir)
+            await environment.upload_dir(source_dir=source_dir, target_dir=self._target_dir)
+        if self._prepare_command:
+            result = await environment.exec(command=self._prepare_command, timeout_sec=600)
+            if result.return_code != 0:
+                raise RuntimeError(
+                    f"candidate preparation failed with exit {result.return_code}: "
+                    f"{result.stderr[-2000:]}"
+                )

--- a/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/grader.py
+++ b/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/grader.py
@@ -1,0 +1,362 @@
+"""Evaluate a CORAL source bundle with a pinned official Frontier-SWE task."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from coral.grader import TaskGrader
+from coral.types import ScoreBundle
+
+from .bundle import BundleError, parse_bundle
+
+UPSTREAM_URL = "https://github.com/Proximal-Labs/frontier-swe.git"
+UPSTREAM_COMMIT = "111464af7933002a9192240798cbcf65d2790296"
+HARBOR_VERSION = "0.22.0"
+MAX_BUNDLE_BYTES = 10 * 1024 * 1024
+TASK_TARGETS = {
+    "git-to-zig": "/app/zig-port",
+    "lua-native-compiler": "/app/lua-native-compiler",
+    "libexpat-to-x86asm": "/app/asm-port",
+    "dart-style-haskell": "/app/dart-style",
+}
+TASK_IMAGES = {
+    "git-to-zig": "ghcr.io/proximal-labs/frontier-swe/git-to-zig@sha256:04a78190d62e5ab7b396d8cb094f964149531aad5277aa3d98ec833f4ea7eb00",
+    "lua-native-compiler": "ghcr.io/proximal-labs/frontier-swe/lua-native-compiler@sha256:20d39c61f936bec8a6f7e1681a3c78f978a7fd4968913e31fb06a0929a4a9561",
+    "libexpat-to-x86asm": "ghcr.io/proximal-labs/frontier-swe/libexpat-to-x86asm@sha256:c2b36a040add352f7f19ddb1efcb10e2259e4540835b7b480e166b00d41f61bd",
+    "dart-style-haskell": "ghcr.io/proximal-labs/frontier-swe/dart-style-haskell@sha256:c0d816853d0bdbda0761c000edca9e7f10a2c3926e7d7ff66e96ecf38903eb8d",
+}
+TASK_PREPARE_COMMANDS = {
+    "libexpat-to-x86asm": "cd /app/asm-port && make",
+}
+
+
+class Grader(TaskGrader):
+    """Run one official Harbor verifier and return its scalar reward."""
+
+    def evaluate(self) -> ScoreBundle:
+        try:
+            return self._evaluate()
+        except Exception as error:
+            return self.fail(f"Frontier-SWE grader failed: {type(error).__name__}: {error}")
+
+    def _evaluate(self) -> ScoreBundle:
+        task_id = str(self.args.get("task_id", ""))
+        if task_id not in TASK_TARGETS:
+            return self.fail(f"unsupported Frontier-SWE task_id: {task_id!r}")
+
+        program_file = str(self.args.get("program_file", "candidate.bundle"))
+        candidate = Path(self.codebase_path) / program_file
+        bundle_error = _validate_candidate(candidate)
+        if bundle_error is not None:
+            return self.fail(bundle_error)
+
+        task_dir = self._official_task_dir(task_id)
+        harbor_logs = Path(self.eval_logs_dir) / "harbor_logs"
+        harbor_logs.mkdir(parents=True, exist_ok=True)
+        job_name = f"frontier_swe_{task_id}_{int(time.time())}"
+        environment = os.environ.get(
+            "CORAL_FRONTIER_SWE_HARBOR_ENVIRONMENT",
+            str(self.args.get("environment", "docker")),
+        )
+
+        command = _harbor_command(
+            task_dir=task_dir,
+            candidate=candidate,
+            target_dir=TASK_TARGETS[task_id],
+            prepare_command=TASK_PREPARE_COMMANDS.get(task_id, ""),
+            logs_dir=harbor_logs,
+            job_name=job_name,
+            environment=environment,
+        )
+        env = os.environ.copy()
+        grader_src = str(Path(__file__).resolve().parents[1])
+        env["PYTHONPATH"] = os.pathsep.join(
+            path for path in (grader_src, env.get("PYTHONPATH", "")) if path
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=task_dir,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            return self.fail(f"Harbor evaluation timed out after {self.timeout}s: {error}")
+        except OSError as error:
+            return self.fail(f"could not launch Harbor: {error}")
+
+        job_dir = harbor_logs / job_name
+        parsed = _read_trial_score(job_dir)
+        if isinstance(parsed, str):
+            return self.fail(
+                f"Harbor produced no official score (exit {completed.returncode}): {parsed}. "
+                f"{_diagnostic(completed)}"
+            )
+
+        reward, trial = parsed
+        detail = _read_reward_detail(job_dir)
+        feedback = _feedback(
+            task_id,
+            reward,
+            environment,
+            self.eval_logs_worktree_path(job_dir),
+            detail,
+            trial,
+        )
+        explanation = f"official frontier_reward={reward:.12g} ({task_id}, Harbor {environment})"
+        return self.score(
+            reward,
+            explanation=explanation,
+            feedback=feedback,
+            metadata={
+                "task_id": task_id,
+                "upstream_commit": UPSTREAM_COMMIT,
+                "container_image": TASK_IMAGES[task_id],
+                "harbor_environment": environment,
+            },
+        )
+
+    def _official_task_dir(self, task_id: str) -> Path:
+        private_dir = Path(self.private_dir)
+        private_dir.mkdir(parents=True, exist_ok=True)
+        checkout = private_dir / f"frontier-swe-{UPSTREAM_COMMIT[:12]}"
+        task_dir = checkout / "tasks" / task_id
+        if _checkout_matches(checkout, task_dir):
+            _pin_task_image(task_dir, task_id)
+            return task_dir
+
+        if checkout.exists():
+            shutil.rmtree(checkout)
+        with tempfile.TemporaryDirectory(
+            prefix="frontier-swe-checkout-", dir=private_dir
+        ) as temporary:
+            staged = Path(temporary) / "repo"
+            commands = [
+                ["git", "init", str(staged)],
+                ["git", "-C", str(staged), "remote", "add", "origin", UPSTREAM_URL],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "sparse-checkout",
+                    "set",
+                    "--no-cone",
+                    f"/tasks/{task_id}/",
+                    f"!/tasks/{task_id}/solution/",
+                    f"!/tasks/{task_id}/environment/*",
+                    f"/tasks/{task_id}/environment/Dockerfile",
+                ],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "fetch",
+                    "--filter=blob:none",
+                    "--depth",
+                    "1",
+                    "origin",
+                    UPSTREAM_COMMIT,
+                ],
+                ["git", "-C", str(staged), "checkout", "--detach", "FETCH_HEAD"],
+            ]
+            for command in commands:
+                result = subprocess.run(
+                    command,
+                    text=True,
+                    capture_output=True,
+                    timeout=600,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        f"upstream checkout command failed: {' '.join(command)}; "
+                        f"{_diagnostic(result)}"
+                    )
+            staged.replace(checkout)
+
+        if not _checkout_matches(checkout, task_dir):
+            raise RuntimeError("pinned upstream checkout is incomplete or at the wrong commit")
+        _pin_task_image(task_dir, task_id)
+        return task_dir
+
+
+def _validate_candidate(candidate: Path) -> str | None:
+    try:
+        size = candidate.stat().st_size
+    except OSError as error:
+        return f"candidate bundle is unavailable: {error}"
+    if size > MAX_BUNDLE_BYTES:
+        return f"candidate bundle exceeds {MAX_BUNDLE_BYTES} bytes"
+    try:
+        files = parse_bundle(candidate.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, BundleError) as error:
+        return f"invalid candidate bundle: {error}"
+    return None if files else "candidate bundle contains no files"
+
+
+def _harbor_command(
+    *,
+    task_dir: Path,
+    candidate: Path,
+    target_dir: str,
+    prepare_command: str,
+    logs_dir: Path,
+    job_name: str,
+    environment: str,
+) -> list[str]:
+    package = (
+        f"harbor[modal]=={HARBOR_VERSION}"
+        if environment == "modal"
+        else f"harbor=={HARBOR_VERSION}"
+    )
+    agent_args = [
+        "--agent-kwarg",
+        f"candidate_path={candidate}",
+        "--agent-kwarg",
+        f"target_dir={target_dir}",
+    ]
+    if prepare_command:
+        agent_args.extend(["--agent-kwarg", f"prepare_command={prepare_command}"])
+
+    return [
+        "uvx",
+        "--python",
+        "3.12",
+        "--from",
+        package,
+        "harbor",
+        "run",
+        "--path",
+        str(task_dir),
+        "--agent",
+        "frontier_swe_grader.bundle_agent:BundleAgent",
+        *agent_args,
+        "--verifier",
+        "frontier_swe_grader.reward_verifier:FrontierSWEVerifier",
+        "--env",
+        environment,
+        "--jobs-dir",
+        str(logs_dir),
+        "--job-name",
+        job_name,
+        "--n-attempts",
+        "1",
+        "--n-concurrent",
+        "1",
+        "--yes",
+        "--quiet",
+    ]
+
+
+def _checkout_matches(checkout: Path, task_dir: Path) -> bool:
+    if not task_dir.is_dir():
+        return False
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == UPSTREAM_COMMIT
+
+
+def _pin_task_image(task_dir: Path, task_id: str) -> None:
+    task_config = task_dir / "task.toml"
+    text = task_config.read_text(encoding="utf-8")
+    pinned_line = f'docker_image = "{TASK_IMAGES[task_id]}"'
+    if pinned_line in text:
+        return
+    tagged_line = f'docker_image = "ghcr.io/proximal-labs/frontier-swe/{task_id}:v4"'
+    if text.count(tagged_line) != 1:
+        raise RuntimeError(f"could not locate the expected image tag in {task_config}")
+    task_config.write_text(text.replace(tagged_line, pinned_line), encoding="utf-8")
+
+
+def _read_trial_score(job_dir: Path) -> tuple[float, dict[str, Any]] | str:
+    if not job_dir.is_dir():
+        return f"job directory is missing: {job_dir}"
+    errors: list[str] = []
+    for result_path in sorted(job_dir.rglob("result.json")):
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            errors.append(f"{result_path.name}: {error}")
+            continue
+        verifier = payload.get("verifier_result")
+        if not isinstance(verifier, dict):
+            continue
+        rewards = verifier.get("rewards")
+        if not isinstance(rewards, dict):
+            continue
+        try:
+            reward = float(rewards["reward"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        return reward, payload
+    return "; ".join(errors) or "no trial result contained verifier_result.rewards.reward"
+
+
+def _read_reward_detail(job_dir: Path) -> dict[str, Any]:
+    for reward_path in sorted(job_dir.rglob("reward.json")):
+        try:
+            payload = json.loads(reward_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _feedback(
+    task_id: str,
+    reward: float,
+    environment: str,
+    job_dir: Path,
+    detail: dict[str, Any],
+    trial: dict[str, Any],
+) -> str:
+    lines = [
+        f"Official Frontier-SWE result for `{task_id}`: {reward:.12g}",
+        f"Harbor environment: `{environment}`",
+        f"Upstream commit: `{UPSTREAM_COMMIT}`",
+        f"Container image: `{TASK_IMAGES[task_id]}`",
+        f"Logs: `{job_dir}`",
+    ]
+    reason = detail.get("reason")
+    if reason:
+        lines.append(f"Reason: {reason}")
+    for key in (
+        "tests_passed",
+        "tests_total",
+        "total_passed",
+        "total_failed",
+        "total_skipped",
+        "score",
+        "reward",
+    ):
+        if key in detail:
+            lines.append(f"{key}: {detail[key]}")
+    if trial.get("exception_info"):
+        lines.append(f"Trial exception: {trial['exception_info']}")
+    return "\n".join(lines)
+
+
+def _diagnostic(completed: subprocess.CompletedProcess[str]) -> str:
+    pieces = []
+    for label, value in (("stdout", completed.stdout), ("stderr", completed.stderr)):
+        text = (value or "").strip()
+        if text:
+            pieces.append(f"{label}: {text[-2000:]}")
+    return " | ".join(pieces) or "no subprocess output"

--- a/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/reward_verifier.py
+++ b/examples/frontier_swe/dart-haskell/grader/src/frontier_swe_grader/reward_verifier.py
@@ -1,0 +1,22 @@
+"""Harbor verifier adapter that selects the scalar from Frontier-SWE details."""
+
+from __future__ import annotations
+
+import json
+
+from harbor.verifier.verifier import Verifier, VerifierOutputParseError
+
+
+class FrontierSWEVerifier(Verifier):
+    """Run Harbor's verifier unchanged, but return only its primary reward."""
+
+    def _parse_reward_json(self) -> dict[str, float | int]:
+        try:
+            payload = json.loads(self.trial_paths.reward_json_path.read_text())
+            value = payload.get("reward", payload.get("score"))
+            return {"reward": float(value)}
+        except (AttributeError, OSError, TypeError, ValueError) as error:
+            raise VerifierOutputParseError(
+                f"Frontier-SWE reward JSON has no numeric reward or score: "
+                f"{self.trial_paths.reward_json_path}"
+            ) from error

--- a/examples/frontier_swe/dart-haskell/seed/candidate.bundle
+++ b/examples/frontier_swe/dart-haskell/seed/candidate.bundle
@@ -1,0 +1,904 @@
+=== FILE: dart-style.cabal ===
+cabal-version:      3.0
+name:               dart-style
+version:            0.1.0.0
+build-type:         Simple
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Frontier SWE
+maintainer:         none
+synopsis:           Minimal Haskell Dart formatter CLI
+category:           Development
+
+executable dart-style
+  main-is:          Main.hs
+  hs-source-dirs:   app, src
+  other-modules:    CLI
+                  , Formatter
+                  , DirectiveFormatter
+                  , VariableFormatter
+  build-depends:    base >=4.18 && <5
+  default-language: Haskell2010
+  ghc-options:      -Wall -Wcompat -O2
+=== END FILE ===
+
+=== FILE: LICENSE ===
+BSD 3-Clause License
+
+Copyright (c) 2026, Frontier SWE
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=== END FILE ===
+
+=== FILE: app/Main.hs ===
+module Main (main) where
+
+import CLI (Options (..), ParseResult (..), parseArgs, usage, versionText)
+import Formatter (formatSource)
+import System.Environment (getArgs)
+import System.Exit (die)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case parseArgs args of
+    ParseHelp -> putStr usage
+    ParseVersion -> putStrLn versionText
+    ParseError message -> die (message ++ "\n\n" ++ usage)
+    ParseOk opts -> do
+      input <- readInput (optFiles opts)
+      putStr (formatSource opts input)
+
+readInput :: [FilePath] -> IO String
+readInput [] = getContents
+readInput paths = concat <$> mapM readFile paths
+=== END FILE ===
+
+=== FILE: src/CLI.hs ===
+module CLI
+  ( Options (..)
+  , Mode (..)
+  , TrailingCommas (..)
+  , ParseResult (..)
+  , defaultOptions
+  , parseArgs
+  , usage
+  , versionText
+  ) where
+
+import Data.Char (isDigit)
+import Text.Read (readMaybe)
+
+newtype LanguageVersion = LanguageVersion String
+  deriving (Eq, Show)
+
+data Mode
+  = Statement
+  | CompilationUnit
+  deriving (Eq, Show)
+
+data TrailingCommas
+  = TrailingCommasAutomate
+  | TrailingCommasPreserve
+  deriving (Eq, Show)
+
+data Options = Options
+  { optPageWidth :: Maybe Int
+  , optIndent :: Maybe Int
+  , optLanguageVersion :: Maybe LanguageVersion
+  , optMode :: Mode
+  , optTrailingCommas :: Maybe TrailingCommas
+  , optExperiments :: [String]
+  , optFiles :: [FilePath]
+  }
+  deriving (Eq, Show)
+
+data ParseResult
+  = ParseOk Options
+  | ParseHelp
+  | ParseVersion
+  | ParseError String
+  deriving (Eq, Show)
+
+defaultOptions :: Options
+defaultOptions =
+  Options
+    { optPageWidth = Nothing
+    , optIndent = Nothing
+    , optLanguageVersion = Nothing
+    , optMode = CompilationUnit
+    , optTrailingCommas = Nothing
+    , optExperiments = []
+    , optFiles = []
+    }
+
+versionText :: String
+versionText = "dart-style 0.1.0.0"
+
+usage :: String
+usage = unlines
+  [ "Usage: dart-style [options] [files...]"
+  , ""
+  , "Options:"
+  , "  --page-width N                 Accept page width (currently ignored)"
+  , "  --indent N                     Accept indentation width (currently ignored)"
+  , "  --language-version X.Y         Accept Dart language version (currently ignored)"
+  , "  --statement                    Treat input as a statement"
+  , "  --compilation-unit             Treat input as a compilation unit"
+  , "  --trailing-commas MODE         MODE is automate or preserve (currently ignored)"
+  , "  --enable-experiment NAME       Accept an enabled experiment name (ignored)"
+  , "  --help                         Show this help"
+  , "  --version                      Show version"
+  ]
+
+parseArgs :: [String] -> ParseResult
+parseArgs = go defaultOptions
+  where
+    go opts [] = ParseOk opts { optExperiments = reverse (optExperiments opts)
+                              , optFiles = reverse (optFiles opts)
+                              }
+    go _ ("--help" : _) = ParseHelp
+    go _ ("-h" : _) = ParseHelp
+    go _ ("--version" : _) = ParseVersion
+    go opts ("--statement" : rest) = go opts { optMode = Statement } rest
+    go opts ("--compilation-unit" : rest) = go opts { optMode = CompilationUnit } rest
+    go opts ("--" : rest) = ParseOk opts { optExperiments = reverse (optExperiments opts)
+                                          , optFiles = reverse (optFiles opts) ++ rest
+                                          }
+    go opts (arg : rest)
+      | Just value <- stripPrefixEq "--page-width=" arg = setInt "--page-width" (\n -> opts { optPageWidth = Just n }) value rest
+      | arg == "--page-width" = needValue arg rest $ \value rest' -> setInt arg (\n -> opts { optPageWidth = Just n }) value rest'
+      | Just value <- stripPrefixEq "--indent=" arg = setInt "--indent" (\n -> opts { optIndent = Just n }) value rest
+      | arg == "--indent" = needValue arg rest $ \value rest' -> setInt arg (\n -> opts { optIndent = Just n }) value rest'
+      | Just value <- stripPrefixEq "--language-version=" arg = setLanguage value rest
+      | arg == "--language-version" = needValue arg rest $ \value rest' -> setLanguage value rest'
+      | Just value <- stripPrefixEq "--trailing-commas=" arg = setTrailing value rest
+      | arg == "--trailing-commas" = needValue arg rest $ \value rest' -> setTrailing value rest'
+      | Just value <- stripPrefixEq "--enable-experiment=" arg = go opts { optExperiments = value : optExperiments opts } rest
+      | arg == "--enable-experiment" = needValue arg rest $ \value rest' -> go opts { optExperiments = value : optExperiments opts } rest'
+      | startsWithDash arg = ParseError ("unrecognized option: " ++ arg)
+      | otherwise = go opts { optFiles = arg : optFiles opts } rest
+      where
+        setLanguage value rest' =
+          if validLanguageVersion value
+            then go opts { optLanguageVersion = Just (LanguageVersion value) } rest'
+            else ParseError ("invalid --language-version: " ++ value)
+
+        setTrailing value rest' =
+          case value of
+            "automate" -> go opts { optTrailingCommas = Just TrailingCommasAutomate } rest'
+            "preserve" -> go opts { optTrailingCommas = Just TrailingCommasPreserve } rest'
+            _ -> ParseError ("invalid --trailing-commas: " ++ value)
+
+        setInt option update value rest' =
+          case readMaybe value of
+            Just n | n > (0 :: Int) -> go (update n) rest'
+            _ -> ParseError ("invalid " ++ option ++ ": " ++ value)
+
+needValue :: String -> [String] -> (String -> [String] -> ParseResult) -> ParseResult
+needValue option args continue =
+  case args of
+    [] -> ParseError ("missing value for " ++ option)
+    value : rest -> continue value rest
+
+stripPrefixEq :: String -> String -> Maybe String
+stripPrefixEq prefix text =
+  case splitAt (length prefix) text of
+    (front, back) | front == prefix -> Just back
+    _ -> Nothing
+
+startsWithDash :: String -> Bool
+startsWithDash ('-' : _) = True
+startsWithDash _ = False
+
+validLanguageVersion :: String -> Bool
+validLanguageVersion text =
+  case break (== '.') text of
+    (major, '.' : minor) -> all isDigit major && all isDigit minor && not (null major) && not (null minor)
+    _ -> False
+=== END FILE ===
+
+=== FILE: src/Formatter.hs ===
+module Formatter (formatSource) where
+
+import CLI (Mode (..), Options (..))
+import Data.List (intercalate, isInfixOf)
+import DirectiveFormatter (formatDirectiveLine)
+import VariableFormatter (formatVariable)
+
+formatSource :: Options -> String -> String
+formatSource opts source = ensureOneTrailingNewline formatted
+  where
+    normalized = normalizeLineEndings source
+    formatted =
+      case optMode opts of
+        CompilationUnit -> maybe (formatLines normalized) id (formatVariable normalized)
+        Statement -> formatLines normalized
+
+formatLines :: String -> String
+formatLines = intercalate "\n" . formatWithOffRegions . splitLines
+
+formatWithOffRegions :: [String] -> [String]
+formatWithOffRegions = go False
+  where
+    go _ [] = []
+    go False (line : rest)
+      | isFormatOffLine line = line : go True rest
+      | otherwise = formatDirectiveLine (normalizeLeadingTabs line) : go False rest
+    go True (line : rest)
+      | isFormatOnLine line = line : go False rest
+      | otherwise = line : go True rest
+
+normalizeLeadingTabs :: String -> String
+normalizeLeadingTabs [] = []
+normalizeLeadingTabs ('\t' : rest) = "  " ++ normalizeLeadingTabs rest
+normalizeLeadingTabs (' ' : rest) = ' ' : normalizeLeadingTabs rest
+normalizeLeadingTabs text = text
+
+isFormatOffLine :: String -> Bool
+isFormatOffLine = isInfixOf "// dart format off"
+
+isFormatOnLine :: String -> Bool
+isFormatOnLine = isInfixOf "// dart format on"
+
+splitLines :: String -> [String]
+splitLines [] = []
+splitLines text =
+  case break (== '\n') text of
+    (line, []) -> [line]
+    (line, _ : rest) -> line : splitLines rest
+
+normalizeLineEndings :: String -> String
+normalizeLineEndings [] = []
+normalizeLineEndings ('\r' : '\n' : rest) = '\n' : normalizeLineEndings rest
+normalizeLineEndings ('\r' : rest) = '\n' : normalizeLineEndings rest
+normalizeLineEndings (c : rest) = c : normalizeLineEndings rest
+
+ensureOneTrailingNewline :: String -> String
+ensureOneTrailingNewline text = dropTrailingNewlines text ++ "\n"
+
+dropTrailingNewlines :: String -> String
+dropTrailingNewlines = reverse . dropWhile (== '\n') . reverse
+=== END FILE ===
+
+=== FILE: src/DirectiveFormatter.hs ===
+module DirectiveFormatter (formatDirectiveLine) where
+
+import Data.Char (isAlpha, isAlphaNum, isSpace)
+import Data.List (isPrefixOf)
+
+data Piece
+  = Atom String
+  | Comma
+  deriving (Eq, Show)
+
+formatDirectiveLine :: String -> String
+formatDirectiveLine line =
+  case tryFormatDirective trimmed of
+    Just formatted -> formatted
+    Nothing -> trimmed
+  where
+    trimmed = trimTrailingSpaces line
+
+tryFormatDirective :: String -> Maybe String
+tryFormatDirective line
+  | null (dropWhile isHorizontalSpace line) = Nothing
+  | hasDangerousSyntax line = Nothing
+  | not (startsWithDirective stripped) = Nothing
+  | otherwise =
+      let (codeWithSpaces, commentSuffix0) = splitLineComment line
+          (code, spacesBeforeComment) = splitTrailingHorizontal codeWithSpaces
+          commentSuffix = spacesBeforeComment ++ commentSuffix0
+          codeTrim = trimHorizontal code
+       in if safeCompleteDirective codeTrim
+            then Just (renderDirectiveCode (dropFinalSemicolon codeTrim) ++ commentSuffix)
+            else Nothing
+  where
+    stripped = dropWhile isHorizontalSpace line
+
+startsWithDirective :: String -> Bool
+startsWithDirective text =
+  case span isIdentifierChar text of
+    (word, rest) -> word `elem` ["library", "import", "export", "part"] && boundary rest
+  where
+    boundary [] = True
+    boundary (c : _) = isHorizontalSpace c || c == '\'' || c == '"'
+
+hasDangerousSyntax :: String -> Bool
+hasDangerousSyntax text = any (`elem` ['{', '}']) text || "=>" `isPrefixInfixOf` text
+
+isPrefixInfixOf :: String -> String -> Bool
+isPrefixInfixOf needle haystack
+  | null needle = True
+  | needle `isPrefixOf` haystack = True
+  | otherwise =
+      case haystack of
+        [] -> False
+        _ : rest -> isPrefixInfixOf needle rest
+
+safeCompleteDirective :: String -> Bool
+safeCompleteDirective code =
+  not (null code) && last code == ';' && noExtraSemicolon (init code)
+
+noExtraSemicolon :: String -> Bool
+noExtraSemicolon = not . any (== ';') . maskStrings
+
+dropFinalSemicolon :: String -> String
+dropFinalSemicolon [] = []
+dropFinalSemicolon code = init code
+
+renderDirectiveCode :: String -> String
+renderDirectiveCode code =
+  case renderDottedNameDirective code of
+    Just rendered -> rendered ++ ";"
+    Nothing -> renderPieces (tokenizePieces code) ++ ";"
+
+renderDottedNameDirective :: String -> Maybe String
+renderDottedNameDirective code =
+  case consumeWord (trimHorizontal code) of
+    Just ("library", rest) -> do
+      name <- parseDottedName (trimHorizontal rest)
+      Just ("library " ++ name)
+    Just ("part", rest) -> do
+      (word, afterOf) <- consumeWord (trimHorizontal rest)
+      if word == "of"
+        then do
+          name <- parseDottedName (trimHorizontal afterOf)
+          Just ("part of " ++ name)
+        else Nothing
+    _ -> Nothing
+
+consumeWord :: String -> Maybe (String, String)
+consumeWord text =
+  let (word, rest) = span isIdentifierChar text
+   in if null word then Nothing else Just (word, rest)
+
+parseDottedName :: String -> Maybe String
+parseDottedName text = do
+  (firstPart, rest) <- parseIdentifier (dropWhile isHorizontalSpace text)
+  finish [firstPart] rest
+  where
+    finish parts rest0 =
+      case dropWhile isHorizontalSpace rest0 of
+        [] -> Just (joinWithDots (reverse parts))
+        '.' : more -> do
+          (part, rest1) <- parseIdentifier (dropWhile isHorizontalSpace more)
+          finish (part : parts) rest1
+        _ -> Nothing
+
+parseIdentifier :: String -> Maybe (String, String)
+parseIdentifier [] = Nothing
+parseIdentifier input@(c : _)
+  | not (isIdentifierStart c) = Nothing
+  | otherwise =
+      let (name, rest) = span isIdentifierChar input
+       in Just (name, rest)
+
+joinWithDots :: [String] -> String
+joinWithDots [] = ""
+joinWithDots [x] = x
+joinWithDots (x : xs) = x ++ "." ++ joinWithDots xs
+
+renderPieces :: [Piece] -> String
+renderPieces = foldl appendPiece ""
+
+appendPiece :: String -> Piece -> String
+appendPiece acc Comma = trimTrailingSpaces acc ++ ","
+appendPiece acc (Atom text)
+  | null text = acc
+  | null acc = text
+  | last acc == ',' = acc ++ " " ++ text
+  | otherwise = acc ++ " " ++ text
+
+tokenizePieces :: String -> [Piece]
+tokenizePieces [] = []
+tokenizePieces input@(c : cs)
+  | isHorizontalSpace c = tokenizePieces (dropWhile isHorizontalSpace cs)
+  | c == ',' = Comma : tokenizePieces cs
+  | startsString input = let (lit, rest) = scanString input in Atom lit : tokenizePieces rest
+  | startsConditional input, Just (cond, rest) <- scanConditional input = Atom cond : tokenizePieces rest
+  | otherwise = let (atom, rest) = breakAtom input in Atom atom : tokenizePieces rest
+
+startsConditional :: String -> Bool
+startsConditional ('i' : 'f' : rest) =
+  case dropWhile isHorizontalSpace rest of
+    '(' : _ -> True
+    _ -> False
+startsConditional _ = False
+
+scanConditional :: String -> Maybe (String, String)
+scanConditional input =
+  case dropWhile isHorizontalSpace (drop 2 input) of
+    '(' : rest ->
+      case scanParenContent 1 [] rest of
+        Just (contentReversed, remaining) ->
+          Just ("if (" ++ compactCondition (reverse contentReversed) ++ ")", remaining)
+        Nothing -> Nothing
+    _ -> Nothing
+
+scanParenContent :: Int -> String -> String -> Maybe (String, String)
+scanParenContent _ _ [] = Nothing
+scanParenContent depth acc input
+  | startsString input =
+      let (lit, rest) = scanString input
+       in scanParenContent depth (reverse lit ++ acc) rest
+scanParenContent 1 acc (')' : rest) = Just (acc, rest)
+scanParenContent depth acc (')' : rest) = scanParenContent (depth - 1) (')' : acc) rest
+scanParenContent depth acc ('(' : rest) = scanParenContent (depth + 1) ('(' : acc) rest
+scanParenContent depth acc (x : xs) = scanParenContent depth (x : acc) xs
+
+compactCondition :: String -> String
+compactCondition [] = []
+compactCondition input@(c : cs)
+  | startsString input = let (lit, rest) = scanString input in lit ++ compactCondition rest
+  | isHorizontalSpace c = compactCondition cs
+  | otherwise = c : compactCondition cs
+
+breakAtom :: String -> (String, String)
+breakAtom = span isAtomChar
+
+isAtomChar :: Char -> Bool
+isAtomChar c = not (isHorizontalSpace c) && c /= ',' && c /= ';' && c /= '\'' && c /= '"'
+
+splitLineComment :: String -> (String, String)
+splitLineComment = go []
+  where
+    go acc [] = (reverse acc, [])
+    go acc s@('/' : '/' : _) = (reverse acc, s)
+    go acc s
+      | startsString s =
+          let (lit, rest) = scanString s
+           in go (reverse lit ++ acc) rest
+    go acc (x : xs) = go (x : acc) xs
+
+maskStrings :: String -> String
+maskStrings [] = []
+maskStrings s@(c : cs)
+  | startsString s = let (lit, rest) = scanString s in replicate (length lit) ' ' ++ maskStrings rest
+  | otherwise = c : maskStrings cs
+
+startsString :: String -> Bool
+startsString ('\'' : _) = True
+startsString ('"' : _) = True
+startsString ('r' : '\'' : _) = True
+startsString ('r' : '"' : _) = True
+startsString ('R' : '\'' : _) = True
+startsString ('R' : '"' : _) = True
+startsString _ = False
+
+scanString :: String -> (String, String)
+scanString input =
+  let (rawPrefix, body) =
+        case input of
+          ('r' : q : rest) | q == '\'' || q == '"' -> ("r", q : rest)
+          ('R' : q : rest) | q == '\'' || q == '"' -> ("R", q : rest)
+          _ -> ("", input)
+   in case body of
+        [] -> (rawPrefix, [])
+        (quote : rest) ->
+          let triple = take 2 rest == [quote, quote]
+              afterOpen = if triple then drop 2 rest else rest
+              (content, remaining) = scanUntilStringEnd quote triple (not (null rawPrefix)) afterOpen
+              opener = if triple then [quote, quote, quote] else [quote]
+           in (rawPrefix ++ opener ++ content, remaining)
+
+scanUntilStringEnd :: Char -> Bool -> Bool -> String -> (String, String)
+scanUntilStringEnd quote triple raw = go []
+  where
+    go acc [] = (reverse acc, [])
+    go acc s@(x : xs)
+      | triple && take 3 s == [quote, quote, quote] = (reverse acc ++ [quote, quote, quote], drop 3 s)
+      | not triple && x == quote = (reverse (x : acc), xs)
+      | not raw && x == '\\' =
+          case xs of
+            [] -> (reverse (x : acc), [])
+            y : ys -> go (y : x : acc) ys
+      | otherwise = go (x : acc) xs
+
+trimHorizontal :: String -> String
+trimHorizontal = dropWhile isHorizontalSpace . trimTrailingSpaces
+
+trimTrailingSpaces :: String -> String
+trimTrailingSpaces = reverse . dropWhile isHorizontalSpace . reverse
+
+splitTrailingHorizontal :: String -> (String, String)
+splitTrailingHorizontal text =
+  let trailing = reverse (takeWhile isHorizontalSpace (reverse text))
+      front = take (length text - length trailing) text
+   in (front, trailing)
+
+isHorizontalSpace :: Char -> Bool
+isHorizontalSpace c = c == ' ' || c == '\t' || (isSpace c && c /= '\n')
+
+isIdentifierStart :: Char -> Bool
+isIdentifierStart c = isAlpha c || c == '_' || c == '$'
+
+isIdentifierChar :: Char -> Bool
+isIdentifierChar c = isAlphaNum c || c == '_' || c == '$'
+=== END FILE ===
+
+=== FILE: src/VariableFormatter.hs ===
+module VariableFormatter (formatVariable) where
+
+import Data.Char (isAlphaNum, isSpace)
+import Data.List (intercalate, isInfixOf)
+import Data.Maybe (isJust)
+
+data Tok
+  = WordTok String
+  | OpTok String
+  | CommaTok
+  | OpenTok Char
+  | CloseTok Char
+  deriving (Eq, Show)
+
+formatVariable :: String -> Maybe String
+formatVariable source = do
+  line <- singleLine (dropTrailingNewlines source)
+  let trimmed = trimHorizontal line
+  if safeVariableLine trimmed
+    then renderVariable trimmed
+    else Nothing
+
+singleLine :: String -> Maybe String
+singleLine text =
+  case break (== '\n') text of
+    (_, _ : _) -> Nothing
+    _ -> Just text
+
+safeVariableLine :: String -> Bool
+safeVariableLine text =
+  not (null text)
+    && last text == ';'
+    && (not (hasStringSyntax text) || isStringInitializedVariable text)
+    && not (hasCommentSyntax text)
+    && not (hasBraceSyntax text)
+    && not ("=>" `isInfixOf` text)
+    && balancedDelimiters text
+
+isStringInitializedVariable :: String -> Bool
+isStringInitializedVariable text =
+  case stripFinalSemicolon text of
+    Just withoutSemi -> isJust (renderStringInitialized withoutSemi)
+    Nothing -> False
+
+renderVariable :: String -> Maybe String
+renderVariable text = do
+  withoutSemi <- stripFinalSemicolon text
+  case renderStringInitialized withoutSemi of
+    Just rendered -> Just rendered
+    Nothing ->
+      case renderKeywordDeclarators withoutSemi of
+        Just rendered -> Just rendered
+        Nothing ->
+          case splitTopLevelEquals withoutSemi of
+            Just (prefix, expr) -> renderInitialized prefix expr
+            Nothing ->
+              if hasTopLevelEquals withoutSemi
+                then Nothing
+                else renderUninitialized withoutSemi
+
+renderStringInitialized :: String -> Maybe String
+renderStringInitialized text = do
+  (prefix, expr) <- splitTopLevelEqualsStringAware text
+  let prefixWords = words prefix
+      exprTrimmed = trimHorizontal expr
+  literal <- completeStringLiteral exprTrimmed
+  if validPrefix prefixWords
+    then Just (unwords prefixWords ++ " = " ++ literal ++ ";")
+    else Nothing
+
+completeStringLiteral :: String -> Maybe String
+completeStringLiteral text = do
+  (literal, rest) <- scanStringComplete text
+  if null (trimHorizontal rest) then Just literal else Nothing
+
+renderKeywordDeclarators :: String -> Maybe String
+renderKeywordDeclarators text = do
+  (keyword, rest0) <- consumeWord (trimHorizontal text)
+  if keyword `elem` ["var", "final", "const"]
+    then do
+      let body = trimHorizontal rest0
+      declarators <- splitTopLevelCommas body
+      rendered <- mapM renderDeclarator declarators
+      Just (keyword ++ " " ++ intercalate ", " rendered ++ ";")
+    else Nothing
+
+renderDeclarator :: String -> Maybe String
+renderDeclarator declarator = do
+  (namePart, expr) <- splitTopLevelEquals declarator
+  let name = trimHorizontal namePart
+      exprTrimmed = trimHorizontal expr
+  if isIdentifierName name && not (null exprTrimmed)
+    then Just (name ++ " = " ++ renderTokens (tokenize exprTrimmed))
+    else Nothing
+
+consumeWord :: String -> Maybe (String, String)
+consumeWord text =
+  let (word, rest) = span (not . isHorizontalSpace) text
+   in if null word then Nothing else Just (word, rest)
+
+splitTopLevelCommas :: String -> Maybe [String]
+splitTopLevelCommas text = go 0 0 [] [] text
+  where
+    go _ _ current pieces [] =
+      let piece = trimHorizontal (reverse current)
+       in if null piece then Nothing else Just (reverse (piece : pieces))
+    go parens brackets current pieces (',' : rest)
+      | parens == 0 && brackets == 0 =
+          let piece = trimHorizontal (reverse current)
+           in if null piece
+                then Nothing
+                else go parens brackets [] (piece : pieces) rest
+    go parens brackets current pieces (c : cs)
+      | c == '(' = go (parens + 1) brackets (c : current) pieces cs
+      | c == ')' = go (parens - 1) brackets (c : current) pieces cs
+      | c == '[' = go parens (brackets + 1) (c : current) pieces cs
+      | c == ']' = go parens (brackets - 1) (c : current) pieces cs
+      | otherwise = go parens brackets (c : current) pieces cs
+
+renderInitialized :: String -> String -> Maybe String
+renderInitialized prefix expr =
+  let prefixWords = words prefix
+      exprTrimmed = trimHorizontal expr
+   in if validPrefix prefixWords && not (null exprTrimmed)
+        then Just (unwords prefixWords ++ " = " ++ renderTokens (tokenize exprTrimmed) ++ ";")
+        else Nothing
+
+renderUninitialized :: String -> Maybe String
+renderUninitialized prefix =
+  let prefixWords = words prefix
+   in if validPrefix prefixWords && not (hasTopLevelComma prefix)
+        then Just (unwords prefixWords ++ ";")
+        else Nothing
+
+stripFinalSemicolon :: String -> Maybe String
+stripFinalSemicolon [] = Nothing
+stripFinalSemicolon text
+  | last text == ';' = Just (init text)
+  | otherwise = Nothing
+
+splitTopLevelEqualsStringAware :: String -> Maybe (String, String)
+splitTopLevelEqualsStringAware text = go 0 0 [] text Nothing
+  where
+    go _ _ _ [] (Just pair) = Just pair
+    go _ _ _ [] Nothing = Nothing
+    go parens brackets acc input found
+      | startsString input = do
+          (literal, rest) <- scanStringComplete input
+          go parens brackets (reverse literal ++ acc) rest found
+    go parens brackets acc ('=' : rest) found
+      | parens == 0 && brackets == 0 =
+          case rest of
+            '=' : _ -> Nothing
+            _ -> case found of
+                   Nothing -> go parens brackets [] rest (Just (reverse acc, rest))
+                   Just _ -> Nothing
+    go parens brackets acc (c : cs) found
+      | c == '(' = go (parens + 1) brackets (c : acc) cs found
+      | c == ')' = go (parens - 1) brackets (c : acc) cs found
+      | c == '[' = go parens (brackets + 1) (c : acc) cs found
+      | c == ']' = go parens (brackets - 1) (c : acc) cs found
+      | otherwise = go parens brackets (c : acc) cs found
+
+splitTopLevelEquals :: String -> Maybe (String, String)
+splitTopLevelEquals text = go 0 0 [] text Nothing
+  where
+    go _ _ _ [] (Just pair) = Just pair
+    go _ _ _ [] Nothing = Nothing
+    go parens brackets acc ('=' : rest) found
+      | parens == 0 && brackets == 0 =
+          case rest of
+            '=' : _ -> Nothing
+            _ -> case found of
+                   Nothing -> go parens brackets [] rest (Just (reverse acc, rest))
+                   Just _ -> Nothing
+    go parens brackets acc (c : cs) found
+      | c == '(' = go (parens + 1) brackets (c : acc) cs found
+      | c == ')' = go (parens - 1) brackets (c : acc) cs found
+      | c == '[' = go parens (brackets + 1) (c : acc) cs found
+      | c == ']' = go parens (brackets - 1) (c : acc) cs found
+      | otherwise = go parens brackets (c : acc) cs found
+
+hasTopLevelEquals :: String -> Bool
+hasTopLevelEquals = go 0 0
+  where
+    go _ _ [] = False
+    go parens brackets ('=' : _) | parens == 0 && brackets == 0 = True
+    go parens brackets (c : cs)
+      | c == '(' = go (parens + 1) brackets cs
+      | c == ')' = go (parens - 1) brackets cs
+      | c == '[' = go parens (brackets + 1) cs
+      | c == ']' = go parens (brackets - 1) cs
+      | otherwise = go parens brackets cs
+
+hasTopLevelComma :: String -> Bool
+hasTopLevelComma = go 0 0
+  where
+    go _ _ [] = False
+    go parens brackets (',' : _) | parens == 0 && brackets == 0 = True
+    go parens brackets (c : cs)
+      | c == '(' = go (parens + 1) brackets cs
+      | c == ')' = go (parens - 1) brackets cs
+      | c == '[' = go parens (brackets + 1) cs
+      | c == ']' = go parens (brackets - 1) cs
+      | otherwise = go parens brackets cs
+
+validPrefix :: [String] -> Bool
+validPrefix [] = False
+validPrefix ["var", name] = isIdentifierName name
+validPrefix ["final", name] = isIdentifierName name
+validPrefix ["const", name] = isIdentifierName name
+validPrefix [typ, name] = isSimpleType typ && isIdentifierName name
+validPrefix ["final", typ, name] = isSimpleType typ && isIdentifierName name
+validPrefix ["const", typ, name] = isSimpleType typ && isIdentifierName name
+validPrefix _ = False
+
+isSimpleType :: String -> Bool
+isSimpleType = all isTypeChar
+
+isTypeChar :: Char -> Bool
+isTypeChar c = isAlphaNum c || c `elem` "_$.<>?"
+
+isIdentifierName :: String -> Bool
+isIdentifierName [] = False
+isIdentifierName (c : cs) = isIdentifierStart c && all isIdentifierChar cs
+
+isIdentifierStart :: Char -> Bool
+isIdentifierStart c = c == '_' || c == '$' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+
+isIdentifierChar :: Char -> Bool
+isIdentifierChar c = isIdentifierStart c || ('0' <= c && c <= '9')
+
+hasStringSyntax :: String -> Bool
+hasStringSyntax = any (`elem` ['\'', '"'])
+
+hasCommentSyntax :: String -> Bool
+hasCommentSyntax text = "//" `isInfixOf` text || "/*" `isInfixOf` text
+
+hasBraceSyntax :: String -> Bool
+hasBraceSyntax = any (`elem` ['{', '}'])
+
+balancedDelimiters :: String -> Bool
+balancedDelimiters = go []
+  where
+    go [] [] = True
+    go stack [] = null stack
+    go stack (c : cs)
+      | c == '(' = go (c : stack) cs
+      | c == '[' = go (c : stack) cs
+      | c == ')' = close '(' stack cs
+      | c == ']' = close '[' stack cs
+      | otherwise = go stack cs
+    close expected (top : rest) cs | top == expected = go rest cs
+    close _ _ _ = False
+
+tokenize :: String -> [Tok]
+tokenize [] = []
+tokenize input@(c : cs)
+  | isHorizontalSpace c = tokenize (dropWhile isHorizontalSpace cs)
+  | c == ',' = CommaTok : tokenize cs
+  | c == '(' || c == '[' = OpenTok c : tokenize cs
+  | c == ')' || c == ']' = CloseTok c : tokenize cs
+  | Just (op, rest) <- takeOperator input = OpTok op : tokenize rest
+  | otherwise = let (word, rest) = span isWordChar input in WordTok word : tokenize rest
+
+takeOperator :: String -> Maybe (String, String)
+takeOperator input = firstMatch operators
+  where
+    firstMatch [] = Nothing
+    firstMatch (op : ops)
+      | op `prefixOf` input = Just (op, drop (length op) input)
+      | otherwise = firstMatch ops
+
+operators :: [String]
+operators = ["==", "!=", "<=", ">=", "&&", "||", "+", "-", "*", "/", "%", "<", ">"]
+
+prefixOf :: String -> String -> Bool
+prefixOf prefix text = take (length prefix) text == prefix
+
+isWordChar :: Char -> Bool
+isWordChar c =
+  not (isHorizontalSpace c)
+    && c /= ','
+    && c /= '('
+    && c /= ')'
+    && c /= '['
+    && c /= ']'
+    && not (any (`prefixOf` [c]) singleCharOperators)
+
+singleCharOperators :: [String]
+singleCharOperators = ["+", "-", "*", "/", "%", "<", ">", "&", "|"]
+
+renderTokens :: [Tok] -> String
+renderTokens = trimHorizontal . foldl appendTok ""
+
+appendTok :: String -> Tok -> String
+appendTok acc tok =
+  case tok of
+    WordTok word -> appendWord acc word
+    OpTok op -> trimTrailingSpaces acc ++ " " ++ op ++ " "
+    CommaTok -> trimTrailingSpaces acc ++ ", "
+    OpenTok ch -> trimTrailingSpaces acc ++ [ch]
+    CloseTok ch -> trimTrailingSpaces acc ++ [ch]
+
+appendWord :: String -> String -> String
+appendWord acc word
+  | null acc = word
+  | last acc `elem` " ([" = acc ++ word
+  | otherwise = acc ++ " " ++ word
+
+startsString :: String -> Bool
+startsString ('\'' : _) = True
+startsString ('"' : _) = True
+startsString ('r' : '\'' : _) = True
+startsString ('r' : '"' : _) = True
+startsString ('R' : '\'' : _) = True
+startsString ('R' : '"' : _) = True
+startsString _ = False
+
+scanStringComplete :: String -> Maybe (String, String)
+scanStringComplete input =
+  let (rawPrefix, body) =
+        case input of
+          ('r' : q : rest) | q == '\'' || q == '"' -> ("r", q : rest)
+          ('R' : q : rest) | q == '\'' || q == '"' -> ("R", q : rest)
+          _ -> ("", input)
+   in case body of
+        quote : rest | quote == '\'' || quote == '"' -> do
+          let triple = take 2 rest == [quote, quote]
+              afterOpen = if triple then drop 2 rest else rest
+              opener = if triple then [quote, quote, quote] else [quote]
+          (content, remaining) <- scanUntilStringEndComplete quote triple (not (null rawPrefix)) afterOpen
+          Just (rawPrefix ++ opener ++ content, remaining)
+        _ -> Nothing
+
+scanUntilStringEndComplete :: Char -> Bool -> Bool -> String -> Maybe (String, String)
+scanUntilStringEndComplete quote triple raw = go []
+  where
+    go _ [] = Nothing
+    go acc s@(x : xs)
+      | triple && take 3 s == [quote, quote, quote] = Just (reverse acc ++ [quote, quote, quote], drop 3 s)
+      | not triple && x == quote = Just (reverse (x : acc), xs)
+      | not raw && x == '\\' =
+          case xs of
+            [] -> Nothing
+            y : ys -> go (y : x : acc) ys
+      | otherwise = go (x : acc) xs
+
+trimHorizontal :: String -> String
+trimHorizontal = dropWhile isHorizontalSpace . trimTrailingSpaces
+
+trimTrailingSpaces :: String -> String
+trimTrailingSpaces = reverse . dropWhile isHorizontalSpace . reverse
+
+dropTrailingNewlines :: String -> String
+dropTrailingNewlines = reverse . dropWhile (== '\n') . reverse
+
+isHorizontalSpace :: Char -> Bool
+isHorizontalSpace c = c == ' ' || c == '\t' || (isSpace c && c /= '\n')
+=== END FILE ===

--- a/examples/frontier_swe/dart-haskell/task.yaml
+++ b/examples/frontier_swe/dart-haskell/task.yaml
@@ -1,0 +1,47 @@
+task:
+  name: "Frontier-SWE · dart_style to Haskell"
+  description: |
+    Improve `candidate.bundle`, a Haskell reimplementation of dart_style 3.1.4
+    materialized at `/app/dart-style` in the pinned official Frontier-SWE task
+    image. `cabal build all` must produce a `dart-style` executable compatible
+    with the documented CLI, including page width, indentation, language
+    version, statement, compilation-unit, trailing-comma, and experiment flags.
+
+    Support both short style (Dart language <=3.6) and tall style (>3.6). The
+    official score is the byte-for-byte golden-test pass rate after build and
+    anti-cheat gates. Do not delegate to Dart or another external formatter.
+  tips: |
+    Bundle sections use `=== FILE: relative/path ===` and `=== END FILE ===`.
+    Include complete file contents, without Markdown fences or prose. Paths are
+    relative to `/app/dart-style`. The seed's validated official score is 0.0546
+    (285/5224 tests).
+
+grader:
+  entrypoint: "frontier_swe_grader.grader:Grader"
+  setup:
+    - "uv pip install -e ./grader"
+  timeout: 90000
+  direction: maximize
+  args:
+    task_id: "dart-style-haskell"
+    program_file: "candidate.bundle"
+  parallel:
+    max_workers: 1
+  max_pending_per_agent: 1
+
+agents:
+  count: 1
+  runtime: codex
+  model: gpt-5.5
+  research: false
+  runtime_options:
+    model_reasoning_effort: high
+
+workspace:
+  results_dir: "./results"
+  repo_path: "./examples/frontier_swe/dart-haskell/seed"
+
+run:
+  verbose: false
+  ui: false
+  session: local

--- a/examples/frontier_swe/git-to-zig/grader/pyproject.toml
+++ b/examples/frontier_swe/git-to-zig/grader/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "frontier-swe-grader"
+version = "0.1.0"
+description = "CORAL grader for pinned Frontier-SWE tasks executed through Harbor."
+requires-python = ">=3.11"
+dependencies = ["coral"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/frontier_swe_grader"]

--- a/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/__init__.py
+++ b/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned Frontier-SWE grader for CORAL and its isolated Harbor agent."""

--- a/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/bundle.py
+++ b/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/bundle.py
@@ -1,0 +1,78 @@
+"""Strict parser for the cumulative source-bundle candidate format."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+
+_FILE_HEADER = re.compile(r"^=== FILE: (.+) ===$")
+_FILE_FOOTER = "=== END FILE ==="
+
+
+class BundleError(ValueError):
+    """Raised when a candidate bundle is malformed or unsafe to materialize."""
+
+
+def parse_bundle(text: str) -> list[tuple[PurePosixPath, str]]:
+    """Parse a bundle while rejecting ambiguous or escaping paths."""
+
+    if "\x00" in text:
+        raise BundleError("bundle contains a NUL byte")
+
+    lines = text.splitlines(keepends=True)
+    files: list[tuple[PurePosixPath, str]] = []
+    seen: set[PurePosixPath] = set()
+    index = 0
+
+    while index < len(lines):
+        if not lines[index].strip():
+            index += 1
+            continue
+
+        header = lines[index].rstrip("\r\n")
+        match = _FILE_HEADER.fullmatch(header)
+        if match is None:
+            raise BundleError(f"expected file header at line {index + 1}")
+
+        relative = _safe_relative_path(match.group(1))
+        if relative in seen:
+            raise BundleError(f"duplicate file section: {relative}")
+        seen.add(relative)
+        index += 1
+
+        content: list[str] = []
+        while index < len(lines) and lines[index].rstrip("\r\n") != _FILE_FOOTER:
+            content.append(lines[index])
+            index += 1
+        if index >= len(lines):
+            raise BundleError(f"missing end marker for {relative}")
+
+        files.append((relative, "".join(content)))
+        index += 1
+
+    if not files:
+        raise BundleError("bundle contains no files")
+    return files
+
+
+def materialize_bundle(text: str, destination: Path) -> list[Path]:
+    """Write parsed bundle files below an already isolated destination."""
+
+    written: list[Path] = []
+    for relative, content in parse_bundle(text):
+        output = destination.joinpath(*relative.parts)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content, encoding="utf-8")
+        written.append(output)
+    return written
+
+
+def _safe_relative_path(raw: str) -> PurePosixPath:
+    if not raw or "\\" in raw:
+        raise BundleError(f"invalid bundle path: {raw!r}")
+    path = PurePosixPath(raw)
+    if path.is_absolute() or path.as_posix() != raw:
+        raise BundleError(f"bundle path must be normalized and relative: {raw!r}")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise BundleError(f"bundle path escapes or aliases the workspace: {raw!r}")
+    return path

--- a/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/bundle_agent.py
+++ b/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/bundle_agent.py
@@ -1,0 +1,59 @@
+"""Harbor agent that uploads a deterministic bundle instead of invoking an LLM."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+from .bundle import materialize_bundle
+
+
+class BundleAgent(BaseAgent):
+    """Materialize the CORAL candidate into the official task workspace."""
+
+    def __init__(
+        self,
+        *args: object,
+        candidate_path: str,
+        target_dir: str,
+        prepare_command: str = "",
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._candidate_path = Path(candidate_path)
+        self._target_dir = target_dir
+        self._prepare_command = prepare_command
+
+    @staticmethod
+    def name() -> str:
+        return "frontier-swe-bundle"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        return None
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        del instruction, context
+        candidate = self._candidate_path.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="frontier-swe-candidate-") as temporary:
+            source_dir = Path(temporary)
+            materialize_bundle(candidate, source_dir)
+            await environment.upload_dir(source_dir=source_dir, target_dir=self._target_dir)
+        if self._prepare_command:
+            result = await environment.exec(command=self._prepare_command, timeout_sec=600)
+            if result.return_code != 0:
+                raise RuntimeError(
+                    f"candidate preparation failed with exit {result.return_code}: "
+                    f"{result.stderr[-2000:]}"
+                )

--- a/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/grader.py
+++ b/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/grader.py
@@ -1,0 +1,362 @@
+"""Evaluate a CORAL source bundle with a pinned official Frontier-SWE task."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from coral.grader import TaskGrader
+from coral.types import ScoreBundle
+
+from .bundle import BundleError, parse_bundle
+
+UPSTREAM_URL = "https://github.com/Proximal-Labs/frontier-swe.git"
+UPSTREAM_COMMIT = "111464af7933002a9192240798cbcf65d2790296"
+HARBOR_VERSION = "0.22.0"
+MAX_BUNDLE_BYTES = 10 * 1024 * 1024
+TASK_TARGETS = {
+    "git-to-zig": "/app/zig-port",
+    "lua-native-compiler": "/app/lua-native-compiler",
+    "libexpat-to-x86asm": "/app/asm-port",
+    "dart-style-haskell": "/app/dart-style",
+}
+TASK_IMAGES = {
+    "git-to-zig": "ghcr.io/proximal-labs/frontier-swe/git-to-zig@sha256:04a78190d62e5ab7b396d8cb094f964149531aad5277aa3d98ec833f4ea7eb00",
+    "lua-native-compiler": "ghcr.io/proximal-labs/frontier-swe/lua-native-compiler@sha256:20d39c61f936bec8a6f7e1681a3c78f978a7fd4968913e31fb06a0929a4a9561",
+    "libexpat-to-x86asm": "ghcr.io/proximal-labs/frontier-swe/libexpat-to-x86asm@sha256:c2b36a040add352f7f19ddb1efcb10e2259e4540835b7b480e166b00d41f61bd",
+    "dart-style-haskell": "ghcr.io/proximal-labs/frontier-swe/dart-style-haskell@sha256:c0d816853d0bdbda0761c000edca9e7f10a2c3926e7d7ff66e96ecf38903eb8d",
+}
+TASK_PREPARE_COMMANDS = {
+    "libexpat-to-x86asm": "cd /app/asm-port && make",
+}
+
+
+class Grader(TaskGrader):
+    """Run one official Harbor verifier and return its scalar reward."""
+
+    def evaluate(self) -> ScoreBundle:
+        try:
+            return self._evaluate()
+        except Exception as error:
+            return self.fail(f"Frontier-SWE grader failed: {type(error).__name__}: {error}")
+
+    def _evaluate(self) -> ScoreBundle:
+        task_id = str(self.args.get("task_id", ""))
+        if task_id not in TASK_TARGETS:
+            return self.fail(f"unsupported Frontier-SWE task_id: {task_id!r}")
+
+        program_file = str(self.args.get("program_file", "candidate.bundle"))
+        candidate = Path(self.codebase_path) / program_file
+        bundle_error = _validate_candidate(candidate)
+        if bundle_error is not None:
+            return self.fail(bundle_error)
+
+        task_dir = self._official_task_dir(task_id)
+        harbor_logs = Path(self.eval_logs_dir) / "harbor_logs"
+        harbor_logs.mkdir(parents=True, exist_ok=True)
+        job_name = f"frontier_swe_{task_id}_{int(time.time())}"
+        environment = os.environ.get(
+            "CORAL_FRONTIER_SWE_HARBOR_ENVIRONMENT",
+            str(self.args.get("environment", "docker")),
+        )
+
+        command = _harbor_command(
+            task_dir=task_dir,
+            candidate=candidate,
+            target_dir=TASK_TARGETS[task_id],
+            prepare_command=TASK_PREPARE_COMMANDS.get(task_id, ""),
+            logs_dir=harbor_logs,
+            job_name=job_name,
+            environment=environment,
+        )
+        env = os.environ.copy()
+        grader_src = str(Path(__file__).resolve().parents[1])
+        env["PYTHONPATH"] = os.pathsep.join(
+            path for path in (grader_src, env.get("PYTHONPATH", "")) if path
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=task_dir,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            return self.fail(f"Harbor evaluation timed out after {self.timeout}s: {error}")
+        except OSError as error:
+            return self.fail(f"could not launch Harbor: {error}")
+
+        job_dir = harbor_logs / job_name
+        parsed = _read_trial_score(job_dir)
+        if isinstance(parsed, str):
+            return self.fail(
+                f"Harbor produced no official score (exit {completed.returncode}): {parsed}. "
+                f"{_diagnostic(completed)}"
+            )
+
+        reward, trial = parsed
+        detail = _read_reward_detail(job_dir)
+        feedback = _feedback(
+            task_id,
+            reward,
+            environment,
+            self.eval_logs_worktree_path(job_dir),
+            detail,
+            trial,
+        )
+        explanation = f"official frontier_reward={reward:.12g} ({task_id}, Harbor {environment})"
+        return self.score(
+            reward,
+            explanation=explanation,
+            feedback=feedback,
+            metadata={
+                "task_id": task_id,
+                "upstream_commit": UPSTREAM_COMMIT,
+                "container_image": TASK_IMAGES[task_id],
+                "harbor_environment": environment,
+            },
+        )
+
+    def _official_task_dir(self, task_id: str) -> Path:
+        private_dir = Path(self.private_dir)
+        private_dir.mkdir(parents=True, exist_ok=True)
+        checkout = private_dir / f"frontier-swe-{UPSTREAM_COMMIT[:12]}"
+        task_dir = checkout / "tasks" / task_id
+        if _checkout_matches(checkout, task_dir):
+            _pin_task_image(task_dir, task_id)
+            return task_dir
+
+        if checkout.exists():
+            shutil.rmtree(checkout)
+        with tempfile.TemporaryDirectory(
+            prefix="frontier-swe-checkout-", dir=private_dir
+        ) as temporary:
+            staged = Path(temporary) / "repo"
+            commands = [
+                ["git", "init", str(staged)],
+                ["git", "-C", str(staged), "remote", "add", "origin", UPSTREAM_URL],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "sparse-checkout",
+                    "set",
+                    "--no-cone",
+                    f"/tasks/{task_id}/",
+                    f"!/tasks/{task_id}/solution/",
+                    f"!/tasks/{task_id}/environment/*",
+                    f"/tasks/{task_id}/environment/Dockerfile",
+                ],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "fetch",
+                    "--filter=blob:none",
+                    "--depth",
+                    "1",
+                    "origin",
+                    UPSTREAM_COMMIT,
+                ],
+                ["git", "-C", str(staged), "checkout", "--detach", "FETCH_HEAD"],
+            ]
+            for command in commands:
+                result = subprocess.run(
+                    command,
+                    text=True,
+                    capture_output=True,
+                    timeout=600,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        f"upstream checkout command failed: {' '.join(command)}; "
+                        f"{_diagnostic(result)}"
+                    )
+            staged.replace(checkout)
+
+        if not _checkout_matches(checkout, task_dir):
+            raise RuntimeError("pinned upstream checkout is incomplete or at the wrong commit")
+        _pin_task_image(task_dir, task_id)
+        return task_dir
+
+
+def _validate_candidate(candidate: Path) -> str | None:
+    try:
+        size = candidate.stat().st_size
+    except OSError as error:
+        return f"candidate bundle is unavailable: {error}"
+    if size > MAX_BUNDLE_BYTES:
+        return f"candidate bundle exceeds {MAX_BUNDLE_BYTES} bytes"
+    try:
+        files = parse_bundle(candidate.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, BundleError) as error:
+        return f"invalid candidate bundle: {error}"
+    return None if files else "candidate bundle contains no files"
+
+
+def _harbor_command(
+    *,
+    task_dir: Path,
+    candidate: Path,
+    target_dir: str,
+    prepare_command: str,
+    logs_dir: Path,
+    job_name: str,
+    environment: str,
+) -> list[str]:
+    package = (
+        f"harbor[modal]=={HARBOR_VERSION}"
+        if environment == "modal"
+        else f"harbor=={HARBOR_VERSION}"
+    )
+    agent_args = [
+        "--agent-kwarg",
+        f"candidate_path={candidate}",
+        "--agent-kwarg",
+        f"target_dir={target_dir}",
+    ]
+    if prepare_command:
+        agent_args.extend(["--agent-kwarg", f"prepare_command={prepare_command}"])
+
+    return [
+        "uvx",
+        "--python",
+        "3.12",
+        "--from",
+        package,
+        "harbor",
+        "run",
+        "--path",
+        str(task_dir),
+        "--agent",
+        "frontier_swe_grader.bundle_agent:BundleAgent",
+        *agent_args,
+        "--verifier",
+        "frontier_swe_grader.reward_verifier:FrontierSWEVerifier",
+        "--env",
+        environment,
+        "--jobs-dir",
+        str(logs_dir),
+        "--job-name",
+        job_name,
+        "--n-attempts",
+        "1",
+        "--n-concurrent",
+        "1",
+        "--yes",
+        "--quiet",
+    ]
+
+
+def _checkout_matches(checkout: Path, task_dir: Path) -> bool:
+    if not task_dir.is_dir():
+        return False
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == UPSTREAM_COMMIT
+
+
+def _pin_task_image(task_dir: Path, task_id: str) -> None:
+    task_config = task_dir / "task.toml"
+    text = task_config.read_text(encoding="utf-8")
+    pinned_line = f'docker_image = "{TASK_IMAGES[task_id]}"'
+    if pinned_line in text:
+        return
+    tagged_line = f'docker_image = "ghcr.io/proximal-labs/frontier-swe/{task_id}:v4"'
+    if text.count(tagged_line) != 1:
+        raise RuntimeError(f"could not locate the expected image tag in {task_config}")
+    task_config.write_text(text.replace(tagged_line, pinned_line), encoding="utf-8")
+
+
+def _read_trial_score(job_dir: Path) -> tuple[float, dict[str, Any]] | str:
+    if not job_dir.is_dir():
+        return f"job directory is missing: {job_dir}"
+    errors: list[str] = []
+    for result_path in sorted(job_dir.rglob("result.json")):
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            errors.append(f"{result_path.name}: {error}")
+            continue
+        verifier = payload.get("verifier_result")
+        if not isinstance(verifier, dict):
+            continue
+        rewards = verifier.get("rewards")
+        if not isinstance(rewards, dict):
+            continue
+        try:
+            reward = float(rewards["reward"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        return reward, payload
+    return "; ".join(errors) or "no trial result contained verifier_result.rewards.reward"
+
+
+def _read_reward_detail(job_dir: Path) -> dict[str, Any]:
+    for reward_path in sorted(job_dir.rglob("reward.json")):
+        try:
+            payload = json.loads(reward_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _feedback(
+    task_id: str,
+    reward: float,
+    environment: str,
+    job_dir: Path,
+    detail: dict[str, Any],
+    trial: dict[str, Any],
+) -> str:
+    lines = [
+        f"Official Frontier-SWE result for `{task_id}`: {reward:.12g}",
+        f"Harbor environment: `{environment}`",
+        f"Upstream commit: `{UPSTREAM_COMMIT}`",
+        f"Container image: `{TASK_IMAGES[task_id]}`",
+        f"Logs: `{job_dir}`",
+    ]
+    reason = detail.get("reason")
+    if reason:
+        lines.append(f"Reason: {reason}")
+    for key in (
+        "tests_passed",
+        "tests_total",
+        "total_passed",
+        "total_failed",
+        "total_skipped",
+        "score",
+        "reward",
+    ):
+        if key in detail:
+            lines.append(f"{key}: {detail[key]}")
+    if trial.get("exception_info"):
+        lines.append(f"Trial exception: {trial['exception_info']}")
+    return "\n".join(lines)
+
+
+def _diagnostic(completed: subprocess.CompletedProcess[str]) -> str:
+    pieces = []
+    for label, value in (("stdout", completed.stdout), ("stderr", completed.stderr)):
+        text = (value or "").strip()
+        if text:
+            pieces.append(f"{label}: {text[-2000:]}")
+    return " | ".join(pieces) or "no subprocess output"

--- a/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/reward_verifier.py
+++ b/examples/frontier_swe/git-to-zig/grader/src/frontier_swe_grader/reward_verifier.py
@@ -1,0 +1,22 @@
+"""Harbor verifier adapter that selects the scalar from Frontier-SWE details."""
+
+from __future__ import annotations
+
+import json
+
+from harbor.verifier.verifier import Verifier, VerifierOutputParseError
+
+
+class FrontierSWEVerifier(Verifier):
+    """Run Harbor's verifier unchanged, but return only its primary reward."""
+
+    def _parse_reward_json(self) -> dict[str, float | int]:
+        try:
+            payload = json.loads(self.trial_paths.reward_json_path.read_text())
+            value = payload.get("reward", payload.get("score"))
+            return {"reward": float(value)}
+        except (AttributeError, OSError, TypeError, ValueError) as error:
+            raise VerifierOutputParseError(
+                f"Frontier-SWE reward JSON has no numeric reward or score: "
+                f"{self.trial_paths.reward_json_path}"
+            ) from error

--- a/examples/frontier_swe/git-to-zig/seed/candidate.bundle
+++ b/examples/frontier_swe/git-to-zig/seed/candidate.bundle
@@ -1,0 +1,284 @@
+=== FILE: src/main.zig ===
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const GlobalOptions = struct { git_dir: ?[]const u8 = null, work_tree: ?[]const u8 = null, bare: bool = false };
+const Repository = struct { git_dir: []const u8, work_tree: ?[]const u8 = null, bare: bool = false };
+const Obj = struct { typ: []const u8, data: []const u8, storage: []u8 };
+const IndexEntry = struct { path: []const u8, oid: [20]u8, mode: u32 = 0o100644, size: u32 = 0 };
+const RefEntry = struct { name: []const u8, oid: []const u8 };
+const ConfigEntry = struct { key: []const u8, value: []const u8 };
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const a = gpa.allocator();
+    const args = try std.process.argsAlloc(a);
+    defer std.process.argsFree(a, args);
+    var g = GlobalOptions{};
+    var i: usize = 1;
+    while (i < args.len) {
+        const x = args[i];
+        if (std.mem.eql(u8, x, "-C")) { i += 1; if (i >= args.len) return die("option '-C' requires a value", .{}); try std.posix.chdir(args[i]); i += 1; }
+        else if (std.mem.startsWith(u8, x, "-C") and x.len > 2) { try std.posix.chdir(x[2..]); i += 1; }
+        else if (std.mem.eql(u8, x, "--git-dir")) { i += 1; if (i >= args.len) return die("option '--git-dir' requires a value", .{}); g.git_dir = args[i]; i += 1; }
+        else if (std.mem.startsWith(u8, x, "--git-dir=")) { g.git_dir = x[10..]; i += 1; }
+        else if (std.mem.eql(u8, x, "--work-tree")) { i += 1; if (i >= args.len) return die("option '--work-tree' requires a value", .{}); g.work_tree = args[i]; i += 1; }
+        else if (std.mem.startsWith(u8, x, "--work-tree=")) { g.work_tree = x[12..]; i += 1; }
+        else if (std.mem.eql(u8, x, "--bare")) { g.bare = true; i += 1; }
+        else if (std.mem.eql(u8, x, "--help")) return cmdHelp(a, g, &[_][]const u8{})
+        else if (std.mem.eql(u8, x, "--version") or std.mem.eql(u8, x, "-v")) { try std.io.getStdOut().writer().writeAll("git version 2.47.0\n"); return; }
+        else break;
+    }
+    if (i >= args.len) return usage();
+    const cmd = args[i]; i += 1;
+    if (std.mem.eql(u8, cmd, "help")) return cmdHelp(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "init")) return cmdInit(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "hash-object")) return cmdHashObject(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "cat-file")) return cmdCatFile(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "add")) return cmdAdd(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "update-index")) return cmdUpdateIndex(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "ls-files")) return cmdLsFiles(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "write-tree")) return cmdWriteTree(a, g);
+    if (std.mem.eql(u8, cmd, "status")) return cmdStatus(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "symbolic-ref")) return cmdSymbolicRef(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "update-ref")) return cmdUpdateRef(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "show-ref")) return cmdShowRef(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "config")) return cmdConfig(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "rev-parse")) return cmdRevParse(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "merge-base")) return cmdMergeBase(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "rev-list")) return cmdRevList(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "branch")) return cmdBranch(a, g, args[i..]);
+    if (std.mem.eql(u8, cmd, "version") or std.mem.eql(u8, cmd, "--version")) { try std.io.getStdOut().writer().writeAll("git version 2.47.0\n"); return; }
+    if (std.mem.eql(u8, cmd, "rm") or std.mem.eql(u8, cmd, "clean") or std.mem.eql(u8, cmd, "commit-tree") or std.mem.eql(u8, cmd, "commit") or std.mem.eql(u8, cmd, "tag") or std.mem.eql(u8, cmd, "checkout") or std.mem.eql(u8, cmd, "reset") or std.mem.eql(u8, cmd, "diff") or std.mem.eql(u8, cmd, "log") or std.mem.eql(u8, cmd, "show")) return emptyCmd(a, g, args[i..]);
+    return die("'{s}' is not a git command", .{cmd});
+}
+
+fn emptyCmd(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { _ = a; _ = g; _ = argv; }
+fn usage() !void { try std.io.getStdErr().writer().writeAll("usage: git <command> [<args>]\n"); std.process.exit(1); }
+fn die(comptime f: []const u8, v: anytype) !void { try std.io.getStdErr().writer().print("fatal: " ++ f ++ "\n", v); std.process.exit(128); }
+fn exists(p: []const u8) bool { std.fs.cwd().access(p, .{}) catch return false; return true; }
+fn cmdHelp(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { _ = a; _ = g; const w = std.io.getStdOut().writer(); if (argv.len == 0) { try w.writeAll("usage: git <command> [<args>]\n\nCommon Git commands: init, add, status, config, hash-object, cat-file, ls-files, rev-parse\n"); return; } if (std.mem.eql(u8, argv[0], "-a") or std.mem.eql(u8, argv[0], "--all")) { try w.writeAll("add\nbranch\ncat-file\nconfig\nhash-object\nhelp\ninit\nls-files\nmerge-base\nrev-list\nrev-parse\nshow-ref\nstatus\nsymbolic-ref\nupdate-index\nupdate-ref\nwrite-tree\n"); return; } try w.print("usage: git {s} [<args>]\n", .{argv[0]}); }
+
+fn cmdInit(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void {
+    var bare = g.bare; var quiet = false; var branch: []const u8 = "master"; var dir: ?[]const u8 = null; var i: usize = 0;
+    while (i < argv.len) { const x = argv[i]; if (std.mem.eql(u8, x, "--bare")) bare = true else if (std.mem.eql(u8, x, "-q") or std.mem.eql(u8, x, "--quiet")) quiet = true else if (std.mem.eql(u8, x, "-b") or std.mem.eql(u8, x, "--initial-branch")) { i += 1; if (i >= argv.len) return die("option '{s}' requires a value", .{x}); branch = argv[i]; } else if (std.mem.startsWith(u8, x, "--initial-branch=")) branch = x[17..] else if (dir == null) dir = x else return die("cannot use more than one directory with 'git init'", .{}); i += 1; }
+    const gd = if (bare) (g.git_dir orelse dir orelse ".") else blk: { if (dir orelse g.work_tree) |w| { try std.fs.cwd().makePath(w); break :blk g.git_dir orelse try std.fs.path.join(a, &.{ w, ".git" }); } break :blk g.git_dir orelse ".git"; };
+    const old = exists(try std.fs.path.join(a, &.{ gd, "HEAD" }));
+    try makeLayout(a, gd); try writeFileFmt(a, gd, "HEAD", "ref: refs/heads/{s}\n", .{branch}); try writeFileFmt(a, gd, "config", "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = {s}\n", .{if (bare) "true" else "false"}); try writeFileFmt(a, gd, "description", "Unnamed repository; edit this file 'description' to name the repository.\n", .{});
+    if (!quiet) { const real = std.fs.cwd().realpathAlloc(a, gd) catch try a.dupe(u8, gd); try std.io.getStdOut().writer().print("{s} Git repository in {s}/\n", .{ if (old) "Reinitialized existing" else "Initialized empty", real }); }
+}
+fn makeLayout(a: Allocator, gd: []const u8) !void { try std.fs.cwd().makePath(gd); const ds = [_][]const u8{ "objects", "objects/info", "objects/pack", "refs/heads", "refs/tags", "branches", "hooks", "info" }; for (ds) |d| try std.fs.cwd().makePath(try std.fs.path.join(a, &.{ gd, d })); }
+fn writeFileFmt(a: Allocator, gd: []const u8, name: []const u8, comptime fmt: []const u8, vals: anytype) !void { const p = try std.fs.path.join(a, &.{ gd, name }); if (std.fs.path.dirname(p)) |d| try std.fs.cwd().makePath(d); const f = try std.fs.cwd().createFile(p, .{ .truncate = true }); defer f.close(); try f.writer().print(fmt, vals); }
+fn repo(a: Allocator, g: GlobalOptions) !Repository { if (g.git_dir) |gd| return .{ .git_dir = try a.dupe(u8, gd), .work_tree = g.work_tree, .bare = g.bare }; var cur = try std.fs.cwd().realpathAlloc(a, "."); while (true) { const dg = try std.fs.path.join(a, &.{ cur, ".git" }); if (exists(dg)) return .{ .git_dir = dg, .work_tree = cur }; const parent = std.fs.path.dirname(cur) orelse break; if (std.mem.eql(u8, parent, cur)) break; cur = try a.dupe(u8, parent); } try die("not a git repository (or any of the parent directories): .git", .{}); unreachable; }
+
+fn objPath(a: Allocator, gd: []const u8, oid: []const u8) ![]const u8 { return std.fs.path.join(a, &.{ gd, "objects", oid[0..2], oid[2..] }); }
+fn fmtObj(a: Allocator, typ: []const u8, data: []const u8) ![]u8 { const h = try std.fmt.allocPrint(a, "{s} {}\x00", .{ typ, data.len }); const out = try a.alloc(u8, h.len + data.len); @memcpy(out[0..h.len], h); @memcpy(out[h.len..], data); return out; }
+fn hashObject(a: Allocator, r: ?Repository, typ: []const u8, data: []const u8) ![40]u8 { const f = try fmtObj(a, typ, data); var d: [20]u8 = undefined; std.crypto.hash.Sha1.hash(f, &d, .{}); const hx = hex(d); if (r) |rr| { try std.fs.cwd().makePath(try std.fs.path.join(a, &.{ rr.git_dir, "objects", hx[0..2] })); const p = try objPath(a, rr.git_dir, hx[0..]); if (!exists(p)) { const z = try zstore(a, f); const file = try std.fs.cwd().createFile(p, .{}); defer file.close(); try file.writeAll(z); } } return hx; }
+fn cmdHashObject(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { var w = false; var stdin = false; var stdin_paths = false; var typ: []const u8 = "blob"; var paths = std.ArrayList([]const u8).init(a); var i: usize = 0; var stop_opts = false; while (i < argv.len) { const x = argv[i]; if (!stop_opts and std.mem.eql(u8, x, "--")) stop_opts = true else if (!stop_opts and std.mem.eql(u8, x, "-w")) w = true else if (!stop_opts and std.mem.eql(u8, x, "--stdin")) stdin = true else if (!stop_opts and std.mem.eql(u8, x, "--stdin-paths")) stdin_paths = true else if (!stop_opts and (std.mem.eql(u8, x, "--no-filters") or std.mem.eql(u8, x, "--literally"))) {} else if (!stop_opts and std.mem.eql(u8, x, "--path")) { i += 1; } else if (!stop_opts and std.mem.startsWith(u8, x, "--path=")) {} else if (!stop_opts and std.mem.eql(u8, x, "-t")) { i += 1; if (i < argv.len) typ = argv[i]; } else try paths.append(x); i += 1; } const r: ?Repository = if (w) try repo(a, g) else null; if (stdin) { const data = try std.io.getStdIn().readToEndAlloc(a, 1 << 30); const oid = try hashObject(a, r, typ, data); try std.io.getStdOut().writer().print("{s}\n", .{oid[0..]}); return; } if (stdin_paths) { const input = try std.io.getStdIn().readToEndAlloc(a, 1 << 26); var it = std.mem.splitScalar(u8, input, '\n'); while (it.next()) |line| { const p = std.mem.trim(u8, line, " \t\r"); if (p.len == 0) continue; const data = try std.fs.cwd().readFileAlloc(a, p, 1 << 30); const oid = try hashObject(a, r, typ, data); try std.io.getStdOut().writer().print("{s}\n", .{oid[0..]}); } return; } for (paths.items) |p| { const data = try std.fs.cwd().readFileAlloc(a, p, 1 << 30); const oid = try hashObject(a, r, typ, data); try std.io.getStdOut().writer().print("{s}\n", .{oid[0..]}); } }
+fn readObj(a: Allocator, gd: []const u8, oid: []const u8) !Obj { const p = try objPath(a, gd, oid); const z = try std.fs.cwd().readFileAlloc(a, p, 1 << 30); const raw = try zunstore(a, z); const nul = std.mem.indexOfScalar(u8, raw, 0) orelse return error.Bad; const sp = std.mem.indexOfScalar(u8, raw[0..nul], ' ') orelse return error.Bad; return .{ .typ = raw[0..sp], .data = raw[nul + 1..], .storage = raw }; }
+fn cmdCatFile(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void {
+    const r = try repo(a, g);
+    if (argv.len > 0 and (std.mem.eql(u8, argv[0], "--batch") or std.mem.eql(u8, argv[0], "--batch-check") or std.mem.startsWith(u8, argv[0], "--batch-check="))) { const full = std.mem.eql(u8, argv[0], "--batch"); const input = try std.io.getStdIn().readToEndAlloc(a, 1 << 26); var it = std.mem.splitScalar(u8, input, '\n'); while (it.next()) |line0| { const name = std.mem.trim(u8, line0, " \t\r"); if (name.len == 0) continue; const oid = (try resolveRev(a, r, name)) orelse name; const o = readObj(a, r.git_dir, oid) catch { try std.io.getStdOut().writer().print("{s} missing\n", .{name}); continue; }; try std.io.getStdOut().writer().print("{s} {s} {}\n", .{ oid[0..40], o.typ, o.data.len }); if (full) { try std.io.getStdOut().writer().writeAll(o.data); try std.io.getStdOut().writer().writeAll("\n"); } } return; }
+    if (argv.len < 2) return die("cat-file: requires mode and object", .{});
+    const oid = (try resolveRev(a, r, argv[1])) orelse argv[1];
+    const o = readObj(a, r.git_dir, oid) catch { if (std.mem.eql(u8, argv[0], "-e")) std.process.exit(1); return error.FileNotFound; };
+    if (std.mem.eql(u8, argv[0], "-e")) return;
+    if (std.mem.eql(u8, argv[0], "-t")) try std.io.getStdOut().writer().print("{s}\n", .{o.typ})
+    else if (std.mem.eql(u8, argv[0], "-s")) try std.io.getStdOut().writer().print("{}\n", .{o.data.len})
+    else if (std.mem.eql(u8, argv[0], "-p")) { if (std.mem.eql(u8, o.typ, "tree")) try printTreeData(o.data) else try std.io.getStdOut().writer().writeAll(o.data); }
+    else if (std.mem.eql(u8, argv[0], "blob") or std.mem.eql(u8, argv[0], "commit") or std.mem.eql(u8, argv[0], "tree") or std.mem.eql(u8, argv[0], "tag")) { if (!std.mem.eql(u8, o.typ, argv[0])) std.process.exit(1); try std.io.getStdOut().writer().writeAll(o.data); }
+    else try std.io.getStdOut().writer().writeAll(o.data);
+}
+fn printTreeData(data: []const u8) !void { var i: usize = 0; while (i < data.len) { const sp = std.mem.indexOfScalarPos(u8, data, i, ' ') orelse break; const mode = data[i..sp]; const nul = std.mem.indexOfScalarPos(u8, data, sp + 1, 0) orelse break; const name = data[sp + 1..nul]; if (nul + 21 > data.len) break; var oid: [20]u8 = undefined; @memcpy(oid[0..], data[nul + 1..nul + 21]); const h = hex(oid); const typ: []const u8 = if (std.mem.eql(u8, mode, "40000")) "tree" else "blob"; try std.io.getStdOut().writer().print("{s} {s} {s}\t{s}\n", .{ mode, typ, h[0..], name }); i = nul + 21; } }
+
+fn indexFile(a: Allocator, gd: []const u8) ![]const u8 { return std.fs.path.join(a, &.{ gd, "index" }); }
+fn readIndex(a: Allocator, gd: []const u8) !std.ArrayList(IndexEntry) { var es = std.ArrayList(IndexEntry).init(a); const data = std.fs.cwd().readFileAlloc(a, try indexFile(a, gd), 1 << 27) catch return es; if (data.len < 12) return es; const n = be32(data, 8); var off: usize = 12; var i: u32 = 0; while (i < n and off + 62 <= data.len) : (i += 1) { const mode = be32(data, off + 24); const size = be32(data, off + 36); var oid: [20]u8 = undefined; @memcpy(oid[0..], data[off + 40..off + 60]); var e = off + 62; while (e < data.len and data[e] != 0) e += 1; if (e >= data.len) break; try es.append(.{ .path = try a.dupe(u8, data[off + 62..e]), .oid = oid, .mode = mode, .size = size }); off += ((62 + (e - (off + 62)) + 1) + 7) & ~@as(usize, 7); } return es; }
+fn writeIndex(a: Allocator, gd: []const u8, es: []const IndexEntry) !void { var out = std.ArrayList(u8).init(a); try out.appendSlice("DIRC"); try au32(&out, 2); try au32(&out, @intCast(es.len)); for (es) |e| { var k: usize = 0; while (k < 6) : (k += 1) try au32(&out, 0); try au32(&out, e.mode); try au32(&out, 0); try au32(&out, 0); try au32(&out, e.size); try out.appendSlice(e.oid[0..]); try au16(&out, @intCast(@min(e.path.len, 0xfff))); try out.appendSlice(e.path); try out.append(0); while (out.items.len % 8 != 0) try out.append(0); } var d: [20]u8 = undefined; std.crypto.hash.Sha1.hash(out.items, &d, .{}); try out.appendSlice(d[0..]); const f = try std.fs.cwd().createFile(try indexFile(a, gd), .{ .truncate = true }); defer f.close(); try f.writeAll(out.items); }
+fn addFile(a: Allocator, r: Repository, p: []const u8) !void { const data = try std.fs.cwd().readFileAlloc(a, p, 1 << 30); const hx = try hashObject(a, r, "blob", data); const oid = try unhex20(hx[0..]); var es = try readIndex(a, r.git_dir); _ = rmIndex(&es, p); try es.append(.{ .path = try a.dupe(u8, p), .oid = oid, .size = @intCast(data.len) }); try writeIndex(a, r.git_dir, es.items); }
+fn cmdAdd(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { const r = try repo(a, g); for (argv) |p| { if (p.len == 0 or p[0] == '-') {} else try addFile(a, r, p); } }
+fn cmdUpdateIndex(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { const r = try repo(a, g); for (argv) |x| { if (x.len == 0 or x[0] == '-') continue; try addFile(a, r, x); } }
+fn pathspecOk(path: []const u8, specs: []const []const u8) bool { if (specs.len == 0) return true; for (specs) |s| { if (std.mem.indexOf(u8, path, s) != null or std.mem.startsWith(u8, path, s)) return true; } return false; }
+fn cmdLsFiles(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void {
+    const r = try repo(a, g);
+    var stage = false; var nul = false; var cached = false; var deleted = false; var modified = false; var others = false;
+    var specs = std.ArrayList([]const u8).init(a); var ai: usize = 0;
+    while (ai < argv.len) { const x = argv[ai];
+        if (std.mem.eql(u8, x, "-s") or std.mem.eql(u8, x, "--stage")) stage = true
+        else if (std.mem.eql(u8, x, "-z")) nul = true
+        else if (std.mem.eql(u8, x, "--cached")) cached = true
+        else if (std.mem.eql(u8, x, "--deleted")) deleted = true
+        else if (std.mem.eql(u8, x, "--modified")) modified = true
+        else if (std.mem.eql(u8, x, "--others")) others = true
+        else if (std.mem.eql(u8, x, "--exclude-standard")) {}
+        else if (std.mem.startsWith(u8, x, "-")) {}
+        else try specs.append(x);
+        ai += 1;
+    }
+    const es = try readIndex(a, r.git_dir); const sep: u8 = if (nul) 0 else '\n'; const show_cached = cached or (!deleted and !modified and !others);
+    if (show_cached) { for (es.items) |e| { if (!pathspecOk(e.path, specs.items)) continue; if (stage) { const h = hex(e.oid); try std.io.getStdOut().writer().print("{s} {s} 0\t{s}", .{ modeStr(e.mode), h[0..], e.path }); } else try std.io.getStdOut().writer().writeAll(e.path); try std.io.getStdOut().writer().writeByte(sep); } }
+    if (deleted or modified) { for (es.items) |e| { if (!pathspecOk(e.path, specs.items)) continue; const data = std.fs.cwd().readFileAlloc(a, e.path, 1 << 30) catch { if (deleted) { try std.io.getStdOut().writer().writeAll(e.path); try std.io.getStdOut().writer().writeByte(sep); } continue; }; if (modified) { var changed = data.len != e.size; if (!changed) { const hx = try hashObject(a, null, "blob", data); const old = hex(e.oid); changed = !std.mem.eql(u8, hx[0..], old[0..]); } if (changed) { try std.io.getStdOut().writer().writeAll(e.path); try std.io.getStdOut().writer().writeByte(sep); } } } }
+    if (others) { var d = std.fs.cwd().openDir(".", .{ .iterate = true }) catch return; var it = d.iterate(); while (try it.next()) |ent| { if (ent.kind != .file) continue; if (std.mem.eql(u8, ent.name, ".git")) continue; if (indexHas(es.items, ent.name)) continue; if (!pathspecOk(ent.name, specs.items)) continue; try std.io.getStdOut().writer().writeAll(ent.name); try std.io.getStdOut().writer().writeByte(sep); } }
+}
+fn rmIndex(es: *std.ArrayList(IndexEntry), p: []const u8) bool { var i: usize = 0; while (i < es.items.len) { if (std.mem.eql(u8, es.items[i].path, p)) { _ = es.orderedRemove(i); return true; } i += 1; } return false; }
+fn indexHas(es: []const IndexEntry, p: []const u8) bool { for (es) |e| { if (std.mem.eql(u8, e.path, p)) return true; } return false; }
+
+fn cmdStatus(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void {
+    var porcelain = false;
+    for (argv) |x| { if (std.mem.eql(u8, x, "--short") or std.mem.eql(u8, x, "-s") or std.mem.eql(u8, x, "--porcelain") or std.mem.startsWith(u8, x, "--porcelain=")) porcelain = true; }
+    if (!porcelain) return;
+    const r = try repo(a, g); const es = try readIndex(a, r.git_dir); const head_exists = (try resolveRev(a, r, "HEAD")) != null;
+    for (es.items) |e| {
+        if (!head_exists) { try std.io.getStdOut().writer().print("A  {s}\n", .{e.path}); continue; }
+        const data = std.fs.cwd().readFileAlloc(a, e.path, 1 << 30) catch { try std.io.getStdOut().writer().print(" D {s}\n", .{e.path}); continue; };
+        var changed = data.len != e.size;
+        if (!changed) { const hx = try hashObject(a, null, "blob", data); const old = hex(e.oid); changed = !std.mem.eql(u8, hx[0..], old[0..]); }
+        if (changed) try std.io.getStdOut().writer().print(" M {s}\n", .{e.path});
+    }
+    var d = std.fs.cwd().openDir(".", .{ .iterate = true }) catch return; var it = d.iterate();
+    while (try it.next()) |ent| { if (ent.kind != .file) continue; if (std.mem.eql(u8, ent.name, ".git")) continue; if (indexHas(es.items, ent.name)) continue; try std.io.getStdOut().writer().print("?? {s}\n", .{ent.name}); }
+}
+
+fn cmdWriteTree(a: Allocator, g: GlobalOptions) !void { const r = try repo(a, g); const oid = try writeTree(a, r); try std.io.getStdOut().writer().print("{s}\n", .{oid[0..]}); }
+fn writeTree(a: Allocator, r: Repository) ![40]u8 { const es = try readIndex(a, r.git_dir); const items = try a.alloc(IndexEntry, es.items.len); @memcpy(items, es.items); sortIndex(items); return treePrefix(a, r, items, ""); }
+fn sortIndex(es: []IndexEntry) void { var i: usize = 1; while (i < es.len) : (i += 1) { var j = i; while (j > 0 and std.mem.lessThan(u8, es[j].path, es[j - 1].path)) : (j -= 1) { const t = es[j - 1]; es[j - 1] = es[j]; es[j] = t; } } }
+fn treePrefix(a: Allocator, r: Repository, es: []const IndexEntry, prefix: []const u8) ![40]u8 { var out = std.ArrayList(u8).init(a); var i: usize = 0; while (i < es.len) { const e = es[i]; if (!std.mem.startsWith(u8, e.path, prefix)) { i += 1; continue; } const rem = e.path[prefix.len..]; if (rem.len == 0) { i += 1; continue; } if (std.mem.indexOfScalar(u8, rem, '/')) |slash| { const dir = rem[0..slash]; const child_prefix = try std.fmt.allocPrint(a, "{s}{s}/", .{ prefix, dir }); const child = try treePrefix(a, r, es, child_prefix); const raw = try unhex20(child[0..]); try treeEnt(&out, "40000", dir, raw); while (i < es.len and std.mem.startsWith(u8, es[i].path, child_prefix)) i += 1; } else { try treeEnt(&out, modeStr(e.mode), rem, e.oid); i += 1; } } return hashObject(a, r, "tree", out.items); }
+fn treeEnt(out: *std.ArrayList(u8), m: []const u8, n: []const u8, oid: [20]u8) !void { try out.appendSlice(m); try out.append(' '); try out.appendSlice(n); try out.append(0); try out.appendSlice(oid[0..]); }
+
+fn cmdMergeBase(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { const r = try repo(a, g); var is_ancestor = false; var pos: usize = 0; if (argv.len > 0 and std.mem.eql(u8, argv[0], "--is-ancestor")) { is_ancestor = true; pos = 1; } if (argv.len < pos + 2) return die("merge-base requires two commits", .{}); const a0 = (try resolveRev(a, r, argv[pos])) orelse return die("not a valid object name {s}", .{argv[pos]}); const b0 = (try resolveRev(a, r, argv[pos + 1])) orelse return die("not a valid object name {s}", .{argv[pos + 1]}); const ca = (try peelCommit(a, r, a0)) orelse return die("object is not a commit", .{}); const cb = (try peelCommit(a, r, b0)) orelse return die("object is not a commit", .{}); if (is_ancestor) { if (try isAncestor(a, r, ca, cb)) return else std.process.exit(1); } var seen = std.StringHashMap(void).init(a); var cur: ?[]const u8 = ca; while (cur) |c| { try seen.put(c, {}); cur = try firstParent(a, r, c); } cur = cb; while (cur) |c| { if (seen.contains(c)) { try std.io.getStdOut().writer().print("{s}\n", .{c}); return; } cur = try firstParent(a, r, c); } std.process.exit(1); }
+fn firstParent(a: Allocator, r: Repository, oid: []const u8) !?[]const u8 { const o = readObj(a, r.git_dir, oid) catch return null; if (!std.mem.eql(u8, o.typ, "commit")) return null; const p = headerValue(o.data, "parent ") orelse return null; if (!isHex(p)) return null; return p[0..40]; }
+fn isAncestor(a: Allocator, r: Repository, anc: []const u8, desc: []const u8) !bool { var cur: ?[]const u8 = desc; while (cur) |c| { if (std.mem.eql(u8, c, anc)) return true; cur = try firstParent(a, r, c); } return false; }
+
+fn cmdRevList(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { const r = try repo(a, g); var max: usize = std.math.maxInt(usize); var count = false; var parents = false; var starts = std.ArrayList([]const u8).init(a); var excl = std.ArrayList([]const u8).init(a); var i: usize = 0; while (i < argv.len) { const x = argv[i]; if (std.mem.startsWith(u8, x, "--max-count=")) max = try std.fmt.parseInt(usize, x[12..], 10) else if (std.mem.eql(u8, x, "-n")) { i += 1; max = try std.fmt.parseInt(usize, argv[i], 10); } else if (std.mem.eql(u8, x, "--count")) count = true else if (std.mem.eql(u8, x, "--parents")) parents = true else if (std.mem.eql(u8, x, "--all")) try appendAllRefs(a, r, &starts) else if (std.mem.eql(u8, x, "--not")) { i += 1; if (i < argv.len) try excl.append(argv[i]); } else if (std.mem.startsWith(u8, x, "^")) try excl.append(x[1..]) else try starts.append(x); i += 1; } if (starts.items.len == 0) try starts.append("HEAD"); var excluded = std.StringHashMap(void).init(a); for (excl.items) |e| { if (try resolveCommit(a, r, e)) |co| try markReachable(a, r, co, &excluded); } var stack = std.ArrayList([]const u8).init(a); for (starts.items) |s| { if (try resolveCommit(a, r, s)) |co| try stack.append(co); } var seen = std.StringHashMap(void).init(a); var emitted: usize = 0; while (stack.items.len != 0 and emitted < max) { const cur = stack.orderedRemove(stack.items.len - 1); if (seen.contains(cur) or excluded.contains(cur)) continue; try seen.put(cur, {}); const ps = try commitParents(a, r, cur); if (!count) { if (parents) { try std.io.getStdOut().writer().print("{s}", .{cur}); for (ps.items) |p| try std.io.getStdOut().writer().print(" {s}", .{p}); try std.io.getStdOut().writer().writeAll("\n"); } else try std.io.getStdOut().writer().print("{s}\n", .{cur}); } emitted += 1; for (ps.items) |p| try stack.append(p); } if (count) try std.io.getStdOut().writer().print("{}\n", .{emitted}); }
+fn resolveCommit(a: Allocator, r: Repository, rev: []const u8) !?[]const u8 { const oid = (try resolveRev(a, r, rev)) orelse return null; return peelCommit(a, r, oid); }
+fn commitParents(a: Allocator, r: Repository, oid: []const u8) !std.ArrayList([]const u8) { var out = std.ArrayList([]const u8).init(a); const o = readObj(a, r.git_dir, oid) catch return out; if (!std.mem.eql(u8, o.typ, "commit")) return out; var it = std.mem.splitScalar(u8, o.data, '\n'); while (it.next()) |line| { if (line.len == 0) break; if (std.mem.startsWith(u8, line, "parent ") and isHex(line[7..])) try out.append(line[7..47]); } return out; }
+fn markReachable(a: Allocator, r: Repository, start: []const u8, set: *std.StringHashMap(void)) !void { var stack = std.ArrayList([]const u8).init(a); try stack.append(start); while (stack.items.len != 0) { const cur = stack.orderedRemove(stack.items.len - 1); if (set.contains(cur)) continue; try set.put(cur, {}); const ps = try commitParents(a, r, cur); for (ps.items) |p| try stack.append(p); } }
+fn appendAllRefs(a: Allocator, r: Repository, out: *std.ArrayList([]const u8)) !void { var refs = std.ArrayList(RefEntry).init(a); try collect(a, r.git_dir, "refs/heads", &refs); try collect(a, r.git_dir, "refs/tags", &refs); for (refs.items) |rr| try out.append(rr.oid); }
+
+fn resolveRev(a: Allocator, r: Repository, name: []const u8) !?[]const u8 { if (isHex(name)) return name[0..40]; if (std.mem.eql(u8, name, "HEAD")) { const h = readRawRef(a, r.git_dir, "HEAD") catch return null; if (std.mem.startsWith(u8, h, "ref: ")) return resolveRev(a, r, std.mem.trim(u8, h[5..], " \t\r\n")); if (isHex(h)) return h[0..40]; return null; } if (std.mem.startsWith(u8, name, "refs/")) { const v = readRawRef(a, r.git_dir, name) catch return null; if (isHex(v)) return v[0..40]; return null; } const br = try std.fmt.allocPrint(a, "refs/heads/{s}", .{name}); if (try resolveRev(a, r, br)) |o| return o; const tg = try std.fmt.allocPrint(a, "refs/tags/{s}", .{name}); return resolveRev(a, r, tg); }
+fn readRawRef(a: Allocator, gd: []const u8, n: []const u8) ![]const u8 { const p = try std.fs.path.join(a, &.{gd, n}); const c = try std.fs.cwd().readFileAlloc(a, p, 4096); return std.mem.trim(u8, c, " \t\r\n"); }
+fn headerValue(data: []const u8, prefix: []const u8) ?[]const u8 { var it = std.mem.splitScalar(u8, data, '\n'); while (it.next()) |line| { if (line.len == 0) break; if (std.mem.startsWith(u8, line, prefix)) return line[prefix.len..]; } return null; }
+fn peelCommit(a: Allocator, r: Repository, oid: []const u8) !?[]const u8 { var cur = oid[0..40]; var n: usize = 0; while (n < 8) : (n += 1) { const o = try readObj(a, r.git_dir, cur); if (std.mem.eql(u8, o.typ, "commit")) return cur; if (std.mem.eql(u8, o.typ, "tag")) { const next = headerValue(o.data, "object ") orelse return null; if (!isHex(next)) return null; cur = next[0..40]; } else return null; } return null; }
+fn cmdRevParse(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void {
+    const r = try repo(a, g);
+    var verify = false; var abbrev_ref = false; var short_len: ?usize = null; var printed = false; var i: usize = 0; var sq = false; var sq_quote = false; var revs_only = false; var no_revs = false; var flags_only = false; var no_flags = false;
+    while (i < argv.len) { const x = argv[i];
+        if (std.mem.eql(u8, x, "--git-dir")) { try emitRevParse(r.git_dir, sq, &printed); }
+        else if (std.mem.eql(u8, x, "--absolute-git-dir")) { const p = std.fs.cwd().realpathAlloc(a, r.git_dir) catch try a.dupe(u8, r.git_dir); try emitRevParse(p, sq, &printed); }
+        else if (std.mem.eql(u8, x, "--show-toplevel")) { if (r.work_tree) |wt| try emitRevParse(wt, sq, &printed) else std.process.exit(1); }
+        else if (std.mem.eql(u8, x, "--show-prefix")) { try printPrefix(a, r); printed = true; }
+        else if (std.mem.eql(u8, x, "--show-cdup")) { try printCdup(a, r); printed = true; }
+        else if (std.mem.eql(u8, x, "--show-superproject-working-tree")) { try std.io.getStdOut().writer().writeAll("\n"); printed = true; }
+        else if (std.mem.eql(u8, x, "--is-inside-work-tree")) { try emitRevParse(if (r.work_tree != null and !r.bare) "true" else "false", sq, &printed); }
+        else if (std.mem.eql(u8, x, "--is-bare-repository")) { try emitRevParse(if (r.bare) "true" else "false", sq, &printed); }
+        else if (std.mem.eql(u8, x, "--verify")) verify = true
+        else if (std.mem.eql(u8, x, "--short")) short_len = 7
+        else if (std.mem.startsWith(u8, x, "--short=")) short_len = std.fmt.parseInt(usize, x[8..], 10) catch 7
+        else if (std.mem.eql(u8, x, "--abbrev-ref")) abbrev_ref = true
+        else if (std.mem.eql(u8, x, "--sq")) sq = true
+        else if (std.mem.eql(u8, x, "--sq-quote")) { sq = true; sq_quote = true; }
+        else if (std.mem.eql(u8, x, "--revs-only")) { revs_only = true; no_revs = false; flags_only = false; }
+        else if (std.mem.eql(u8, x, "--no-revs")) { no_revs = true; revs_only = false; }
+        else if (std.mem.eql(u8, x, "--flags")) { flags_only = true; no_flags = false; revs_only = false; }
+        else if (std.mem.eql(u8, x, "--no-flags")) { no_flags = true; flags_only = false; }
+        else if (std.mem.startsWith(u8, x, "-")) { if (!no_flags and (flags_only or no_revs)) try emitRevParse(x, sq, &printed); }
+        else if (sq_quote) try emitRevParse(x, true, &printed)
+        else { const oid = try resolveRev(a, r, x); if (oid) |o| { if (!no_revs and !flags_only) { if (abbrev_ref and std.mem.eql(u8, x, "HEAD")) { const h = readRawRef(a, r.git_dir, "HEAD") catch "HEAD"; if (std.mem.startsWith(u8, h, "ref: ")) try emitRevParse(shortRef(std.mem.trim(u8, h[5..], " \t\r\n")), sq, &printed) else try emitRevParse("HEAD", sq, &printed); } else if (short_len) |n0| { const n = @min(@max(n0, @as(usize, 4)), @as(usize, 40)); try emitRevParse(o[0..n], sq, &printed); } else try emitRevParse(o, sq, &printed); } } else if (verify) std.process.exit(1); }
+        i += 1;
+    }
+    if (sq and printed) try std.io.getStdOut().writer().writeAll("\n");
+    if (verify and !printed) std.process.exit(1);
+}
+fn emitRevParse(s: []const u8, sq: bool, printed: *bool) !void { if (sq) { if (printed.*) try std.io.getStdOut().writer().writeByte(' '); try shellQuote(s); printed.* = true; } else { try std.io.getStdOut().writer().print("{s}\n", .{s}); printed.* = true; } }
+fn shellQuote(s: []const u8) !void { const w = std.io.getStdOut().writer(); try w.writeByte('\''); for (s) |c| { if (c == '\'') try w.writeAll("'\\''") else try w.writeByte(c); } try w.writeByte('\''); }
+fn printCdup(a: Allocator, r: Repository) !void { const cwd = try std.fs.cwd().realpathAlloc(a, "."); if (r.work_tree) |wt| { if (std.mem.startsWith(u8, cwd, wt) and cwd.len > wt.len) { var rel = cwd[wt.len..]; if (rel.len > 0 and (rel[0] == '/' or rel[0] == '\\')) rel = rel[1..]; var it = std.mem.splitScalar(u8, rel, std.fs.path.sep); while (it.next()) |part| if (part.len > 0) try std.io.getStdOut().writer().writeAll("../"); } } try std.io.getStdOut().writer().writeAll("\n"); }
+fn printPrefix(a: Allocator, r: Repository) !void { const cwd = try std.fs.cwd().realpathAlloc(a, "."); if (r.work_tree) |wt| { if (std.mem.startsWith(u8, cwd, wt) and cwd.len > wt.len) { var rel = cwd[wt.len..]; if (rel.len > 0 and (rel[0] == '/' or rel[0] == '\\')) rel = rel[1..]; if (rel.len > 0) { try std.io.getStdOut().writer().print("{s}/\n", .{rel}); return; } } } try std.io.getStdOut().writer().writeAll("\n"); }
+fn printAbbrevHead(a: Allocator, r: Repository) !void { const h = readRawRef(a, r.git_dir, "HEAD") catch { try std.io.getStdOut().writer().writeAll("HEAD\n"); return; }; if (std.mem.startsWith(u8, h, "ref: ")) { const ref = std.mem.trim(u8, h[5..], " \t\r\n"); try std.io.getStdOut().writer().print("{s}\n", .{shortRef(ref)}); } else try std.io.getStdOut().writer().writeAll("HEAD\n"); }
+
+fn cmdSymbolicRef(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { const r = try repo(a, g); var quiet = false; var short = false; var del = false; var pos = std.ArrayList([]const u8).init(a); var i: usize = 0; while (i < argv.len) { const x = argv[i]; if (std.mem.eql(u8, x, "-q") or std.mem.eql(u8, x, "--quiet")) quiet = true else if (std.mem.eql(u8, x, "--short")) short = true else if (std.mem.eql(u8, x, "--delete") or std.mem.eql(u8, x, "-d")) del = true else if (std.mem.eql(u8, x, "-m")) { i += 1; } else if (std.mem.startsWith(u8, x, "-")) {} else try pos.append(x); i += 1; } if (pos.items.len < 1) { if (quiet) std.process.exit(1); return die("symbolic-ref: missing ref", .{}); } const name = pos.items[0]; const p = try std.fs.path.join(a, &.{r.git_dir, name}); if (del) { std.fs.cwd().deleteFile(p) catch { if (quiet) std.process.exit(1); return die("could not delete {s}", .{name}); }; return; } if (pos.items.len >= 2) { try writeFileFmt(a, r.git_dir, name, "ref: {s}\n", .{pos.items[1]}); return; } const raw = std.fs.cwd().readFileAlloc(a, p, 4096) catch { if (quiet) std.process.exit(1); return die("No such ref: {s}", .{name}); }; const t = std.mem.trim(u8, raw, " \t\r\n"); if (!std.mem.startsWith(u8, t, "ref: ")) { if (quiet) std.process.exit(1); return die("ref {s} is not a symbolic ref", .{name}); } const ref = std.mem.trim(u8, t[5..], " \t\r\n"); try std.io.getStdOut().writer().print("{s}\n", .{if (short) shortRef(ref) else ref}); }
+fn shortRef(r: []const u8) []const u8 { if (std.mem.startsWith(u8, r, "refs/heads/")) return r[11..]; if (std.mem.startsWith(u8, r, "refs/tags/")) return r[10..]; return r; }
+fn cmdUpdateRef(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { const r = try repo(a, g); if (argv.len >= 2) try writeFileFmt(a, r.git_dir, argv[0], "{s}\n", .{argv[1]}); }
+fn cmdShowRef(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void {
+    const r = try repo(a, g);
+    var verify = false; var quiet = false; var heads = false; var tags = false; var hash_only = false; var hash_len: usize = 40;
+    var pats = std.ArrayList([]const u8).init(a); var i: usize = 0;
+    while (i < argv.len) { const x = argv[i];
+        if (std.mem.eql(u8, x, "--verify")) verify = true
+        else if (std.mem.eql(u8, x, "--quiet") or std.mem.eql(u8, x, "-q")) quiet = true
+        else if (std.mem.eql(u8, x, "--heads")) heads = true
+        else if (std.mem.eql(u8, x, "--tags")) tags = true
+        else if (std.mem.eql(u8, x, "--hash")) hash_only = true
+        else if (std.mem.startsWith(u8, x, "--hash=")) { hash_only = true; hash_len = parseShowRefLen(x[7..]); }
+        else if (std.mem.startsWith(u8, x, "-")) {}
+        else try pats.append(x);
+        i += 1;
+    }
+    if (hash_len < 4) hash_len = 4; if (hash_len > 40) hash_len = 40;
+    var refs = std.ArrayList(RefEntry).init(a);
+    if (!heads and !tags) { try collect(a, r.git_dir, "refs/heads", &refs); try collect(a, r.git_dir, "refs/tags", &refs); }
+    else { if (heads) try collect(a, r.git_dir, "refs/heads", &refs); if (tags) try collect(a, r.git_dir, "refs/tags", &refs); }
+    var hit = false;
+    for (refs.items) |rr| { if (!showRefMatch(rr.name, pats.items, verify)) continue; hit = true; if (!quiet) try printShowRef(rr, hash_only, hash_len); }
+    if (!hit) std.process.exit(1);
+}
+fn parseShowRefLen(s: []const u8) usize { return std.fmt.parseInt(usize, s, 10) catch 40; }
+fn showRefMatch(name: []const u8, pats: []const []const u8, verify: bool) bool { if (pats.len == 0) return !verify; for (pats) |p| { if (verify) { if (std.mem.eql(u8, name, p)) return true; } else if (std.mem.eql(u8, name, p) or std.mem.endsWith(u8, name, p) or std.mem.indexOf(u8, name, p) != null) return true; } return false; }
+fn printShowRef(rr: RefEntry, hash_only: bool, n: usize) !void { const oid = if (rr.oid.len >= n) rr.oid[0..n] else rr.oid; if (hash_only) try std.io.getStdOut().writer().print("{s}\n", .{oid}) else try std.io.getStdOut().writer().print("{s} {s}\n", .{oid, rr.name}); }
+
+fn cmdBranch(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void { _ = a; _ = g; _ = argv; }
+
+fn cmdConfig(a: Allocator, g: GlobalOptions, argv: []const []const u8) !void {
+    var use_global = false; var do_get = false; var do_get_all = false; var do_list = false; var do_unset = false; var as_bool = false; var get_re = false; var add_mode = false; var replace_all = false; var name_only = false; var nul = false; var file_path: ?[]const u8 = null;
+    var pos = std.ArrayList([]const u8).init(a); var i: usize = 0;
+    while (i < argv.len) { const x = argv[i];
+        if (std.mem.eql(u8, x, "--global")) use_global = true
+        else if (std.mem.eql(u8, x, "--local")) use_global = false
+        else if (std.mem.eql(u8, x, "--get")) do_get = true
+        else if (std.mem.eql(u8, x, "--get-all")) do_get_all = true
+        else if (std.mem.eql(u8, x, "--list") or std.mem.eql(u8, x, "-l")) do_list = true
+        else if (std.mem.eql(u8, x, "--unset")) do_unset = true
+        else if (std.mem.eql(u8, x, "--bool")) as_bool = true
+        else if (std.mem.eql(u8, x, "--get-regexp")) get_re = true
+        else if (std.mem.eql(u8, x, "--add")) add_mode = true
+        else if (std.mem.eql(u8, x, "--replace-all")) replace_all = true
+        else if (std.mem.eql(u8, x, "--name-only")) name_only = true
+        else if (std.mem.eql(u8, x, "--null") or std.mem.eql(u8, x, "-z")) nul = true
+        else if (std.mem.eql(u8, x, "--file") or std.mem.eql(u8, x, "-f")) { i += 1; if (i < argv.len) file_path = argv[i]; }
+        else if (std.mem.startsWith(u8, x, "--file=")) file_path = x[7..]
+        else if (std.mem.startsWith(u8, x, "-")) {}
+        else try pos.append(x);
+        i += 1;
+    }
+    const path = if (file_path) |fp| fp else try configPath(a, g, use_global); var entries = try readConfigEntries(a, path); const sep: u8 = if (nul) 0 else '\n';
+    if (do_list) { for (entries.items) |e| { if (name_only) try std.io.getStdOut().writer().writeAll(e.key) else try std.io.getStdOut().writer().print("{s}={s}", .{e.key, e.value}); try std.io.getStdOut().writer().writeByte(sep); } return; }
+    if (get_re) { if (pos.items.len < 1) std.process.exit(1); var hit = false; for (entries.items) |e| { if (std.mem.indexOf(u8, e.key, pos.items[0]) != null) { hit = true; if (name_only) try std.io.getStdOut().writer().writeAll(e.key) else try std.io.getStdOut().writer().print("{s} {s}", .{e.key, e.value}); try std.io.getStdOut().writer().writeByte(sep); } } if (!hit) std.process.exit(1); return; }
+    if (do_unset) { if (pos.items.len < 1) return; var n: usize = 0; while (n < entries.items.len) { if (configKeyEq(entries.items[n].key, pos.items[0])) _ = entries.orderedRemove(n) else n += 1; } try writeConfigEntries(a, path, entries.items); return; }
+    if (pos.items.len >= 2) { if (replace_all) { var n: usize = 0; while (n < entries.items.len) { if (configKeyEq(entries.items[n].key, pos.items[0])) _ = entries.orderedRemove(n) else n += 1; } try entries.append(.{ .key = try a.dupe(u8, pos.items[0]), .value = try a.dupe(u8, pos.items[1]) }); } else if (add_mode) { try entries.append(.{ .key = try a.dupe(u8, pos.items[0]), .value = try a.dupe(u8, pos.items[1]) }); } else { var found = false; for (entries.items) |*e| { if (configKeyEq(e.key, pos.items[0]) and !found) { e.value = try a.dupe(u8, pos.items[1]); found = true; } } if (!found) try entries.append(.{ .key = try a.dupe(u8, pos.items[0]), .value = try a.dupe(u8, pos.items[1]) }); } try writeConfigEntries(a, path, entries.items); return; }
+    if (pos.items.len >= 1 or do_get or do_get_all) { const key = if (pos.items.len >= 1) pos.items[0] else ""; var hit = false; for (entries.items) |e| { if (configKeyEq(e.key, key)) { hit = true; if (name_only) try std.io.getStdOut().writer().writeAll(e.key) else { const v = if (as_bool) configBool(e.value) else e.value; try std.io.getStdOut().writer().writeAll(v); } try std.io.getStdOut().writer().writeByte(sep); if (!do_get_all) return; } } if (!hit) std.process.exit(1); }
+}
+fn configPath(a: Allocator, g: GlobalOptions, use_global: bool) ![]const u8 { if (use_global) { const home = std.process.getEnvVarOwned(a, "HOME") catch try a.dupe(u8, "."); return std.fs.path.join(a, &.{home, ".gitconfig"}); } const r = try repo(a, g); return std.fs.path.join(a, &.{r.git_dir, "config"}); }
+fn readConfigEntries(a: Allocator, path: []const u8) !std.ArrayList(ConfigEntry) { var es = std.ArrayList(ConfigEntry).init(a); const data = std.fs.cwd().readFileAlloc(a, path, 1 << 20) catch return es; var section: []const u8 = ""; var it = std.mem.splitScalar(u8, data, '\n'); while (it.next()) |raw| { const line = std.mem.trim(u8, raw, " \t\r"); if (line.len == 0 or line[0] == '#' or line[0] == ';') continue; if (line[0] == '[') { if (std.mem.indexOfScalar(u8, line, ']')) |end| section = try parseSection(a, line[1..end]); continue; } const eq = std.mem.indexOfScalar(u8, line, '='); const cut = eq orelse firstSpace(line); if (cut) |c| { const name = std.mem.trim(u8, line[0..c], " \t"); var val = if (eq != null) std.mem.trim(u8, line[c + 1..], " \t\r") else std.mem.trim(u8, line[c..], " \t\r"); if (val.len >= 2 and val[0] == '"' and val[val.len - 1] == '"') val = val[1..val.len - 1]; if (name.len > 0) try es.append(.{ .key = try std.fmt.allocPrint(a, "{s}.{s}", .{section, name}), .value = try a.dupe(u8, val) }); } else if (line.len > 0) try es.append(.{ .key = try std.fmt.allocPrint(a, "{s}.{s}", .{section, line}), .value = try a.dupe(u8, "true") }); } return es; }
+fn parseSection(a: Allocator, s: []const u8) ![]const u8 { const t = std.mem.trim(u8, s, " \t"); if (std.mem.indexOfScalar(u8, t, '"')) |q1| { if (std.mem.lastIndexOfScalar(u8, t, '"')) |q2| { if (q2 > q1) { const base = std.mem.trim(u8, t[0..q1], " \t"); return std.fmt.allocPrint(a, "{s}.{s}", .{base, t[q1 + 1..q2]}); } } } return a.dupe(u8, t); }
+fn firstSpace(s: []const u8) ?usize { for (s, 0..) |c, i| { if (c == ' ' or c == '\t') return i; } return null; }
+fn configKeyEq(a: []const u8, b: []const u8) bool { return std.ascii.eqlIgnoreCase(a, b); }
+fn configBool(v: []const u8) []const u8 { if (std.ascii.eqlIgnoreCase(v, "true") or std.ascii.eqlIgnoreCase(v, "yes") or std.ascii.eqlIgnoreCase(v, "on") or std.mem.eql(u8, v, "1")) return "true"; if (std.ascii.eqlIgnoreCase(v, "false") or std.ascii.eqlIgnoreCase(v, "no") or std.ascii.eqlIgnoreCase(v, "off") or std.mem.eql(u8, v, "0")) return "false"; return v; }
+fn writeConfigEntries(a: Allocator, path: []const u8, es: []const ConfigEntry) !void { if (std.fs.path.dirname(path)) |d| try std.fs.cwd().makePath(d); var out = std.ArrayList(u8).init(a); for (es) |e| { const ks = try configSectionName(a, e.key); try out.writer().print("[{s}]\n\t{s} = {s}\n", .{ks.section, ks.name, e.value}); } const f = try std.fs.cwd().createFile(path, .{ .truncate = true }); defer f.close(); try f.writeAll(out.items); }
+const KeySplit = struct { section: []const u8, name: []const u8 };
+fn configSectionName(a: Allocator, key: []const u8) !KeySplit { var it = std.mem.splitScalar(u8, key, '.'); const p0 = it.next() orelse key; const p1 = it.next() orelse return .{ .section = try a.dupe(u8, "core"), .name = key }; const rest = it.rest(); if (rest.len == 0) return .{ .section = try a.dupe(u8, p0), .name = try a.dupe(u8, p1) }; return .{ .section = try std.fmt.allocPrint(a, "{s} \"{s}\"", .{p0, p1}), .name = try a.dupe(u8, rest) }; }
+
+fn readRef(a: Allocator, gd: []const u8, n: []const u8) ![]const u8 { const p = try std.fs.path.join(a, &.{gd, n}); const c = try std.fs.cwd().readFileAlloc(a, p, 4096); return std.mem.trim(u8, c, " \r\n\t"); }
+fn collect(a: Allocator, gd: []const u8, prefix: []const u8, refs: *std.ArrayList(RefEntry)) !void { const p = try std.fs.path.join(a, &.{gd, prefix}); var d = std.fs.cwd().openDir(p, .{ .iterate = true }) catch return; var it = d.iterate(); while (try it.next()) |e| { const n = try std.fs.path.join(a, &.{prefix, e.name}); if (e.kind == .directory) try collect(a, gd, n, refs) else { const oid = readRef(a, gd, n) catch continue; try refs.append(.{ .name = n, .oid = oid }); } } }
+
+fn be32(b: []const u8, o: usize) u32 { return (@as(u32, b[o]) << 24) | (@as(u32, b[o + 1]) << 16) | (@as(u32, b[o + 2]) << 8) | @as(u32, b[o + 3]); }
+fn au32(o: *std.ArrayList(u8), v: u32) !void { try o.append(@intCast(v >> 24)); try o.append(@intCast((v >> 16) & 255)); try o.append(@intCast((v >> 8) & 255)); try o.append(@intCast(v & 255)); }
+fn au16(o: *std.ArrayList(u8), v: u16) !void { try o.append(@intCast(v >> 8)); try o.append(@intCast(v & 255)); }
+fn hex(d: [20]u8) [40]u8 { const t = "0123456789abcdef"; var o: [40]u8 = undefined; for (d, 0..) |b, i| { o[i * 2] = t[b >> 4]; o[i * 2 + 1] = t[b & 15]; } return o; }
+fn isHex(s: []const u8) bool { if (s.len < 40) return false; for (s[0..40]) |c| { if (!((c >= '0' and c <= '9') or (c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F'))) return false; } return true; }
+fn unhex20(s: []const u8) ![20]u8 { var o: [20]u8 = undefined; var i: usize = 0; while (i < 20) : (i += 1) { const hi = hv(s[i * 2]) orelse return error.Bad; const lo = hv(s[i * 2 + 1]) orelse return error.Bad; o[i] = (hi << 4) | lo; } return o; }
+fn hv(c: u8) ?u8 { if (c >= '0' and c <= '9') return c - '0'; if (c >= 'a' and c <= 'f') return c - 'a' + 10; if (c >= 'A' and c <= 'F') return c - 'A' + 10; return null; }
+fn modeStr(m: u32) []const u8 { return if (m == 0o100755) "100755" else "100644"; }
+fn zstore(a: Allocator, d: []const u8) ![]u8 { var o = std.ArrayList(u8).init(a); try o.append(0x78); try o.append(0x01); try o.append(1); try au16le(&o, @intCast(d.len)); try au16le(&o, ~@as(u16, @intCast(d.len))); try o.appendSlice(d); const ad = adler(d); try au32(&o, ad); return o.toOwnedSlice(); }
+fn au16le(o: *std.ArrayList(u8), v: u16) !void { try o.append(@intCast(v & 255)); try o.append(@intCast(v >> 8)); }
+fn zunstore(a: Allocator, z: []const u8) ![]u8 { var o = std.ArrayList(u8).init(a); var i: usize = 2; while (i + 5 <= z.len) { const final = (z[i] & 1) != 0; i += 1; const l16 = @as(u16, z[i]) | (@as(u16, z[i + 1]) << 8); const l: usize = l16; i += 4; if (i + l > z.len) break; try o.appendSlice(z[i..i + l]); i += l; if (final) break; } return o.toOwnedSlice(); }
+fn adler(d: []const u8) u32 { var s1: u32 = 1; var s2: u32 = 0; for (d) |b| { s1 = (s1 + b) % 65521; s2 = (s2 + s1) % 65521; } return (s2 << 16) | s1; }
+=== END FILE ===

--- a/examples/frontier_swe/git-to-zig/task.yaml
+++ b/examples/frontier_swe/git-to-zig/task.yaml
@@ -1,0 +1,47 @@
+task:
+  name: "Frontier-SWE · Git to Zig"
+  description: |
+    Improve `candidate.bundle`, a cumulative multi-file Zig implementation of
+    Git v2.47.0. Harbor materializes the bundle over `/app/zig-port` in the
+    pinned official Frontier-SWE task image. `zig build` must produce
+    `zig-out/bin/git` with compatible commands, output, and exit codes.
+
+    Do not compile or link the C Git source, delegate to the installed `git`,
+    use libgit2, access verifier files, or change the task contract. The
+    official verifier runs the Git test suites and scores the fraction of the
+    pinned oracle's attempted tests that pass.
+  tips: |
+    Bundle sections use `=== FILE: relative/path ===` and `=== END FILE ===`.
+    Include complete file contents, without Markdown fences or prose. Paths are
+    relative to `/app/zig-port`. The seed's validated official score is 0.197833.
+    The full verifier typically takes about 13 minutes after image setup.
+
+grader:
+  entrypoint: "frontier_swe_grader.grader:Grader"
+  setup:
+    - "uv pip install -e ./grader"
+  timeout: 90000
+  direction: maximize
+  args:
+    task_id: "git-to-zig"
+    program_file: "candidate.bundle"
+  parallel:
+    max_workers: 1
+  max_pending_per_agent: 1
+
+agents:
+  count: 1
+  runtime: codex
+  model: gpt-5.5
+  research: false
+  runtime_options:
+    model_reasoning_effort: high
+
+workspace:
+  results_dir: "./results"
+  repo_path: "./examples/frontier_swe/git-to-zig/seed"
+
+run:
+  verbose: false
+  ui: false
+  session: local

--- a/examples/frontier_swe/libexpat-to-x86asm/grader/pyproject.toml
+++ b/examples/frontier_swe/libexpat-to-x86asm/grader/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "frontier-swe-grader"
+version = "0.1.0"
+description = "CORAL grader for pinned Frontier-SWE tasks executed through Harbor."
+requires-python = ">=3.11"
+dependencies = ["coral"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/frontier_swe_grader"]

--- a/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/__init__.py
+++ b/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned Frontier-SWE grader for CORAL and its isolated Harbor agent."""

--- a/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/bundle.py
+++ b/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/bundle.py
@@ -1,0 +1,78 @@
+"""Strict parser for the cumulative source-bundle candidate format."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+
+_FILE_HEADER = re.compile(r"^=== FILE: (.+) ===$")
+_FILE_FOOTER = "=== END FILE ==="
+
+
+class BundleError(ValueError):
+    """Raised when a candidate bundle is malformed or unsafe to materialize."""
+
+
+def parse_bundle(text: str) -> list[tuple[PurePosixPath, str]]:
+    """Parse a bundle while rejecting ambiguous or escaping paths."""
+
+    if "\x00" in text:
+        raise BundleError("bundle contains a NUL byte")
+
+    lines = text.splitlines(keepends=True)
+    files: list[tuple[PurePosixPath, str]] = []
+    seen: set[PurePosixPath] = set()
+    index = 0
+
+    while index < len(lines):
+        if not lines[index].strip():
+            index += 1
+            continue
+
+        header = lines[index].rstrip("\r\n")
+        match = _FILE_HEADER.fullmatch(header)
+        if match is None:
+            raise BundleError(f"expected file header at line {index + 1}")
+
+        relative = _safe_relative_path(match.group(1))
+        if relative in seen:
+            raise BundleError(f"duplicate file section: {relative}")
+        seen.add(relative)
+        index += 1
+
+        content: list[str] = []
+        while index < len(lines) and lines[index].rstrip("\r\n") != _FILE_FOOTER:
+            content.append(lines[index])
+            index += 1
+        if index >= len(lines):
+            raise BundleError(f"missing end marker for {relative}")
+
+        files.append((relative, "".join(content)))
+        index += 1
+
+    if not files:
+        raise BundleError("bundle contains no files")
+    return files
+
+
+def materialize_bundle(text: str, destination: Path) -> list[Path]:
+    """Write parsed bundle files below an already isolated destination."""
+
+    written: list[Path] = []
+    for relative, content in parse_bundle(text):
+        output = destination.joinpath(*relative.parts)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content, encoding="utf-8")
+        written.append(output)
+    return written
+
+
+def _safe_relative_path(raw: str) -> PurePosixPath:
+    if not raw or "\\" in raw:
+        raise BundleError(f"invalid bundle path: {raw!r}")
+    path = PurePosixPath(raw)
+    if path.is_absolute() or path.as_posix() != raw:
+        raise BundleError(f"bundle path must be normalized and relative: {raw!r}")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise BundleError(f"bundle path escapes or aliases the workspace: {raw!r}")
+    return path

--- a/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/bundle_agent.py
+++ b/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/bundle_agent.py
@@ -1,0 +1,59 @@
+"""Harbor agent that uploads a deterministic bundle instead of invoking an LLM."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+from .bundle import materialize_bundle
+
+
+class BundleAgent(BaseAgent):
+    """Materialize the CORAL candidate into the official task workspace."""
+
+    def __init__(
+        self,
+        *args: object,
+        candidate_path: str,
+        target_dir: str,
+        prepare_command: str = "",
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._candidate_path = Path(candidate_path)
+        self._target_dir = target_dir
+        self._prepare_command = prepare_command
+
+    @staticmethod
+    def name() -> str:
+        return "frontier-swe-bundle"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        return None
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        del instruction, context
+        candidate = self._candidate_path.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="frontier-swe-candidate-") as temporary:
+            source_dir = Path(temporary)
+            materialize_bundle(candidate, source_dir)
+            await environment.upload_dir(source_dir=source_dir, target_dir=self._target_dir)
+        if self._prepare_command:
+            result = await environment.exec(command=self._prepare_command, timeout_sec=600)
+            if result.return_code != 0:
+                raise RuntimeError(
+                    f"candidate preparation failed with exit {result.return_code}: "
+                    f"{result.stderr[-2000:]}"
+                )

--- a/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/grader.py
+++ b/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/grader.py
@@ -1,0 +1,362 @@
+"""Evaluate a CORAL source bundle with a pinned official Frontier-SWE task."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from coral.grader import TaskGrader
+from coral.types import ScoreBundle
+
+from .bundle import BundleError, parse_bundle
+
+UPSTREAM_URL = "https://github.com/Proximal-Labs/frontier-swe.git"
+UPSTREAM_COMMIT = "111464af7933002a9192240798cbcf65d2790296"
+HARBOR_VERSION = "0.22.0"
+MAX_BUNDLE_BYTES = 10 * 1024 * 1024
+TASK_TARGETS = {
+    "git-to-zig": "/app/zig-port",
+    "lua-native-compiler": "/app/lua-native-compiler",
+    "libexpat-to-x86asm": "/app/asm-port",
+    "dart-style-haskell": "/app/dart-style",
+}
+TASK_IMAGES = {
+    "git-to-zig": "ghcr.io/proximal-labs/frontier-swe/git-to-zig@sha256:04a78190d62e5ab7b396d8cb094f964149531aad5277aa3d98ec833f4ea7eb00",
+    "lua-native-compiler": "ghcr.io/proximal-labs/frontier-swe/lua-native-compiler@sha256:20d39c61f936bec8a6f7e1681a3c78f978a7fd4968913e31fb06a0929a4a9561",
+    "libexpat-to-x86asm": "ghcr.io/proximal-labs/frontier-swe/libexpat-to-x86asm@sha256:c2b36a040add352f7f19ddb1efcb10e2259e4540835b7b480e166b00d41f61bd",
+    "dart-style-haskell": "ghcr.io/proximal-labs/frontier-swe/dart-style-haskell@sha256:c0d816853d0bdbda0761c000edca9e7f10a2c3926e7d7ff66e96ecf38903eb8d",
+}
+TASK_PREPARE_COMMANDS = {
+    "libexpat-to-x86asm": "cd /app/asm-port && make",
+}
+
+
+class Grader(TaskGrader):
+    """Run one official Harbor verifier and return its scalar reward."""
+
+    def evaluate(self) -> ScoreBundle:
+        try:
+            return self._evaluate()
+        except Exception as error:
+            return self.fail(f"Frontier-SWE grader failed: {type(error).__name__}: {error}")
+
+    def _evaluate(self) -> ScoreBundle:
+        task_id = str(self.args.get("task_id", ""))
+        if task_id not in TASK_TARGETS:
+            return self.fail(f"unsupported Frontier-SWE task_id: {task_id!r}")
+
+        program_file = str(self.args.get("program_file", "candidate.bundle"))
+        candidate = Path(self.codebase_path) / program_file
+        bundle_error = _validate_candidate(candidate)
+        if bundle_error is not None:
+            return self.fail(bundle_error)
+
+        task_dir = self._official_task_dir(task_id)
+        harbor_logs = Path(self.eval_logs_dir) / "harbor_logs"
+        harbor_logs.mkdir(parents=True, exist_ok=True)
+        job_name = f"frontier_swe_{task_id}_{int(time.time())}"
+        environment = os.environ.get(
+            "CORAL_FRONTIER_SWE_HARBOR_ENVIRONMENT",
+            str(self.args.get("environment", "docker")),
+        )
+
+        command = _harbor_command(
+            task_dir=task_dir,
+            candidate=candidate,
+            target_dir=TASK_TARGETS[task_id],
+            prepare_command=TASK_PREPARE_COMMANDS.get(task_id, ""),
+            logs_dir=harbor_logs,
+            job_name=job_name,
+            environment=environment,
+        )
+        env = os.environ.copy()
+        grader_src = str(Path(__file__).resolve().parents[1])
+        env["PYTHONPATH"] = os.pathsep.join(
+            path for path in (grader_src, env.get("PYTHONPATH", "")) if path
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=task_dir,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            return self.fail(f"Harbor evaluation timed out after {self.timeout}s: {error}")
+        except OSError as error:
+            return self.fail(f"could not launch Harbor: {error}")
+
+        job_dir = harbor_logs / job_name
+        parsed = _read_trial_score(job_dir)
+        if isinstance(parsed, str):
+            return self.fail(
+                f"Harbor produced no official score (exit {completed.returncode}): {parsed}. "
+                f"{_diagnostic(completed)}"
+            )
+
+        reward, trial = parsed
+        detail = _read_reward_detail(job_dir)
+        feedback = _feedback(
+            task_id,
+            reward,
+            environment,
+            self.eval_logs_worktree_path(job_dir),
+            detail,
+            trial,
+        )
+        explanation = f"official frontier_reward={reward:.12g} ({task_id}, Harbor {environment})"
+        return self.score(
+            reward,
+            explanation=explanation,
+            feedback=feedback,
+            metadata={
+                "task_id": task_id,
+                "upstream_commit": UPSTREAM_COMMIT,
+                "container_image": TASK_IMAGES[task_id],
+                "harbor_environment": environment,
+            },
+        )
+
+    def _official_task_dir(self, task_id: str) -> Path:
+        private_dir = Path(self.private_dir)
+        private_dir.mkdir(parents=True, exist_ok=True)
+        checkout = private_dir / f"frontier-swe-{UPSTREAM_COMMIT[:12]}"
+        task_dir = checkout / "tasks" / task_id
+        if _checkout_matches(checkout, task_dir):
+            _pin_task_image(task_dir, task_id)
+            return task_dir
+
+        if checkout.exists():
+            shutil.rmtree(checkout)
+        with tempfile.TemporaryDirectory(
+            prefix="frontier-swe-checkout-", dir=private_dir
+        ) as temporary:
+            staged = Path(temporary) / "repo"
+            commands = [
+                ["git", "init", str(staged)],
+                ["git", "-C", str(staged), "remote", "add", "origin", UPSTREAM_URL],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "sparse-checkout",
+                    "set",
+                    "--no-cone",
+                    f"/tasks/{task_id}/",
+                    f"!/tasks/{task_id}/solution/",
+                    f"!/tasks/{task_id}/environment/*",
+                    f"/tasks/{task_id}/environment/Dockerfile",
+                ],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "fetch",
+                    "--filter=blob:none",
+                    "--depth",
+                    "1",
+                    "origin",
+                    UPSTREAM_COMMIT,
+                ],
+                ["git", "-C", str(staged), "checkout", "--detach", "FETCH_HEAD"],
+            ]
+            for command in commands:
+                result = subprocess.run(
+                    command,
+                    text=True,
+                    capture_output=True,
+                    timeout=600,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        f"upstream checkout command failed: {' '.join(command)}; "
+                        f"{_diagnostic(result)}"
+                    )
+            staged.replace(checkout)
+
+        if not _checkout_matches(checkout, task_dir):
+            raise RuntimeError("pinned upstream checkout is incomplete or at the wrong commit")
+        _pin_task_image(task_dir, task_id)
+        return task_dir
+
+
+def _validate_candidate(candidate: Path) -> str | None:
+    try:
+        size = candidate.stat().st_size
+    except OSError as error:
+        return f"candidate bundle is unavailable: {error}"
+    if size > MAX_BUNDLE_BYTES:
+        return f"candidate bundle exceeds {MAX_BUNDLE_BYTES} bytes"
+    try:
+        files = parse_bundle(candidate.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, BundleError) as error:
+        return f"invalid candidate bundle: {error}"
+    return None if files else "candidate bundle contains no files"
+
+
+def _harbor_command(
+    *,
+    task_dir: Path,
+    candidate: Path,
+    target_dir: str,
+    prepare_command: str,
+    logs_dir: Path,
+    job_name: str,
+    environment: str,
+) -> list[str]:
+    package = (
+        f"harbor[modal]=={HARBOR_VERSION}"
+        if environment == "modal"
+        else f"harbor=={HARBOR_VERSION}"
+    )
+    agent_args = [
+        "--agent-kwarg",
+        f"candidate_path={candidate}",
+        "--agent-kwarg",
+        f"target_dir={target_dir}",
+    ]
+    if prepare_command:
+        agent_args.extend(["--agent-kwarg", f"prepare_command={prepare_command}"])
+
+    return [
+        "uvx",
+        "--python",
+        "3.12",
+        "--from",
+        package,
+        "harbor",
+        "run",
+        "--path",
+        str(task_dir),
+        "--agent",
+        "frontier_swe_grader.bundle_agent:BundleAgent",
+        *agent_args,
+        "--verifier",
+        "frontier_swe_grader.reward_verifier:FrontierSWEVerifier",
+        "--env",
+        environment,
+        "--jobs-dir",
+        str(logs_dir),
+        "--job-name",
+        job_name,
+        "--n-attempts",
+        "1",
+        "--n-concurrent",
+        "1",
+        "--yes",
+        "--quiet",
+    ]
+
+
+def _checkout_matches(checkout: Path, task_dir: Path) -> bool:
+    if not task_dir.is_dir():
+        return False
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == UPSTREAM_COMMIT
+
+
+def _pin_task_image(task_dir: Path, task_id: str) -> None:
+    task_config = task_dir / "task.toml"
+    text = task_config.read_text(encoding="utf-8")
+    pinned_line = f'docker_image = "{TASK_IMAGES[task_id]}"'
+    if pinned_line in text:
+        return
+    tagged_line = f'docker_image = "ghcr.io/proximal-labs/frontier-swe/{task_id}:v4"'
+    if text.count(tagged_line) != 1:
+        raise RuntimeError(f"could not locate the expected image tag in {task_config}")
+    task_config.write_text(text.replace(tagged_line, pinned_line), encoding="utf-8")
+
+
+def _read_trial_score(job_dir: Path) -> tuple[float, dict[str, Any]] | str:
+    if not job_dir.is_dir():
+        return f"job directory is missing: {job_dir}"
+    errors: list[str] = []
+    for result_path in sorted(job_dir.rglob("result.json")):
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            errors.append(f"{result_path.name}: {error}")
+            continue
+        verifier = payload.get("verifier_result")
+        if not isinstance(verifier, dict):
+            continue
+        rewards = verifier.get("rewards")
+        if not isinstance(rewards, dict):
+            continue
+        try:
+            reward = float(rewards["reward"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        return reward, payload
+    return "; ".join(errors) or "no trial result contained verifier_result.rewards.reward"
+
+
+def _read_reward_detail(job_dir: Path) -> dict[str, Any]:
+    for reward_path in sorted(job_dir.rglob("reward.json")):
+        try:
+            payload = json.loads(reward_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _feedback(
+    task_id: str,
+    reward: float,
+    environment: str,
+    job_dir: Path,
+    detail: dict[str, Any],
+    trial: dict[str, Any],
+) -> str:
+    lines = [
+        f"Official Frontier-SWE result for `{task_id}`: {reward:.12g}",
+        f"Harbor environment: `{environment}`",
+        f"Upstream commit: `{UPSTREAM_COMMIT}`",
+        f"Container image: `{TASK_IMAGES[task_id]}`",
+        f"Logs: `{job_dir}`",
+    ]
+    reason = detail.get("reason")
+    if reason:
+        lines.append(f"Reason: {reason}")
+    for key in (
+        "tests_passed",
+        "tests_total",
+        "total_passed",
+        "total_failed",
+        "total_skipped",
+        "score",
+        "reward",
+    ):
+        if key in detail:
+            lines.append(f"{key}: {detail[key]}")
+    if trial.get("exception_info"):
+        lines.append(f"Trial exception: {trial['exception_info']}")
+    return "\n".join(lines)
+
+
+def _diagnostic(completed: subprocess.CompletedProcess[str]) -> str:
+    pieces = []
+    for label, value in (("stdout", completed.stdout), ("stderr", completed.stderr)):
+        text = (value or "").strip()
+        if text:
+            pieces.append(f"{label}: {text[-2000:]}")
+    return " | ".join(pieces) or "no subprocess output"

--- a/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/reward_verifier.py
+++ b/examples/frontier_swe/libexpat-to-x86asm/grader/src/frontier_swe_grader/reward_verifier.py
@@ -1,0 +1,22 @@
+"""Harbor verifier adapter that selects the scalar from Frontier-SWE details."""
+
+from __future__ import annotations
+
+import json
+
+from harbor.verifier.verifier import Verifier, VerifierOutputParseError
+
+
+class FrontierSWEVerifier(Verifier):
+    """Run Harbor's verifier unchanged, but return only its primary reward."""
+
+    def _parse_reward_json(self) -> dict[str, float | int]:
+        try:
+            payload = json.loads(self.trial_paths.reward_json_path.read_text())
+            value = payload.get("reward", payload.get("score"))
+            return {"reward": float(value)}
+        except (AttributeError, OSError, TypeError, ValueError) as error:
+            raise VerifierOutputParseError(
+                f"Frontier-SWE reward JSON has no numeric reward or score: "
+                f"{self.trial_paths.reward_json_path}"
+            ) from error

--- a/examples/frontier_swe/libexpat-to-x86asm/seed/candidate.bundle
+++ b/examples/frontier_swe/libexpat-to-x86asm/seed/candidate.bundle
@@ -1,0 +1,429 @@
+=== FILE: Makefile ===
+.PHONY: all clean
+
+ASM ?= nasm
+LD ?= ld
+
+all: libexpat.so
+
+libexpat.so: expat_stub.o
+	$(LD) -shared -soname libexpat.so.1 -o $@ $<
+
+expat_stub.o: expat_stub.asm
+	$(ASM) -f elf64 -g -F dwarf -o $@ $<
+
+clean:
+	rm -f expat_stub.o libexpat.so libexpat.so.1
+=== END FILE ===
+
+=== FILE: expat_stub.asm ===
+bits 64
+default rel
+
+%define P_USERDATA 0
+%define P_START    8
+%define P_END      16
+%define P_CHAR     24
+%define P_ERROR    32
+%define P_BYTEIDX  40
+%define P_LINE     48
+%define P_COLUMN   56
+%define P_BASE     64
+%define P_MALLOC   72
+%define P_REALLOC  80
+%define P_FREE     88
+
+%define XML_ERROR_NONE           0
+%define XML_ERROR_SYNTAX         2
+%define XML_ERROR_INVALID_TOKEN  4
+%define XML_ERROR_UNCLOSED_TOKEN 5
+
+section .rodata
+version_string: db "expat_2.6.4", 0
+error_none: db "no error", 0
+error_syntax: db "syntax error", 0
+error_invalid: db "not well-formed (invalid token)", 0
+error_unclosed: db "unclosed token", 0
+empty_string: db 0
+feature_sizeof_xml_char: db "sizeof(XML_Char)", 0
+feature_sizeof_xml_lchar: db "sizeof(XML_LChar)", 0
+feature_list:
+    dd 6
+    dd 0
+    dq feature_sizeof_xml_char
+    dq 1
+    dd 7
+    dd 0
+    dq feature_sizeof_xml_lchar
+    dq 1
+    dd 0
+    dd 0
+    dq 0
+    dq 0
+
+section .bss
+parser_state: resq 32
+scratch_buffer: resb 8192
+
+section .text
+
+%macro export 1
+global %1:function
+%1:
+%endmacro
+
+ret_void:
+    ret
+
+ret_zero:
+    xor eax, eax
+    ret
+
+ret_one:
+    mov eax, 1
+    ret
+
+ret_parser:
+    lea rax, [parser_state]
+    ret
+
+ret_null:
+    xor eax, eax
+    ret
+
+ret_empty_string:
+    lea rax, [empty_string]
+    ret
+
+ret_error_none_string:
+    lea rax, [error_none]
+    ret
+
+ret_version_string:
+    lea rax, [version_string]
+    ret
+
+ret_scratch:
+    lea rax, [scratch_buffer]
+    ret
+
+clear_parser_state:
+    lea rdi, [parser_state]
+    xor eax, eax
+    mov ecx, 32
+    rep stosq
+    mov qword [parser_state + P_LINE], 1
+    lea rax, [parser_state]
+    ret
+
+; Parser creation and lifetime.
+export XML_ParserCreate
+    jmp clear_parser_state
+export XML_ParserCreateNS
+    jmp clear_parser_state
+export XML_ParserCreate_MM
+    ; XML_ParserCreate_MM(encoding, memsuite, namespaceSeparator).
+    ; Keep the static parser model, but remember callbacks from the optional
+    ; XML_Memory_Handling_Suite: malloc_fcn, realloc_fcn, free_fcn.
+    push rsi
+    lea rdi, [parser_state]
+    xor eax, eax
+    mov ecx, 32
+    rep stosq
+    mov qword [parser_state + P_LINE], 1
+    pop rsi
+    test rsi, rsi
+    jz .done
+    mov rax, [rsi]
+    mov [parser_state + P_MALLOC], rax
+    mov rax, [rsi + 8]
+    mov [parser_state + P_REALLOC], rax
+    mov rax, [rsi + 16]
+    mov [parser_state + P_FREE], rax
+.done:
+    lea rax, [parser_state]
+    ret
+export XML_ExternalEntityParserCreate
+    jmp ret_parser
+export XML_ParserFree
+    jmp ret_void
+export XML_ParserReset
+    test rdi, rdi
+    jz .done
+    mov qword [rdi + P_ERROR], XML_ERROR_NONE
+    mov qword [rdi + P_BYTEIDX], 0
+    mov qword [rdi + P_LINE], 1
+    mov qword [rdi + P_COLUMN], 0
+.done:
+    jmp ret_one
+
+; Handler setters store callback pointers but parsing remains an accept-fast stub.
+export XML_SetElementDeclHandler
+    jmp ret_void
+export XML_SetAttlistDeclHandler
+    jmp ret_void
+export XML_SetXmlDeclHandler
+    jmp ret_void
+export XML_SetEntityDeclHandler
+    jmp ret_void
+export XML_SetElementHandler
+    test rdi, rdi
+    jz .done
+    mov [rdi + P_START], rsi
+    mov [rdi + P_END], rdx
+.done:
+    ret
+export XML_SetStartElementHandler
+    test rdi, rdi
+    jz .done
+    mov [rdi + P_START], rsi
+.done:
+    ret
+export XML_SetEndElementHandler
+    test rdi, rdi
+    jz .done
+    mov [rdi + P_END], rsi
+.done:
+    ret
+export XML_SetCharacterDataHandler
+    test rdi, rdi
+    jz .done
+    mov [rdi + P_CHAR], rsi
+.done:
+    ret
+export XML_SetProcessingInstructionHandler
+    jmp ret_void
+export XML_SetCommentHandler
+    jmp ret_void
+export XML_SetCdataSectionHandler
+    jmp ret_void
+export XML_SetStartCdataSectionHandler
+    jmp ret_void
+export XML_SetEndCdataSectionHandler
+    jmp ret_void
+export XML_SetDefaultHandler
+    jmp ret_void
+export XML_SetDefaultHandlerExpand
+    jmp ret_void
+export XML_SetDoctypeDeclHandler
+    jmp ret_void
+export XML_SetStartDoctypeDeclHandler
+    jmp ret_void
+export XML_SetEndDoctypeDeclHandler
+    jmp ret_void
+export XML_SetUnparsedEntityDeclHandler
+    jmp ret_void
+export XML_SetNotationDeclHandler
+    jmp ret_void
+export XML_SetNamespaceDeclHandler
+    jmp ret_void
+export XML_SetStartNamespaceDeclHandler
+    jmp ret_void
+export XML_SetEndNamespaceDeclHandler
+    jmp ret_void
+export XML_SetNotStandaloneHandler
+    jmp ret_void
+export XML_SetExternalEntityRefHandler
+    jmp ret_void
+export XML_SetExternalEntityRefHandlerArg
+    jmp ret_void
+export XML_SetSkippedEntityHandler
+    jmp ret_void
+export XML_SetUnknownEncodingHandler
+    jmp ret_void
+export XML_SetReturnNSTriplet
+    jmp ret_void
+export XML_SetUserData
+    test rdi, rdi
+    jz .done
+    mov [rdi + P_USERDATA], rsi
+.done:
+    ret
+export XML_UseParserAsHandlerArg
+    test rdi, rdi
+    jz .done
+    mov [rdi + P_USERDATA], rdi
+.done:
+    ret
+
+; Status and option APIs.
+export XML_SetEncoding
+    jmp ret_one
+export XML_UseForeignDTD
+    jmp ret_zero
+export XML_SetBase
+    test rdi, rdi
+    jz .done
+    mov [rdi + P_BASE], rsi
+.done:
+    mov eax, 1
+    ret
+export XML_GetBase
+    test rdi, rdi
+    jz .none
+    mov rax, [rdi + P_BASE]
+    ret
+.none:
+    xor eax, eax
+    ret
+export XML_SetParamEntityParsing
+    jmp ret_one
+export XML_SetHashSalt
+    jmp ret_one
+export XML_SetBillionLaughsAttackProtectionMaximumAmplification
+    jmp ret_one
+export XML_SetBillionLaughsAttackProtectionActivationThreshold
+    jmp ret_one
+export XML_SetReparseDeferralEnabled
+    jmp ret_one
+export XML_DefaultCurrent
+    jmp ret_void
+
+; Accept-fast parser entry points restored to the stable baseline behavior.
+export XML_Parse
+    jmp ret_one
+export XML_GetBuffer
+    jmp ret_scratch
+export XML_ParseBuffer
+    jmp ret_one
+export XML_StopParser
+    jmp ret_one
+export XML_ResumeParser
+    jmp ret_one
+export XML_GetParsingStatus
+    test rsi, rsi
+    jz .done
+    mov dword [rsi], 0
+    mov dword [rsi + 4], 0
+.done:
+    ret
+
+; Position, attribute, and context getters.
+export XML_GetSpecifiedAttributeCount
+    jmp ret_zero
+export XML_GetIdAttributeIndex
+    mov eax, -1
+    ret
+export XML_GetAttributeInfo
+    jmp ret_null
+export XML_GetErrorCode
+    test rdi, rdi
+    jz .none
+    mov eax, [rdi + P_ERROR]
+    ret
+.none:
+    xor eax, eax
+    ret
+export XML_GetCurrentLineNumber
+    test rdi, rdi
+    jz .default_line
+    mov rax, [rdi + P_LINE]
+    test rax, rax
+    jnz .done
+.default_line:
+    mov eax, 1
+.done:
+    ret
+export XML_GetCurrentColumnNumber
+    test rdi, rdi
+    jz .zero
+    mov rax, [rdi + P_COLUMN]
+    ret
+.zero:
+    xor eax, eax
+    ret
+export XML_GetCurrentByteIndex
+    test rdi, rdi
+    jz .unknown
+    mov rax, [rdi + P_BYTEIDX]
+    ret
+.unknown:
+    mov rax, -1
+    ret
+export XML_GetCurrentByteCount
+    jmp ret_zero
+export XML_GetInputContext
+    test rsi, rsi
+    jz .skip_offset
+    mov dword [rsi], 0
+.skip_offset:
+    test rdx, rdx
+    jz .done
+    mov dword [rdx], 0
+.done:
+    jmp ret_null
+
+; Memory helpers dispatch to callbacks supplied to XML_ParserCreate_MM.
+; Without a custom memory suite they keep the previous NULL/no-op behavior.
+export XML_FreeContentModel
+    jmp ret_void
+export XML_MemMalloc
+    test rdi, rdi
+    jz .none
+    mov rax, [rdi + P_MALLOC]
+    test rax, rax
+    jz .none
+    mov rdi, rsi
+    jmp rax
+.none:
+    xor eax, eax
+    ret
+export XML_MemRealloc
+    test rdi, rdi
+    jz .none
+    mov rax, [rdi + P_REALLOC]
+    test rax, rax
+    jz .none
+    mov rdi, rsi
+    mov rsi, rdx
+    jmp rax
+.none:
+    xor eax, eax
+    ret
+export XML_MemFree
+    test rdi, rdi
+    jz .done
+    mov rax, [rdi + P_FREE]
+    test rax, rax
+    jz .done
+    mov rdi, rsi
+    jmp rax
+.done:
+    ret
+
+; Version and feature information.
+export XML_ErrorString
+    cmp edi, XML_ERROR_NONE
+    je .none
+    cmp edi, XML_ERROR_SYNTAX
+    je .syntax
+    cmp edi, XML_ERROR_INVALID_TOKEN
+    je .invalid
+    cmp edi, XML_ERROR_UNCLOSED_TOKEN
+    je .unclosed
+    xor eax, eax
+    ret
+.none:
+    lea rax, [error_none]
+    ret
+.syntax:
+    lea rax, [error_syntax]
+    ret
+.invalid:
+    lea rax, [error_invalid]
+    ret
+.unclosed:
+    lea rax, [error_unclosed]
+    ret
+export XML_ExpatVersion
+    jmp ret_version_string
+export XML_ExpatVersionInfo
+    mov rax, 0x0000000600000002
+    mov edx, 4
+    ret
+export XML_GetFeatureList
+    lea rax, [feature_list]
+    ret
+
+section .note.GNU-stack noalloc noexec nowrite progbits
+=== END FILE ===

--- a/examples/frontier_swe/libexpat-to-x86asm/task.yaml
+++ b/examples/frontier_swe/libexpat-to-x86asm/task.yaml
@@ -1,0 +1,47 @@
+task:
+  name: "Frontier-SWE · libexpat to x86-64 assembly"
+  description: |
+    Improve `candidate.bundle`, an x86-64 assembly implementation of libexpat
+    2.6.4 materialized at `/app/asm-port` in the pinned official Frontier-SWE
+    task image. The build must produce an ABI-compatible `libexpat.so` that
+    exports the public Expat API and follows the System V AMD64 ABI.
+
+    Do not compile or link the C Expat source and do not load, wrap, or delegate
+    to an existing libexpat shared library. The official reward combines
+    weighted API correctness with benchmark performance, subject to build,
+    linking, and anti-cheat gates.
+  tips: |
+    Bundle sections use `=== FILE: relative/path ===` and `=== END FILE ===`.
+    Include complete file contents, without Markdown fences or prose. Paths are
+    relative to `/app/asm-port`. One pinned-image validation scored the seed at
+    1397.818394; the performance component makes this reward machine-dependent.
+
+grader:
+  entrypoint: "frontier_swe_grader.grader:Grader"
+  setup:
+    - "uv pip install -e ./grader"
+  timeout: 90000
+  direction: maximize
+  args:
+    task_id: "libexpat-to-x86asm"
+    program_file: "candidate.bundle"
+  parallel:
+    max_workers: 1
+  max_pending_per_agent: 1
+
+agents:
+  count: 1
+  runtime: codex
+  model: gpt-5.5
+  research: false
+  runtime_options:
+    model_reasoning_effort: high
+
+workspace:
+  results_dir: "./results"
+  repo_path: "./examples/frontier_swe/libexpat-to-x86asm/seed"
+
+run:
+  verbose: false
+  ui: false
+  session: local

--- a/examples/frontier_swe/lua-native-compiler/grader/pyproject.toml
+++ b/examples/frontier_swe/lua-native-compiler/grader/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "frontier-swe-grader"
+version = "0.1.0"
+description = "CORAL grader for pinned Frontier-SWE tasks executed through Harbor."
+requires-python = ">=3.11"
+dependencies = ["coral"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/frontier_swe_grader"]

--- a/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/__init__.py
+++ b/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned Frontier-SWE grader for CORAL and its isolated Harbor agent."""

--- a/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/bundle.py
+++ b/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/bundle.py
@@ -1,0 +1,78 @@
+"""Strict parser for the cumulative source-bundle candidate format."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+
+_FILE_HEADER = re.compile(r"^=== FILE: (.+) ===$")
+_FILE_FOOTER = "=== END FILE ==="
+
+
+class BundleError(ValueError):
+    """Raised when a candidate bundle is malformed or unsafe to materialize."""
+
+
+def parse_bundle(text: str) -> list[tuple[PurePosixPath, str]]:
+    """Parse a bundle while rejecting ambiguous or escaping paths."""
+
+    if "\x00" in text:
+        raise BundleError("bundle contains a NUL byte")
+
+    lines = text.splitlines(keepends=True)
+    files: list[tuple[PurePosixPath, str]] = []
+    seen: set[PurePosixPath] = set()
+    index = 0
+
+    while index < len(lines):
+        if not lines[index].strip():
+            index += 1
+            continue
+
+        header = lines[index].rstrip("\r\n")
+        match = _FILE_HEADER.fullmatch(header)
+        if match is None:
+            raise BundleError(f"expected file header at line {index + 1}")
+
+        relative = _safe_relative_path(match.group(1))
+        if relative in seen:
+            raise BundleError(f"duplicate file section: {relative}")
+        seen.add(relative)
+        index += 1
+
+        content: list[str] = []
+        while index < len(lines) and lines[index].rstrip("\r\n") != _FILE_FOOTER:
+            content.append(lines[index])
+            index += 1
+        if index >= len(lines):
+            raise BundleError(f"missing end marker for {relative}")
+
+        files.append((relative, "".join(content)))
+        index += 1
+
+    if not files:
+        raise BundleError("bundle contains no files")
+    return files
+
+
+def materialize_bundle(text: str, destination: Path) -> list[Path]:
+    """Write parsed bundle files below an already isolated destination."""
+
+    written: list[Path] = []
+    for relative, content in parse_bundle(text):
+        output = destination.joinpath(*relative.parts)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content, encoding="utf-8")
+        written.append(output)
+    return written
+
+
+def _safe_relative_path(raw: str) -> PurePosixPath:
+    if not raw or "\\" in raw:
+        raise BundleError(f"invalid bundle path: {raw!r}")
+    path = PurePosixPath(raw)
+    if path.is_absolute() or path.as_posix() != raw:
+        raise BundleError(f"bundle path must be normalized and relative: {raw!r}")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise BundleError(f"bundle path escapes or aliases the workspace: {raw!r}")
+    return path

--- a/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/bundle_agent.py
+++ b/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/bundle_agent.py
@@ -1,0 +1,59 @@
+"""Harbor agent that uploads a deterministic bundle instead of invoking an LLM."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+from .bundle import materialize_bundle
+
+
+class BundleAgent(BaseAgent):
+    """Materialize the CORAL candidate into the official task workspace."""
+
+    def __init__(
+        self,
+        *args: object,
+        candidate_path: str,
+        target_dir: str,
+        prepare_command: str = "",
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._candidate_path = Path(candidate_path)
+        self._target_dir = target_dir
+        self._prepare_command = prepare_command
+
+    @staticmethod
+    def name() -> str:
+        return "frontier-swe-bundle"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        return None
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        del instruction, context
+        candidate = self._candidate_path.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="frontier-swe-candidate-") as temporary:
+            source_dir = Path(temporary)
+            materialize_bundle(candidate, source_dir)
+            await environment.upload_dir(source_dir=source_dir, target_dir=self._target_dir)
+        if self._prepare_command:
+            result = await environment.exec(command=self._prepare_command, timeout_sec=600)
+            if result.return_code != 0:
+                raise RuntimeError(
+                    f"candidate preparation failed with exit {result.return_code}: "
+                    f"{result.stderr[-2000:]}"
+                )

--- a/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/grader.py
+++ b/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/grader.py
@@ -1,0 +1,362 @@
+"""Evaluate a CORAL source bundle with a pinned official Frontier-SWE task."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from coral.grader import TaskGrader
+from coral.types import ScoreBundle
+
+from .bundle import BundleError, parse_bundle
+
+UPSTREAM_URL = "https://github.com/Proximal-Labs/frontier-swe.git"
+UPSTREAM_COMMIT = "111464af7933002a9192240798cbcf65d2790296"
+HARBOR_VERSION = "0.22.0"
+MAX_BUNDLE_BYTES = 10 * 1024 * 1024
+TASK_TARGETS = {
+    "git-to-zig": "/app/zig-port",
+    "lua-native-compiler": "/app/lua-native-compiler",
+    "libexpat-to-x86asm": "/app/asm-port",
+    "dart-style-haskell": "/app/dart-style",
+}
+TASK_IMAGES = {
+    "git-to-zig": "ghcr.io/proximal-labs/frontier-swe/git-to-zig@sha256:04a78190d62e5ab7b396d8cb094f964149531aad5277aa3d98ec833f4ea7eb00",
+    "lua-native-compiler": "ghcr.io/proximal-labs/frontier-swe/lua-native-compiler@sha256:20d39c61f936bec8a6f7e1681a3c78f978a7fd4968913e31fb06a0929a4a9561",
+    "libexpat-to-x86asm": "ghcr.io/proximal-labs/frontier-swe/libexpat-to-x86asm@sha256:c2b36a040add352f7f19ddb1efcb10e2259e4540835b7b480e166b00d41f61bd",
+    "dart-style-haskell": "ghcr.io/proximal-labs/frontier-swe/dart-style-haskell@sha256:c0d816853d0bdbda0761c000edca9e7f10a2c3926e7d7ff66e96ecf38903eb8d",
+}
+TASK_PREPARE_COMMANDS = {
+    "libexpat-to-x86asm": "cd /app/asm-port && make",
+}
+
+
+class Grader(TaskGrader):
+    """Run one official Harbor verifier and return its scalar reward."""
+
+    def evaluate(self) -> ScoreBundle:
+        try:
+            return self._evaluate()
+        except Exception as error:
+            return self.fail(f"Frontier-SWE grader failed: {type(error).__name__}: {error}")
+
+    def _evaluate(self) -> ScoreBundle:
+        task_id = str(self.args.get("task_id", ""))
+        if task_id not in TASK_TARGETS:
+            return self.fail(f"unsupported Frontier-SWE task_id: {task_id!r}")
+
+        program_file = str(self.args.get("program_file", "candidate.bundle"))
+        candidate = Path(self.codebase_path) / program_file
+        bundle_error = _validate_candidate(candidate)
+        if bundle_error is not None:
+            return self.fail(bundle_error)
+
+        task_dir = self._official_task_dir(task_id)
+        harbor_logs = Path(self.eval_logs_dir) / "harbor_logs"
+        harbor_logs.mkdir(parents=True, exist_ok=True)
+        job_name = f"frontier_swe_{task_id}_{int(time.time())}"
+        environment = os.environ.get(
+            "CORAL_FRONTIER_SWE_HARBOR_ENVIRONMENT",
+            str(self.args.get("environment", "docker")),
+        )
+
+        command = _harbor_command(
+            task_dir=task_dir,
+            candidate=candidate,
+            target_dir=TASK_TARGETS[task_id],
+            prepare_command=TASK_PREPARE_COMMANDS.get(task_id, ""),
+            logs_dir=harbor_logs,
+            job_name=job_name,
+            environment=environment,
+        )
+        env = os.environ.copy()
+        grader_src = str(Path(__file__).resolve().parents[1])
+        env["PYTHONPATH"] = os.pathsep.join(
+            path for path in (grader_src, env.get("PYTHONPATH", "")) if path
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=task_dir,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            return self.fail(f"Harbor evaluation timed out after {self.timeout}s: {error}")
+        except OSError as error:
+            return self.fail(f"could not launch Harbor: {error}")
+
+        job_dir = harbor_logs / job_name
+        parsed = _read_trial_score(job_dir)
+        if isinstance(parsed, str):
+            return self.fail(
+                f"Harbor produced no official score (exit {completed.returncode}): {parsed}. "
+                f"{_diagnostic(completed)}"
+            )
+
+        reward, trial = parsed
+        detail = _read_reward_detail(job_dir)
+        feedback = _feedback(
+            task_id,
+            reward,
+            environment,
+            self.eval_logs_worktree_path(job_dir),
+            detail,
+            trial,
+        )
+        explanation = f"official frontier_reward={reward:.12g} ({task_id}, Harbor {environment})"
+        return self.score(
+            reward,
+            explanation=explanation,
+            feedback=feedback,
+            metadata={
+                "task_id": task_id,
+                "upstream_commit": UPSTREAM_COMMIT,
+                "container_image": TASK_IMAGES[task_id],
+                "harbor_environment": environment,
+            },
+        )
+
+    def _official_task_dir(self, task_id: str) -> Path:
+        private_dir = Path(self.private_dir)
+        private_dir.mkdir(parents=True, exist_ok=True)
+        checkout = private_dir / f"frontier-swe-{UPSTREAM_COMMIT[:12]}"
+        task_dir = checkout / "tasks" / task_id
+        if _checkout_matches(checkout, task_dir):
+            _pin_task_image(task_dir, task_id)
+            return task_dir
+
+        if checkout.exists():
+            shutil.rmtree(checkout)
+        with tempfile.TemporaryDirectory(
+            prefix="frontier-swe-checkout-", dir=private_dir
+        ) as temporary:
+            staged = Path(temporary) / "repo"
+            commands = [
+                ["git", "init", str(staged)],
+                ["git", "-C", str(staged), "remote", "add", "origin", UPSTREAM_URL],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "sparse-checkout",
+                    "set",
+                    "--no-cone",
+                    f"/tasks/{task_id}/",
+                    f"!/tasks/{task_id}/solution/",
+                    f"!/tasks/{task_id}/environment/*",
+                    f"/tasks/{task_id}/environment/Dockerfile",
+                ],
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "fetch",
+                    "--filter=blob:none",
+                    "--depth",
+                    "1",
+                    "origin",
+                    UPSTREAM_COMMIT,
+                ],
+                ["git", "-C", str(staged), "checkout", "--detach", "FETCH_HEAD"],
+            ]
+            for command in commands:
+                result = subprocess.run(
+                    command,
+                    text=True,
+                    capture_output=True,
+                    timeout=600,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        f"upstream checkout command failed: {' '.join(command)}; "
+                        f"{_diagnostic(result)}"
+                    )
+            staged.replace(checkout)
+
+        if not _checkout_matches(checkout, task_dir):
+            raise RuntimeError("pinned upstream checkout is incomplete or at the wrong commit")
+        _pin_task_image(task_dir, task_id)
+        return task_dir
+
+
+def _validate_candidate(candidate: Path) -> str | None:
+    try:
+        size = candidate.stat().st_size
+    except OSError as error:
+        return f"candidate bundle is unavailable: {error}"
+    if size > MAX_BUNDLE_BYTES:
+        return f"candidate bundle exceeds {MAX_BUNDLE_BYTES} bytes"
+    try:
+        files = parse_bundle(candidate.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, BundleError) as error:
+        return f"invalid candidate bundle: {error}"
+    return None if files else "candidate bundle contains no files"
+
+
+def _harbor_command(
+    *,
+    task_dir: Path,
+    candidate: Path,
+    target_dir: str,
+    prepare_command: str,
+    logs_dir: Path,
+    job_name: str,
+    environment: str,
+) -> list[str]:
+    package = (
+        f"harbor[modal]=={HARBOR_VERSION}"
+        if environment == "modal"
+        else f"harbor=={HARBOR_VERSION}"
+    )
+    agent_args = [
+        "--agent-kwarg",
+        f"candidate_path={candidate}",
+        "--agent-kwarg",
+        f"target_dir={target_dir}",
+    ]
+    if prepare_command:
+        agent_args.extend(["--agent-kwarg", f"prepare_command={prepare_command}"])
+
+    return [
+        "uvx",
+        "--python",
+        "3.12",
+        "--from",
+        package,
+        "harbor",
+        "run",
+        "--path",
+        str(task_dir),
+        "--agent",
+        "frontier_swe_grader.bundle_agent:BundleAgent",
+        *agent_args,
+        "--verifier",
+        "frontier_swe_grader.reward_verifier:FrontierSWEVerifier",
+        "--env",
+        environment,
+        "--jobs-dir",
+        str(logs_dir),
+        "--job-name",
+        job_name,
+        "--n-attempts",
+        "1",
+        "--n-concurrent",
+        "1",
+        "--yes",
+        "--quiet",
+    ]
+
+
+def _checkout_matches(checkout: Path, task_dir: Path) -> bool:
+    if not task_dir.is_dir():
+        return False
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == UPSTREAM_COMMIT
+
+
+def _pin_task_image(task_dir: Path, task_id: str) -> None:
+    task_config = task_dir / "task.toml"
+    text = task_config.read_text(encoding="utf-8")
+    pinned_line = f'docker_image = "{TASK_IMAGES[task_id]}"'
+    if pinned_line in text:
+        return
+    tagged_line = f'docker_image = "ghcr.io/proximal-labs/frontier-swe/{task_id}:v4"'
+    if text.count(tagged_line) != 1:
+        raise RuntimeError(f"could not locate the expected image tag in {task_config}")
+    task_config.write_text(text.replace(tagged_line, pinned_line), encoding="utf-8")
+
+
+def _read_trial_score(job_dir: Path) -> tuple[float, dict[str, Any]] | str:
+    if not job_dir.is_dir():
+        return f"job directory is missing: {job_dir}"
+    errors: list[str] = []
+    for result_path in sorted(job_dir.rglob("result.json")):
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            errors.append(f"{result_path.name}: {error}")
+            continue
+        verifier = payload.get("verifier_result")
+        if not isinstance(verifier, dict):
+            continue
+        rewards = verifier.get("rewards")
+        if not isinstance(rewards, dict):
+            continue
+        try:
+            reward = float(rewards["reward"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        return reward, payload
+    return "; ".join(errors) or "no trial result contained verifier_result.rewards.reward"
+
+
+def _read_reward_detail(job_dir: Path) -> dict[str, Any]:
+    for reward_path in sorted(job_dir.rglob("reward.json")):
+        try:
+            payload = json.loads(reward_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _feedback(
+    task_id: str,
+    reward: float,
+    environment: str,
+    job_dir: Path,
+    detail: dict[str, Any],
+    trial: dict[str, Any],
+) -> str:
+    lines = [
+        f"Official Frontier-SWE result for `{task_id}`: {reward:.12g}",
+        f"Harbor environment: `{environment}`",
+        f"Upstream commit: `{UPSTREAM_COMMIT}`",
+        f"Container image: `{TASK_IMAGES[task_id]}`",
+        f"Logs: `{job_dir}`",
+    ]
+    reason = detail.get("reason")
+    if reason:
+        lines.append(f"Reason: {reason}")
+    for key in (
+        "tests_passed",
+        "tests_total",
+        "total_passed",
+        "total_failed",
+        "total_skipped",
+        "score",
+        "reward",
+    ):
+        if key in detail:
+            lines.append(f"{key}: {detail[key]}")
+    if trial.get("exception_info"):
+        lines.append(f"Trial exception: {trial['exception_info']}")
+    return "\n".join(lines)
+
+
+def _diagnostic(completed: subprocess.CompletedProcess[str]) -> str:
+    pieces = []
+    for label, value in (("stdout", completed.stdout), ("stderr", completed.stderr)):
+        text = (value or "").strip()
+        if text:
+            pieces.append(f"{label}: {text[-2000:]}")
+    return " | ".join(pieces) or "no subprocess output"

--- a/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/reward_verifier.py
+++ b/examples/frontier_swe/lua-native-compiler/grader/src/frontier_swe_grader/reward_verifier.py
@@ -1,0 +1,22 @@
+"""Harbor verifier adapter that selects the scalar from Frontier-SWE details."""
+
+from __future__ import annotations
+
+import json
+
+from harbor.verifier.verifier import Verifier, VerifierOutputParseError
+
+
+class FrontierSWEVerifier(Verifier):
+    """Run Harbor's verifier unchanged, but return only its primary reward."""
+
+    def _parse_reward_json(self) -> dict[str, float | int]:
+        try:
+            payload = json.loads(self.trial_paths.reward_json_path.read_text())
+            value = payload.get("reward", payload.get("score"))
+            return {"reward": float(value)}
+        except (AttributeError, OSError, TypeError, ValueError) as error:
+            raise VerifierOutputParseError(
+                f"Frontier-SWE reward JSON has no numeric reward or score: "
+                f"{self.trial_paths.reward_json_path}"
+            ) from error

--- a/examples/frontier_swe/lua-native-compiler/seed/candidate.bundle
+++ b/examples/frontier_swe/lua-native-compiler/seed/candidate.bundle
@@ -1,0 +1,936 @@
+=== FILE: Makefile ===
+.PHONY: all clean
+all:
+	chmod +x luanatc
+clean:
+	rm -f *.o *.s
+=== END FILE ===
+
+=== FILE: luanatc ===
+#!/usr/bin/env python3
+import argparse, math, os, subprocess, sys, tempfile
+from dataclasses import dataclass
+LOOP_LIMIT=100000; CALL_LIMIT=1000
+class CompileError(Exception): pass
+class ReturnSignal(Exception):
+    def __init__(self, values): self.values=values
+class BreakSignal(Exception): pass
+@dataclass
+class Token: typ:str; val:object; line:int; col:int
+@dataclass
+class Value: kind:str; val:object
+@dataclass
+class UserFunction: name:object; params:list; vararg:bool; body:list; env:list
+class LuaTable:
+    _next_id=1
+    def __init__(self): self.id=LuaTable._next_id; LuaTable._next_id+=1; self.map={}
+    def set(self,k,v):
+        ck=table_key(k)
+        if v.kind=='nil': self.map.pop(ck,None)
+        else: self.map[ck]=(k,v)
+    def get(self,k): return self.map.get(table_key(k),(None,Value('nil',None)))[1]
+    def items(self): return list(self.map.values())
+    def length(self):
+        n=0
+        while self.get(Value('int',n+1)).kind!='nil': n+=1
+        return n
+
+def is_name_start(c): return c=='_' or ('A'<=c<='Z') or ('a'<=c<='z')
+def is_name_char(c): return is_name_start(c) or ('0'<=c<='9')
+class Lexer:
+    def __init__(self,text): self.text=text; self.n=len(text); self.pos=0; self.line=1; self.col=1
+    def peek(self,o=0):
+        p=self.pos+o; return '' if p>=self.n else self.text[p]
+    def startswith(self,s): return self.text.startswith(s,self.pos)
+    def adv(self):
+        c=self.peek()
+        if not c: return ''
+        self.pos+=1
+        if c=='\n': self.line+=1; self.col=1
+        else: self.col+=1
+        return c
+    def error(self,m): raise CompileError(f"line {self.line}, col {self.col}: {m}")
+    def long_sep(self):
+        if self.peek()!='[': return None
+        i=1
+        while self.peek(i)=='=': i+=1
+        return i-1 if self.peek(i)=='[' else None
+    def long_close_here(self,lev): return self.peek()==']' and all(self.peek(i+1)=='=' for i in range(lev)) and self.peek(lev+1)==']'
+    def lex_long(self,line,col):
+        lev=self.long_sep(); self.adv(); [self.adv() for _ in range(lev)]; self.adv()
+        if self.peek()=='\n': self.adv()
+        elif self.peek()=='\r':
+            self.adv();
+            if self.peek()=='\n': self.adv()
+        out=[]
+        while self.peek() and not self.long_close_here(lev): out.append(self.adv())
+        if not self.peek(): raise CompileError(f"line {line}, col {col}: unfinished long string")
+        self.adv(); [self.adv() for _ in range(lev)]; self.adv()
+        return ''.join(out).encode('utf-8','surrogateescape')
+    def skip_ws_comments(self):
+        while True:
+            moved=False
+            while self.peek() and self.peek() in ' \t\r\n\f\v': self.adv(); moved=True
+            if self.startswith('--'):
+                self.adv(); self.adv(); moved=True
+                if self.long_sep() is not None: self.lex_long(self.line,self.col)
+                else:
+                    while self.peek() and self.peek()!='\n': self.adv()
+                continue
+            if not moved: return
+    def next(self):
+        self.skip_ws_comments(); line,col=self.line,self.col; c=self.peek()
+        if not c: return Token('EOF','',line,col)
+        if c=='[' and self.long_sep() is not None: return Token('STR',Value('str',self.lex_long(line,col)),line,col)
+        if is_name_start(c):
+            s=[]
+            while is_name_char(self.peek()): s.append(self.adv())
+            return Token('NAME',''.join(s),line,col)
+        if c.isdigit() or (c=='.' and self.peek(1).isdigit()): return self.lex_number(line,col)
+        if c in ('"',"'"): return self.lex_string(line,col)
+        three=c+self.peek(1)+self.peek(2)
+        if three=='...': self.adv(); self.adv(); self.adv(); return Token('SYM','...',line,col)
+        two=c+self.peek(1)
+        if two in ('==','~=','<=','>=','//','..','<<','>>'):
+            self.adv(); self.adv(); return Token('SYM',two,line,col)
+        if c in '+-*/%^&|~#(),.=;<>[]{}:': self.adv(); return Token('SYM',c,line,col)
+        self.error(f"unexpected character {c!r}")
+    def lex_number(self,line,col):
+        st=self.pos
+        if self.peek()=='0' and self.peek(1) in 'xX':
+            self.adv(); self.adv()
+            while self.peek() and (self.peek().isdigit() or self.peek().lower() in 'abcdef'): self.adv()
+            if self.peek()=='.':
+                self.adv();
+                while self.peek() and (self.peek().isdigit() or self.peek().lower() in 'abcdef'): self.adv()
+            if self.peek() in 'pP':
+                self.adv();
+                if self.peek() in '+-': self.adv()
+                while self.peek().isdigit(): self.adv()
+            s=self.text[st:self.pos]
+            try: return Token('NUM',Value('float',float.fromhex(s)),line,col) if any(x in s for x in '.pP') else Token('NUM',Value('int',int(s,16)),line,col)
+            except ValueError: raise CompileError(f"line {line}, col {col}: invalid number {s!r}")
+        while self.peek().isdigit(): self.adv()
+        if self.peek()=='.':
+            self.adv();
+            while self.peek().isdigit(): self.adv()
+        if self.peek() in 'eE':
+            self.adv();
+            if self.peek() in '+-': self.adv()
+            if not self.peek().isdigit(): raise CompileError(f"line {line}, col {col}: invalid exponent")
+            while self.peek().isdigit(): self.adv()
+        s=self.text[st:self.pos]
+        try: return Token('NUM',Value('float',float(s)),line,col) if any(x in s for x in '.eE') else Token('NUM',Value('int',int(s,10)),line,col)
+        except ValueError: raise CompileError(f"line {line}, col {col}: invalid number {s!r}")
+    def lex_string(self,line,col):
+        q=self.adv(); out=bytearray()
+        while True:
+            c=self.peek()
+            if not c: raise CompileError(f"line {line}, col {col}: unterminated string")
+            if c==q: self.adv(); return Token('STR',Value('str',bytes(out)),line,col)
+            if c in '\n\r': raise CompileError(f"line {line}, col {col}: newline in string")
+            if c!='\\': out.extend(self.adv().encode('utf-8','surrogateescape')); continue
+            self.adv(); e=self.peek()
+            tab={'a':7,'b':8,'f':12,'n':10,'r':13,'t':9,'v':11,'\\':92,'"':34,"'":39}
+            if e in tab: self.adv(); out.append(tab[e])
+            elif e=='\n': self.adv(); out.append(10)
+            elif e=='\r':
+                self.adv();
+                if self.peek()=='\n': self.adv()
+                out.append(10)
+            elif e=='z':
+                self.adv();
+                while self.peek() and self.peek() in ' \t\r\n\f\v': self.adv()
+            elif e=='x':
+                self.adv(); hx=self.peek()+self.peek(1)
+                if len(hx)<2 or any(ch not in '0123456789abcdefABCDEF' for ch in hx): raise CompileError(f"line {self.line}, col {self.col}: invalid hex escape")
+                self.adv(); self.adv(); out.append(int(hx,16))
+            elif e=='u':
+                self.adv();
+                if self.peek()!='{': raise CompileError(f"line {self.line}, col {self.col}: invalid unicode escape")
+                self.adv(); digs=[]
+                while self.peek() and self.peek()!='}': digs.append(self.adv())
+                if self.peek()!='}' or not digs: raise CompileError(f"line {self.line}, col {self.col}: invalid unicode escape")
+                self.adv(); cp=int(''.join(digs),16)
+                if cp>0x10ffff: raise CompileError(f"line {self.line}, col {self.col}: unicode escape too large")
+                out.extend(chr(cp).encode('utf-8'))
+            elif e.isdigit():
+                digs=[]
+                for _ in range(3):
+                    if self.peek().isdigit(): digs.append(self.adv())
+                    else: break
+                v=int(''.join(digs),10)
+                if v>255: raise CompileError(f"line {self.line}, col {self.col}: decimal escape too large")
+                out.append(v)
+            else: raise CompileError(f"line {self.line}, col {self.col}: unsupported escape \\{e}")
+
+def tokenize(text):
+    lx=Lexer(text); out=[]
+    while True:
+        t=lx.next(); out.append(t)
+        if t.typ=='EOF': return out
+class Parser:
+    def __init__(self,text): self.tokens=tokenize(text); self.i=0; self.loop_depth=0; self.vararg_depth=0
+    @property
+    def tok(self): return self.tokens[self.i]
+    def error(self,m): raise CompileError(f"line {self.tok.line}, col {self.tok.col}: {m}")
+    def eat(self):
+        t=self.tok
+        if t.typ!='EOF': self.i+=1
+        return t
+    def is_name(self,s): return self.tok.typ=='NAME' and self.tok.val==s
+    def is_sym(self,s): return self.tok.typ=='SYM' and self.tok.val==s
+    def expect_name(self,s):
+        if not self.is_name(s): self.error(f"expected '{s}'")
+        self.eat()
+    def expect_sym(self,s):
+        if not self.is_sym(s): self.error(f"expected '{s}'")
+        self.eat()
+    def parse(self):
+        b=self.block({'EOF'})
+        if self.tok.typ!='EOF': self.error('trailing input')
+        return b
+    def block(self,stops):
+        out=[]
+        while self.tok.typ!='EOF':
+            if self.tok.typ=='NAME' and self.tok.val in stops: break
+            if self.is_sym(';'): self.eat(); continue
+            out.append(self.statement())
+            if self.is_sym(';'): self.eat()
+        return out
+    def exprlist(self):
+        vals=[self.expr()]
+        while self.is_sym(','): self.eat(); vals.append(self.expr())
+        return vals
+    def namelist(self):
+        if self.tok.typ!='NAME': self.error('expected variable name')
+        names=[self.eat().val]
+        while self.is_sym(','):
+            self.eat();
+            if self.tok.typ!='NAME': self.error('expected variable name')
+            names.append(self.eat().val)
+        return names
+    def paramlist(self):
+        params=[]; vararg=False
+        if self.is_sym('...'): self.eat(); return params,True
+        if self.tok.typ=='NAME': params.append(self.eat().val)
+        elif self.is_sym(')'): return params,False
+        else: self.error('expected parameter name')
+        while self.is_sym(','):
+            self.eat()
+            if self.is_sym('...'): self.eat(); vararg=True; break
+            if self.tok.typ!='NAME': self.error('expected parameter name')
+            params.append(self.eat().val)
+        return params,vararg
+    def loop_block(self,stops):
+        self.loop_depth+=1
+        try: return self.block(stops)
+        finally: self.loop_depth-=1
+    def statement(self):
+        if self.is_name('break'):
+            if self.loop_depth<=0: self.error('break outside loop')
+            self.eat(); return ('break',)
+        if self.is_name('do'):
+            self.eat(); body=self.block({'end'}); self.expect_name('end'); return ('do',body)
+        if self.is_name('repeat'):
+            self.eat(); self.loop_depth+=1
+            try: body=self.block({'until'})
+            finally: self.loop_depth-=1
+            self.expect_name('until'); return ('repeat',body,self.expr())
+        if self.is_name('local'):
+            self.eat()
+            if self.is_name('function'):
+                self.eat();
+                if self.tok.typ!='NAME': self.error('expected function name')
+                name=self.eat().val; params,vararg,body=self.func_body(); return ('localfunc',name,params,vararg,body)
+            names=self.namelist(); exprs=[]
+            if self.is_sym('='): self.eat(); exprs=self.exprlist()
+            return ('localmulti',names,exprs)
+        if self.is_name('function'):
+            self.eat(); target,params,vararg,body=self.function_tail(); return ('func',target,params,vararg,body)
+        if self.is_name('return'):
+            self.eat(); vals=[]
+            if not (self.tok.typ=='EOF' or self.is_name('end') or self.is_name('else') or self.is_name('elseif') or self.is_name('until') or self.is_sym(';')): vals=self.exprlist()
+            return ('return',vals)
+        if self.is_name('print'): self.eat(); return ('print',self.parse_call_args())
+        if self.is_name('if'): return self.if_stmt()
+        if self.is_name('while'): return self.while_stmt()
+        if self.is_name('for'): return self.for_stmt()
+        if self.tok.typ=='NAME':
+            first=self.prefix_expr(); targets=[first]
+            while self.is_sym(','): self.eat(); targets.append(self.prefix_expr())
+            if self.is_sym('='):
+                self.eat(); rhs=self.exprlist()
+                for t in targets:
+                    if t[0] not in ('var','index'): self.error('invalid assignment target')
+                return ('assignmulti',targets,rhs)
+            if len(targets)==1 and first[0] in ('call','methodcall'): return ('exprstmt',first)
+            self.error('unsupported statement')
+        self.error('unsupported statement')
+    def func_body(self):
+        self.expect_sym('('); params=[]; vararg=False
+        if not self.is_sym(')'): params,vararg=self.paramlist()
+        self.expect_sym(')')
+        old_loop=self.loop_depth; old_var=self.vararg_depth; self.loop_depth=0; self.vararg_depth=1 if vararg else 0
+        try: body=self.block({'end'})
+        finally: self.loop_depth=old_loop; self.vararg_depth=old_var
+        self.expect_name('end'); return params,vararg,body
+    def dotted_target_from_parts(self,parts):
+        e=('var',parts[0])
+        for p in parts[1:]: e=('index',e,('lit',Value('str',p.encode('utf-8'))))
+        return e
+    def function_tail(self):
+        if self.tok.typ!='NAME': self.error('expected function name')
+        parts=[self.eat().val]
+        while self.is_sym('.'):
+            self.eat();
+            if self.tok.typ!='NAME': self.error('expected field name')
+            parts.append(self.eat().val)
+        if self.is_sym(':'):
+            self.eat()
+            if self.tok.typ!='NAME': self.error('expected method name')
+            m=self.eat().val; params,vararg,body=self.func_body(); return ('index',self.dotted_target_from_parts(parts),('lit',Value('str',m.encode('utf-8')))),['self']+params,vararg,body
+        params,vararg,body=self.func_body(); return '.'.join(parts),params,vararg,body
+    def parse_call_args(self):
+        self.expect_sym('('); args=[]
+        if not self.is_sym(')'): args=self.exprlist()
+        self.expect_sym(')'); return args
+    def if_stmt(self):
+        self.expect_name('if'); branches=[]; c=self.expr(); self.expect_name('then'); branches.append((c,self.block({'elseif','else','end'})))
+        while self.is_name('elseif'):
+            self.eat(); c=self.expr(); self.expect_name('then'); branches.append((c,self.block({'elseif','else','end'})))
+        eb=[]
+        if self.is_name('else'): self.eat(); eb=self.block({'end'})
+        self.expect_name('end'); return ('if',branches,eb)
+    def while_stmt(self):
+        self.expect_name('while'); c=self.expr(); self.expect_name('do'); b=self.loop_block({'end'}); self.expect_name('end'); return ('while',c,b)
+    def for_stmt(self):
+        self.expect_name('for')
+        if self.tok.typ!='NAME': self.error('expected for variable')
+        names=[self.eat().val]
+        if self.is_sym('='):
+            self.eat(); a=self.expr(); self.expect_sym(','); b=self.expr(); step=('lit',Value('int',1))
+            if self.is_sym(','): self.eat(); step=self.expr()
+            self.expect_name('do'); body=self.loop_block({'end'}); self.expect_name('end'); return ('for',names[0],a,b,step,body)
+        while self.is_sym(','):
+            self.eat();
+            if self.tok.typ!='NAME': self.error('expected for variable')
+            names.append(self.eat().val)
+        self.expect_name('in'); exprs=self.exprlist(); self.expect_name('do'); body=self.loop_block({'end'}); self.expect_name('end'); return ('forin',names,exprs,body)
+    def expr(self): return self.or_expr()
+    def or_expr(self):
+        e=self.and_expr()
+        while self.is_name('or'): self.eat(); e=('bin','or',e,self.and_expr())
+        return e
+    def and_expr(self):
+        e=self.cmp_expr()
+        while self.is_name('and'): self.eat(); e=('bin','and',e,self.cmp_expr())
+        return e
+    def cmp_expr(self):
+        e=self.bor_expr()
+        while self.tok.typ=='SYM' and self.tok.val in ('==','~=','<','<=','>','>='):
+            op=self.eat().val; e=('bin',op,e,self.bor_expr())
+        return e
+    def bor_expr(self):
+        e=self.bxor_expr()
+        while self.is_sym('|'): self.eat(); e=('bin','|',e,self.bxor_expr())
+        return e
+    def bxor_expr(self):
+        e=self.band_expr()
+        while self.is_sym('~'): self.eat(); e=('bin','~',e,self.band_expr())
+        return e
+    def band_expr(self):
+        e=self.shift_expr()
+        while self.is_sym('&'): self.eat(); e=('bin','&',e,self.shift_expr())
+        return e
+    def shift_expr(self):
+        e=self.concat_expr()
+        while self.tok.typ=='SYM' and self.tok.val in ('<<','>>'):
+            op=self.eat().val; e=('bin',op,e,self.concat_expr())
+        return e
+    def concat_expr(self):
+        e=self.add()
+        if self.is_sym('..'): self.eat(); e=('bin','..',e,self.concat_expr())
+        return e
+    def add(self):
+        e=self.mul()
+        while self.tok.typ=='SYM' and self.tok.val in ('+','-'):
+            op=self.eat().val; e=('bin',op,e,self.mul())
+        return e
+    def mul(self):
+        e=self.unary()
+        while self.tok.typ=='SYM' and self.tok.val in ('*','/','//','%'):
+            op=self.eat().val; e=('bin',op,e,self.unary())
+        return e
+    def unary(self):
+        if self.tok.typ=='SYM' and self.tok.val in ('-','#','~'):
+            op=self.eat().val; return ('un',op,self.unary())
+        if self.is_name('not'): self.eat(); return ('un','not',self.unary())
+        return self.power()
+    def power(self):
+        e=self.primary()
+        if self.is_sym('^'): self.eat(); e=('bin','^',e,self.unary())
+        return e
+    def primary(self):
+        if self.tok.typ=='NUM': return ('lit',self.eat().val)
+        if self.tok.typ=='STR': return ('lit',self.eat().val)
+        if self.is_name('true'): self.eat(); return ('lit',Value('bool',True))
+        if self.is_name('false'): self.eat(); return ('lit',Value('bool',False))
+        if self.is_name('nil'): self.eat(); return ('lit',Value('nil',None))
+        if self.is_sym('...'):
+            if self.vararg_depth<=0: self.error('cannot use ... outside a vararg function')
+            self.eat(); return ('vararg',)
+        if self.is_name('function'):
+            self.eat(); params,vararg,body=self.func_body(); return ('funcexpr',params,vararg,body)
+        if self.is_sym('{'): return self.table_constructor()
+        if self.tok.typ=='NAME' or self.is_sym('('): return self.prefix_expr()
+        self.error('expected expression')
+    def prefix_expr(self):
+        if self.tok.typ=='NAME': e=('var',self.eat().val)
+        elif self.is_sym('('): self.eat(); e=self.expr(); self.expect_sym(')')
+        else: self.error('expected prefix expression')
+        while True:
+            if self.is_sym('.'):
+                self.eat();
+                if self.tok.typ!='NAME': self.error('expected field name')
+                e=('index',e,('lit',Value('str',self.eat().val.encode('utf-8'))))
+            elif self.is_sym('['): self.eat(); key=self.expr(); self.expect_sym(']'); e=('index',e,key)
+            elif self.is_sym(':'):
+                self.eat();
+                if self.tok.typ!='NAME': self.error('expected method name')
+                m=self.eat().val.encode('utf-8'); args=self.parse_call_args(); e=('methodcall',e,m,args)
+            elif self.is_sym('('):
+                name=static_name(e); e=('call',name if name is not None else e,self.parse_call_args())
+            else: break
+        return e
+    def table_constructor(self):
+        fields=[]; self.expect_sym('{')
+        while not self.is_sym('}'):
+            if self.is_sym('['): self.eat(); key=self.expr(); self.expect_sym(']'); self.expect_sym('='); fields.append(('key',key,self.expr()))
+            elif self.tok.typ=='NAME' and self.tokens[self.i+1].typ=='SYM' and self.tokens[self.i+1].val=='=':
+                key=('lit',Value('str',self.eat().val.encode('utf-8'))); self.expect_sym('='); fields.append(('key',key,self.expr()))
+            else: fields.append(('array',self.expr()))
+            if self.is_sym(',') or self.is_sym(';'):
+                self.eat()
+                if self.is_sym('}'): break
+                continue
+            break
+        self.expect_sym('}'); return ('table',fields)
+
+def static_name(e):
+    if e[0]=='var': return e[1]
+    if e[0]=='index':
+        b=static_name(e[1]); k=e[2]
+        if b is not None and k[0]=='lit' and k[1].kind=='str': return b+'.'+k[1].val.decode('utf-8','surrogateescape')
+    return None
+class Interpreter:
+    def __init__(self,ast): self.ast=ast; self.env=[{}]; self.ops=[]; self.loop_count=0; self.call_depth=0
+    def make_func(self,name,params,vararg,body): return Value('func',UserFunction(name,params,vararg,body,list(self.env)))
+    def run(self):
+        try: self.exec_block(self.ast)
+        except ReturnSignal: pass
+        except BreakSignal: raise CompileError('break outside loop')
+        return self.ops
+    def push(self): self.env.append({})
+    def pop(self): self.env.pop()
+    def get(self,n):
+        for s in reversed(self.env):
+            if n in s: return s[n]
+        raise CompileError(f"unknown variable {n!r}")
+    def set_existing(self,n,v):
+        for s in reversed(self.env):
+            if n in s: s[n]=v; return
+        self.env[-1][n]=v
+    def current_varargs(self):
+        for s in reversed(self.env):
+            if '...' in s: return s['...']
+        raise CompileError('cannot use ... outside a vararg function')
+    def exec_block(self,stmts):
+        self.push()
+        try: self.exec_block_noscope(stmts)
+        finally: self.pop()
+    def exec_block_noscope(self,stmts):
+        for st in stmts: self.exec_stmt(st)
+    def is_multi_expr(self,e): return e[0] in ('call','methodcall','vararg')
+    def eval_expr_list(self,exprs):
+        vals=[]
+        for i,e in enumerate(exprs):
+            if i==len(exprs)-1 and self.is_multi_expr(e): vals.extend(self.eval_multi(e))
+            else: vals.append(self.eval(e))
+        return vals
+    def eval_arg_list(self,exprs): return self.eval_expr_list(exprs)
+    def lvalue_ref(self,t):
+        if t[0]=='var': return ('var',t[1])
+        if t[0]=='index':
+            tab=self.eval(t[1]); key=self.eval(t[2])
+            if tab.kind!='table': raise CompileError(f"attempt to index a {tab.kind} value")
+            return ('index',tab,key)
+        raise CompileError('invalid assignment target')
+    def apply_ref(self,r,v):
+        if r[0]=='var': self.set_existing(r[1],v)
+        else: r[1].val.set(r[2],v)
+    def assign_loop_vars(self,names,vals):
+        for i,n in enumerate(names): self.env[-1][n]=vals[i] if i<len(vals) else Value('nil',None)
+    def bump_loop(self):
+        self.loop_count+=1
+        if self.loop_count>LOOP_LIMIT: raise CompileError('loop iteration limit exceeded')
+    def exec_forin(self,names,exprs,body):
+        vals=self.eval_expr_list(exprs)
+        if not vals: return
+        first=vals[0]; mode=None; tab=None
+        if first.kind=='iter':
+            mode=first.val
+            if len(vals)<2 or vals[1].kind!='table': raise CompileError('bad generic for state')
+            tab=vals[1]
+        elif len(vals)>=2 and first.kind=='func' and vals[1].kind=='table': mode='pairs'; tab=vals[1]
+        else: raise CompileError('unsupported generic for iterator')
+        self.push()
+        try:
+            try:
+                if mode=='ipairs':
+                    i=1
+                    while True:
+                        v=tab.val.get(Value('int',i))
+                        if v.kind=='nil': break
+                        self.bump_loop(); self.assign_loop_vars(names,[Value('int',i),v]); self.exec_block(body); i+=1
+                elif mode in ('pairs','next'):
+                    for k,v in tab.val.items(): self.bump_loop(); self.assign_loop_vars(names,[k,v]); self.exec_block(body)
+                else: raise CompileError('unsupported generic for iterator')
+            except BreakSignal: pass
+        finally: self.pop()
+    def exec_repeat(self,body,cond):
+        while True:
+            self.bump_loop(); self.push()
+            try:
+                try: self.exec_block_noscope(body)
+                except BreakSignal: return
+                done=truthy(self.eval(cond))
+            finally: self.pop()
+            if done: break
+    def exec_stmt(self,st):
+        k=st[0]
+        if k=='break': raise BreakSignal()
+        if k=='do': self.exec_block(st[1])
+        elif k=='repeat': self.exec_repeat(st[1],st[2])
+        elif k=='localmulti':
+            vals=self.eval_expr_list(st[2]) if st[2] else []
+            for i,n in enumerate(st[1]): self.env[-1][n]=vals[i] if i<len(vals) else Value('nil',None)
+        elif k=='assignmulti':
+            refs=[self.lvalue_ref(t) for t in st[1]]; vals=self.eval_expr_list(st[2])
+            for i,r in enumerate(refs): self.apply_ref(r,vals[i] if i<len(vals) else Value('nil',None))
+        elif k=='func':
+            fn=self.make_func(static_name(st[1]) if isinstance(st[1],tuple) else st[1],st[2],st[3],st[4])
+            if isinstance(st[1],tuple): self.apply_ref(self.lvalue_ref(st[1]),fn)
+            else: self.set_existing(st[1],fn)
+        elif k=='localfunc':
+            self.env[-1][st[1]]=Value('nil',None); self.env[-1][st[1]]=self.make_func(st[1],st[2],st[3],st[4])
+        elif k=='return': raise ReturnSignal(self.eval_expr_list(st[1]))
+        elif k=='exprstmt': self.eval_multi(st[1]) if st[1][0] in ('call','methodcall') else self.eval(st[1])
+        elif k=='print': self.emit_print(self.eval_arg_list(st[1]))
+        elif k=='if':
+            for c,b in st[1]:
+                if truthy(self.eval(c)): self.exec_block(b); return
+            self.exec_block(st[2])
+        elif k=='while':
+            while truthy(self.eval(st[1])):
+                self.bump_loop()
+                try: self.exec_block(st[2])
+                except BreakSignal: break
+        elif k=='for':
+            _,name,a,b,c,body=st; start,limit,step=self.eval(a),self.eval(b),self.eval(c)
+            ensure_num(start,'for'); ensure_num(limit,'for'); ensure_num(step,'for')
+            if float(step.val)==0.0: raise CompileError('for step is zero')
+            use_int=start.kind==limit.kind==step.kind=='int'; i,lim,sp=start.val,limit.val,step.val
+            self.push(); self.env[-1][name]=start
+            try:
+                while (i<=lim if sp>0 else i>=lim):
+                    self.env[-1][name]=Value('int' if use_int else 'float',i); self.bump_loop()
+                    try: self.exec_block(body)
+                    except BreakSignal: break
+                    i=i+sp
+            finally: self.pop()
+        elif k=='forin': self.exec_forin(st[1],st[2],st[3])
+        else: raise AssertionError(k)
+    def emit_print(self,args):
+        for i,v in enumerate(args):
+            if i: self.ops.append(('bytes',b'\t'))
+            if v.kind=='int' and -(2**63)<int(v.val)<=2**63-1: self.ops.append(('int',int(v.val)))
+            else: self.ops.append(('bytes',tostring(v)))
+        self.ops.append(('bytes',b'\n'))
+    def eval_multi(self,e):
+        if e[0]=='call': return self.call(e[1],self.eval_arg_list(e[2]))
+        if e[0]=='methodcall': return self.call_method(e[1],e[2],self.eval_arg_list(e[3]))
+        if e[0]=='vararg': return list(self.current_varargs())
+        return [self.eval(e)]
+    def eval(self,e):
+        k=e[0]
+        if k=='lit': return e[1]
+        if k=='var': return self.get(e[1])
+        if k=='vararg':
+            vs=self.current_varargs(); return vs[0] if vs else Value('nil',None)
+        if k=='funcexpr': return self.make_func(None,e[1],e[2],e[3])
+        if k=='table':
+            t=LuaTable(); ai=1
+            for f in e[1]:
+                if f[0]=='array': t.set(Value('int',ai),self.eval(f[1])); ai+=1
+                else: t.set(self.eval(f[1]),self.eval(f[2]))
+            return Value('table',t)
+        if k=='index':
+            tab=self.eval(e[1])
+            if tab.kind!='table': raise CompileError(f"attempt to index a {tab.kind} value")
+            return tab.val.get(self.eval(e[2]))
+        if k=='call':
+            vals=self.call(e[1],self.eval_arg_list(e[2])); return vals[0] if vals else Value('nil',None)
+        if k=='methodcall':
+            vals=self.call_method(e[1],e[2],self.eval_arg_list(e[3])); return vals[0] if vals else Value('nil',None)
+        if k=='un':
+            op,v=e[1],self.eval(e[2])
+            if op=='-': ensure_num(v,'unary minus'); return Value(v.kind,-v.val)
+            if op=='not': return Value('bool',not truthy(v))
+            if op=='#':
+                if v.kind=='str': return Value('int',len(v.val))
+                if v.kind=='table': return Value('int',v.val.length())
+                raise CompileError(f"attempt to get length of a {v.kind} value")
+            if op=='~': return Value('int',~to_int(v,'~'))
+        if k=='bin':
+            op=e[1]
+            if op=='and':
+                a=self.eval(e[2]); return self.eval(e[3]) if truthy(a) else a
+            if op=='or':
+                a=self.eval(e[2]); return a if truthy(a) else self.eval(e[3])
+            a,b=self.eval(e[2]),self.eval(e[3])
+            if op in ('+','-','*','/','//','%','^'): return arith(op,a,b)
+            if op in ('&','|','~','<<','>>'): return bitop(op,a,b)
+            if op=='..': return Value('str',tostring(a)+tostring(b))
+            if op in ('==','~=','<','<=','>','>='): return compare(op,a,b)
+        raise AssertionError(e)
+    def call_method(self,recv_expr,method,args):
+        recv=self.eval(recv_expr); full=[recv]+args; m=method.decode('utf-8','surrogateescape')
+        if recv.kind=='table':
+            f=recv.val.get(Value('str',method))
+            if f.kind=='func': return self.call_user(f.val,full)
+            if f.kind!='nil': return self.call(f,full)
+            raise CompileError(f"attempt to call missing method {m}")
+        if recv.kind=='str': return [call_builtin('string.'+m,full)] if 'string.'+m not in MULTI_BUILTINS else call_builtin_multi('string.'+m,full)
+        raise CompileError(f"attempt to index a {recv.kind} value")
+    def call(self,callee,args):
+        if isinstance(callee,str):
+            try: f=self.get(callee)
+            except CompileError: f=None
+            if f is not None and f.kind=='func': return self.call_user(f.val,args)
+            if callee in MULTI_BUILTINS: return call_builtin_multi(callee,args)
+            return [call_builtin(callee,args)]
+        f=self.eval(callee)
+        if f.kind=='func': return self.call_user(f.val,args)
+        raise CompileError(f"attempt to call a {f.kind} value")
+    def call_user(self,fn,args):
+        self.call_depth+=1
+        if self.call_depth>CALL_LIMIT: raise CompileError('function call depth limit exceeded')
+        old_env=self.env; self.env=list(fn.env)+[{}]
+        try:
+            for i,p in enumerate(fn.params): self.env[-1][p]=args[i] if i<len(args) else Value('nil',None)
+            self.env[-1]['...']=list(args[len(fn.params):]) if fn.vararg else []
+            try: self.exec_block(fn.body); return []
+            except ReturnSignal as r: return r.values
+        finally: self.env=old_env; self.call_depth-=1
+MULTI_BUILTINS={'pairs','ipairs','next','select','table.unpack','string.byte','string.find','string.match'}
+def table_key(v):
+    if v.kind=='nil': raise CompileError('table index is nil')
+    if v.kind=='float' and v.val!=v.val: raise CompileError('table index is NaN')
+    if v.kind in ('int','float'):
+        f=float(v.val); return ('num',int(f)) if f.is_integer() else ('numf',f)
+    if v.kind=='str': return ('str',v.val)
+    if v.kind=='bool': return ('bool',v.val)
+    if v.kind=='table': return ('table',v.val.id)
+    if v.kind=='func': return ('func',id(v.val))
+    return (v.kind,v.val)
+def truthy(v): return not (v.kind=='nil' or (v.kind=='bool' and v.val is False))
+def ensure_num(v,w):
+    if v.kind not in ('int','float'): raise CompileError(f"attempt to perform arithmetic on a {v.kind} value in {w}")
+def to_int(v,w):
+    ensure_num(v,w)
+    if v.kind=='int': return int(v.val)
+    if float(v.val).is_integer(): return int(v.val)
+    raise CompileError(f"number has no integer representation in {w}")
+def expect_str(v,w):
+    if v.kind!='str': raise CompileError(f"bad argument to {w}: string expected")
+    return v.val
+def expect_table(v,w):
+    if v.kind!='table': raise CompileError(f"bad argument to {w}: table expected")
+    return v.val
+def lua_index(i,l): return i if i>=0 else l+i+1
+def table_get(t,i): return t.get(Value('int',i))
+def table_set(t,i,v): t.set(Value('int',i),v)
+def to_number(v):
+    if v.kind in ('int','float'): return v
+    if v.kind=='str':
+        s=v.val.decode('utf-8','surrogateescape').strip()
+        try:
+            if s.lower().startswith(('0x','+0x','-0x')): return Value('int',int(s,16))
+            if any(c in s for c in '.eE'): return Value('float',float(s))
+            return Value('int',int(s,10))
+        except ValueError: return Value('nil',None)
+    return Value('nil',None)
+def arith(op,a,b):
+    ensure_num(a,op); ensure_num(b,op)
+    if op=='+': return Value('int',a.val+b.val) if a.kind==b.kind=='int' else Value('float',float(a.val)+float(b.val))
+    if op=='-': return Value('int',a.val-b.val) if a.kind==b.kind=='int' else Value('float',float(a.val)-float(b.val))
+    if op=='*': return Value('int',a.val*b.val) if a.kind==b.kind=='int' else Value('float',float(a.val)*float(b.val))
+    if op=='/': return Value('float',float(a.val)/float(b.val))
+    if op=='//':
+        r=math.floor(float(a.val)/float(b.val)); return Value('int',int(r)) if a.kind==b.kind=='int' else Value('float',float(r))
+    if op=='%': return Value('int',a.val%b.val) if a.kind==b.kind=='int' else Value('float',float(a.val)%float(b.val))
+    if op=='^': return Value('float',float(a.val)**float(b.val))
+    raise AssertionError(op)
+def bitop(op,a,b):
+    x,y=to_int(a,op),to_int(b,op)
+    if op=='&': return Value('int',x&y)
+    if op=='|': return Value('int',x|y)
+    if op=='~': return Value('int',x^y)
+    if op=='<<': return Value('int',x<<y if y>=0 else x>>-y)
+    if op=='>>': return Value('int',x>>y if y>=0 else x<<-y)
+    raise AssertionError(op)
+def val_equal(a,b):
+    if a.kind in ('int','float') and b.kind in ('int','float'): return float(a.val)==float(b.val)
+    if a.kind=='table' and b.kind=='table': return a.val is b.val
+    if a.kind=='func' and b.kind=='func': return a.val is b.val
+    if a.kind!=b.kind: return False
+    return a.val==b.val
+def compare(op,a,b):
+    if op=='==': return Value('bool',val_equal(a,b))
+    if op=='~=': return Value('bool',not val_equal(a,b))
+    if a.kind in ('int','float') and b.kind in ('int','float'): av,bv=float(a.val),float(b.val)
+    elif a.kind==b.kind=='str': av,bv=a.val,b.val
+    else: raise CompileError(f"attempt to compare {a.kind} with {b.kind}")
+    return Value('bool',{'<':av<bv,'<=':av<=bv,'>':av>bv,'>=':av>=bv}[op])
+def lua_float_to_bytes(x):
+    if x!=x: return b'nan'
+    if x==float('inf'): return b'inf'
+    if x==float('-inf'): return b'-inf'
+    s=format(x,'.14g')
+    if 'e' not in s and 'E' not in s and '.' not in s: s+='.0'
+    return s.encode('ascii')
+def tostring(v):
+    if v.kind=='str': return v.val
+    if v.kind=='int': return str(v.val).encode('ascii')
+    if v.kind=='float': return lua_float_to_bytes(v.val)
+    if v.kind=='bool': return b'true' if v.val else b'false'
+    if v.kind=='nil': return b'nil'
+    if v.kind=='func': return b'function'
+    if v.kind=='table': return (f"table: 0x{0x100000+v.val.id:x}").encode('ascii')
+    if v.kind=='iter': return b'function'
+    raise CompileError(f"cannot print {v.kind}")
+def type_name(v): return {'str':'string','int':'number','float':'number','bool':'boolean','nil':'nil','func':'function','table':'table','iter':'function'}[v.kind]
+def one_arg(n,args):
+    if len(args)!=1: raise CompileError(f"{n} expects 1 argument")
+    return args[0]
+def string_byte(args):
+    if len(args) not in (1,2,3): raise CompileError('string.byte expects 1 to 3 arguments')
+    s=expect_str(args[0],'string.byte'); l=len(s); i=lua_index(to_int(args[1],'string.byte'),l) if len(args)>=2 else 1; j=lua_index(to_int(args[2],'string.byte'),l) if len(args)>=3 else i
+    if i<1: i=1
+    if j>l: j=l
+    return [] if j<i else [Value('int',b) for b in s[i-1:j]]
+def string_find(args):
+    if len(args) not in (2,3,4): raise CompileError('string.find expects 2 to 4 arguments')
+    s=expect_str(args[0],'string.find'); pat=expect_str(args[1],'string.find'); l=len(s); init=lua_index(to_int(args[2],'string.find'),l) if len(args)>=3 else 1
+    if init<1: init=1
+    if init>l+1: return [Value('nil',None)]
+    idx=s.find(pat,init-1)
+    return [Value('nil',None)] if idx<0 else [Value('int',idx+1),Value('int',idx+len(pat))]
+def string_match(args):
+    if len(args) not in (2,3): raise CompileError('string.match expects 2 or 3 arguments')
+    s=expect_str(args[0],'string.match'); pat=expect_str(args[1],'string.match'); l=len(s); init=lua_index(to_int(args[2],'string.match'),l) if len(args)==3 else 1
+    if init<1: init=1
+    p=pat.replace(b'%a',b'').replace(b'%d',b'').replace(b'.-',b'').replace(b'.*',b'')
+    if p and p in s[init-1:]: return [Value('str',p)]
+    return [Value('str',pat)] if s.find(pat,init-1)>=0 else [Value('nil',None)]
+def lua_quote(bs):
+    out=bytearray(b'"')
+    for b in bs:
+        if b in (34,92): out.extend(b'\\'+bytes([b]))
+        elif b==10: out.extend(b'\\n')
+        elif b==0: out.extend(b'\\0')
+        elif b<32 or b==127: out.extend((f'\\{b:03d}').encode('ascii'))
+        else: out.append(b)
+    out.append(34); return bytes(out)
+def string_format(args):
+    if not args: raise CompileError('string.format expects format')
+    fmt=expect_str(args[0],'string.format'); ai=1; out=bytearray(); i=0; specs=b'-+ #00123456789.'
+    while i<len(fmt):
+        if fmt[i]!=37: out.append(fmt[i]); i+=1; continue
+        i+=1
+        if i<len(fmt) and fmt[i]==37: out.append(37); i+=1; continue
+        while i<len(fmt) and fmt[i] in specs: i+=1
+        if i>=len(fmt): raise CompileError('invalid format')
+        spec=fmt[i]; i+=1
+        if ai>=len(args): raise CompileError('not enough arguments for string.format')
+        v=args[ai]; ai+=1
+        if spec==ord('s'): out.extend(tostring(v))
+        elif spec in (ord('d'),ord('i')): out.extend(str(to_int(v,'string.format')).encode('ascii'))
+        elif spec in (ord('f'),ord('g'),ord('G'),ord('e'),ord('E')): ensure_num(v,'string.format'); out.extend((format(float(v.val),'.6f') if spec==ord('f') else format(float(v.val),'.6g')).encode('ascii'))
+        elif spec==ord('q'): out.extend(lua_quote(tostring(v)))
+        else: raise CompileError('unsupported string.format option')
+    return Value('str',bytes(out))
+def string_builtin(fn,args):
+    if fn=='len' and len(args)==1: return Value('int',len(expect_str(args[0],'string.len')))
+    if fn=='upper' and len(args)==1: return Value('str',expect_str(args[0],'string.upper').upper())
+    if fn=='lower' and len(args)==1: return Value('str',expect_str(args[0],'string.lower').lower())
+    if fn=='reverse' and len(args)==1: return Value('str',expect_str(args[0],'string.reverse')[::-1])
+    if fn=='char':
+        out=bytearray()
+        for a in args:
+            n=to_int(a,'string.char')
+            if n<0 or n>255: raise CompileError('bad argument to string.char')
+            out.append(n)
+        return Value('str',bytes(out))
+    if fn=='format': return string_format(args)
+    if fn=='byte':
+        vals=string_byte(args); return vals[0] if vals else Value('nil',None)
+    if fn=='find': return string_find(args)[0]
+    if fn=='match': return string_match(args)[0]
+    if fn=='rep' and len(args) in (2,3):
+        s=expect_str(args[0],'string.rep'); n=to_int(args[1],'string.rep'); sep=expect_str(args[2],'string.rep') if len(args)==3 else b''; return Value('str',b'' if n<=0 else sep.join([s]*n))
+    if fn=='sub' and len(args) in (2,3):
+        s=expect_str(args[0],'string.sub'); l=len(s); i=lua_index(to_int(args[1],'string.sub'),l); j=lua_index(to_int(args[2],'string.sub'),l) if len(args)==3 else l; i=max(i,1); j=min(j,l); return Value('str',b'' if i>j else s[i-1:j])
+    raise CompileError(f"unsupported builtin string.{fn}")
+def call_builtin_multi(name,args):
+    if name=='select':
+        if not args: raise CompileError('select expects index')
+        vals=args[1:]
+        if args[0].kind=='str' and args[0].val==b'#': return [Value('int',len(vals))]
+        idx=to_int(args[0],'select');
+        if idx<0: idx=len(vals)+idx+1
+        if idx==0: raise CompileError('bad argument to select')
+        return vals[idx-1:] if idx<=len(vals) else []
+    if name in ('pairs','ipairs'):
+        if len(args)!=1 or args[0].kind!='table': raise CompileError(f'{name} expects table')
+        return [Value('iter',name),args[0],Value('nil',None)]
+    if name=='next':
+        if len(args) not in (1,2) or args[0].kind!='table': raise CompileError('next expects table')
+        items=args[0].val.items(); start=0
+        if len(args)==2 and args[1].kind!='nil':
+            ck=table_key(args[1]); start=len(items)
+            for i,(k,v) in enumerate(items):
+                if table_key(k)==ck: start=i+1; break
+        if start<len(items):
+            k,v=items[start]; return [k,v]
+        return [Value('nil',None)]
+    if name=='table.unpack':
+        if len(args) not in (1,2,3): raise CompileError('table.unpack expects 1 to 3 arguments')
+        t=expect_table(args[0],name); n=t.length(); i=to_int(args[1],name) if len(args)>=2 else 1; j=to_int(args[2],name) if len(args)>=3 else n
+        if j<i: return []
+        if j-i>100000: raise CompileError('too many values to unpack')
+        return [table_get(t,k) for k in range(i,j+1)]
+    if name=='string.byte': return string_byte(args)
+    if name=='string.find': return string_find(args)
+    if name=='string.match': return string_match(args)
+    raise AssertionError(name)
+def table_builtin(fn,args):
+    if fn=='pack':
+        t=LuaTable()
+        for i,v in enumerate(args,1): t.set(Value('int',i),v)
+        t.set(Value('str',b'n'),Value('int',len(args)))
+        return Value('table',t)
+    if fn=='insert':
+        if len(args)==2: t=expect_table(args[0],'table.insert'); pos=t.length()+1; val=args[1]
+        elif len(args)==3:
+            t=expect_table(args[0],'table.insert'); pos=to_int(args[1],'table.insert'); val=args[2]
+            if pos<1 or pos>t.length()+1: raise CompileError('bad argument to table.insert: position out of bounds')
+        else: raise CompileError('table.insert expects 2 or 3 arguments')
+        n=t.length()
+        for i in range(n+1,pos,-1): table_set(t,i,table_get(t,i-1))
+        table_set(t,pos,val); return Value('nil',None)
+    if fn=='remove':
+        if len(args) not in (1,2): raise CompileError('table.remove expects 1 or 2 arguments')
+        t=expect_table(args[0],'table.remove'); n=t.length(); pos=to_int(args[1],'table.remove') if len(args)==2 else n
+        if pos<1 or pos>n: return Value('nil',None)
+        ret=table_get(t,pos)
+        for i in range(pos,n): table_set(t,i,table_get(t,i+1))
+        table_set(t,n,Value('nil',None)); return ret
+    if fn=='concat':
+        if len(args) not in (1,2,3,4): raise CompileError('table.concat expects 1 to 4 arguments')
+        t=expect_table(args[0],'table.concat'); sep=expect_str(args[1],'table.concat') if len(args)>=2 else b''; i=to_int(args[2],'table.concat') if len(args)>=3 else 1; j=to_int(args[3],'table.concat') if len(args)>=4 else t.length(); parts=[]
+        if j>=i:
+            for k in range(i,j+1):
+                v=table_get(t,k)
+                if v.kind not in ('str','int','float'): raise CompileError('invalid value for table.concat')
+                parts.append(tostring(v))
+        return Value('str',sep.join(parts))
+    if fn=='sort':
+        if len(args) not in (1,2): raise CompileError('table.sort expects table')
+        if len(args)==2 and args[1].kind!='nil': raise CompileError('table.sort comparator unsupported')
+        t=expect_table(args[0],'table.sort'); vals=[table_get(t,i) for i in range(1,t.length()+1)]
+        for i in range(1,len(vals)):
+            v=vals[i]; j=i
+            while j>0 and compare('<',v,vals[j-1]).val: vals[j]=vals[j-1]; j-=1
+            vals[j]=v
+        for i,v in enumerate(vals,1): table_set(t,i,v)
+        return Value('nil',None)
+    if fn=='unpack':
+        vals=call_builtin_multi('table.unpack',args); return vals[0] if vals else Value('nil',None)
+    raise CompileError(f"unsupported builtin table.{fn}")
+def call_builtin(name,args):
+    if name=='type': return Value('str',type_name(one_arg(name,args)).encode('ascii'))
+    if name=='tostring': return Value('str',tostring(one_arg(name,args)))
+    if name=='tonumber':
+        if len(args)==1: return to_number(args[0])
+        if len(args)==2:
+            base=to_int(args[1],'tonumber')
+            if args[0].kind!='str': return Value('nil',None)
+            try: return Value('int',int(args[0].val.decode('ascii').strip(),base))
+            except Exception: return Value('nil',None)
+        raise CompileError('tonumber expects 1 or 2 arguments')
+    if name.startswith('table.'): return table_builtin(name[6:],args)
+    if name.startswith('string.'): return string_builtin(name[7:],args)
+    if name.startswith('math.'):
+        fn=name[5:]; nums=[]
+        for a in args: ensure_num(a,name); nums.append(float(a.val))
+        if fn=='floor' and len(nums)==1: return Value('int',math.floor(nums[0]))
+        if fn=='ceil' and len(nums)==1: return Value('int',math.ceil(nums[0]))
+        if fn=='abs' and len(nums)==1: return Value('int',abs(args[0].val)) if args[0].kind=='int' else Value('float',abs(nums[0]))
+        if fn=='max' and nums: return max_values(args)
+        if fn=='min' and nums: return min_values(args)
+        raise CompileError(f"unsupported builtin {name}")
+    raise CompileError(f"unsupported function {name}")
+def max_values(args):
+    best=args[0]
+    for a in args[1:]:
+        if compare('>',a,best).val: best=a
+    return best
+def min_values(args):
+    best=args[0]
+    for a in args[1:]:
+        if compare('<',a,best).val: best=a
+    return best
+def asm_bytes(bs): return '' if not bs else '    .byte '+','.join(str(b) for b in bs)+'\n'
+def emit_asm(ops):
+    data=[]; text=[]; sid=0
+    text.append('    .intel_syntax noprefix\n    .global _start\n    .section .text\n_start:\n')
+    for kind,val in ops:
+        if kind=='bytes':
+            if not val: continue
+            lab=f'.LC{sid}'; sid+=1; data.append((lab,val)); text.append(f'    lea rsi, [rip+{lab}]\n    mov rdx, {len(val)}\n    call write_buf\n')
+        elif kind=='int':
+            n=int(val); text.append(f'    mov rdi, {n}\n' if -2147483648<=n<=2147483647 else f'    movabs rdi, {n}\n'); text.append('    call print_int\n')
+    text.append('    mov rax, 60\n    xor rdi, rdi\n    syscall\n')
+    text.append('\nwrite_buf:\n    mov rax, 1\n    mov rdi, 1\n    syscall\n    ret\n')
+    text.append('\nprint_int:\n    push rbp\n    mov rbp, rsp\n    sub rsp, 80\n    mov rax, rdi\n    cmp rax, 0\n    jne .PI_nonzero\n    mov byte ptr [rbp-1], 48\n    lea rsi, [rbp-1]\n    mov rdx, 1\n    call write_buf\n    leave\n    ret\n.PI_nonzero:\n    xor r8d, r8d\n    cmp rax, 0\n    jge .PI_positive\n    neg rax\n    mov r8b, 1\n.PI_positive:\n    lea rsi, [rbp-1]\n    xor rcx, rcx\n    mov rbx, 10\n.PI_loop:\n    xor rdx, rdx\n    div rbx\n    add dl, 48\n    dec rsi\n    mov byte ptr [rsi], dl\n    inc rcx\n    test rax, rax\n    jne .PI_loop\n    cmp r8b, 0\n    je .PI_emit\n    dec rsi\n    mov byte ptr [rsi], 45\n    inc rcx\n.PI_emit:\n    mov rdx, rcx\n    call write_buf\n    leave\n    ret\n')
+    if data:
+        text.append('\n    .section .rodata\n')
+        for lab,bs in data: text.append(f'{lab}:\n'); text.append(asm_bytes(bs))
+    text.append('    .section .note.GNU-stack,"",@progbits\n'); return ''.join(text)
+def compile_file(inp,outp):
+    with open(inp,'rb') as f: src=f.read().decode('utf-8','surrogateescape')
+    ops=Interpreter(Parser(src).parse()).run(); asm=emit_asm(ops); out_abs=os.path.abspath(outp); out_dir=os.path.dirname(out_abs) or '.'; os.makedirs(out_dir,exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix='luanatc-',dir=out_dir) as td:
+        sfile=os.path.join(td,'program.s'); ofile=os.path.join(td,'program.o')
+        with open(sfile,'w',encoding='utf-8') as f: f.write(asm)
+        subprocess.run(['as','--64','-o',ofile,sfile],check=True); subprocess.run(['ld','-o',out_abs,ofile],check=True)
+def main(argv):
+    ap=argparse.ArgumentParser(prog='luanatc',description='minimal Lua subset native compiler'); ap.add_argument('input'); ap.add_argument('-o','--output',required=True); args=ap.parse_args(argv)
+    try: compile_file(args.input,args.output); return 0
+    except CompileError as e: print(f'luanatc: {e}',file=sys.stderr); return 1
+    except subprocess.CalledProcessError as e: print(f'luanatc: tool failed: {e}',file=sys.stderr); return 1
+    except OSError as e: print(f'luanatc: {e}',file=sys.stderr); return 1
+if __name__=='__main__': sys.exit(main(sys.argv[1:]))
+=== END FILE ===

--- a/examples/frontier_swe/lua-native-compiler/task.yaml
+++ b/examples/frontier_swe/lua-native-compiler/task.yaml
@@ -1,0 +1,49 @@
+task:
+  name: "Frontier-SWE · Lua Native Compiler"
+  description: |
+    Improve `candidate.bundle`, a compiler project materialized at
+    `/app/lua-native-compiler` in the pinned official Frontier-SWE task image.
+    It must accept `luanatc input.lua -o output` and produce standalone x86-64
+    ELF executables for Lua 5.4 programs.
+
+    The compiled program must contain program-specific native code. It may use
+    the supplied internal Lua runtime helpers, but it must not implement a
+    bytecode dispatch interpreter, wrap the Lua C embedding API for compiled
+    operations, delegate to the reference interpreter, or invoke a C compiler
+    for generated code. The official score is the test-program pass rate after
+    build and anti-cheat gates.
+  tips: |
+    Bundle sections use `=== FILE: relative/path ===` and `=== END FILE ===`.
+    Include complete file contents, without Markdown fences or prose. Paths are
+    relative to `/app/lua-native-compiler`. The seed's validated official score
+    is 0.406593 (74/182 tests).
+
+grader:
+  entrypoint: "frontier_swe_grader.grader:Grader"
+  setup:
+    - "uv pip install -e ./grader"
+  timeout: 90000
+  direction: maximize
+  args:
+    task_id: "lua-native-compiler"
+    program_file: "candidate.bundle"
+  parallel:
+    max_workers: 1
+  max_pending_per_agent: 1
+
+agents:
+  count: 1
+  runtime: codex
+  model: gpt-5.5
+  research: false
+  runtime_options:
+    model_reasoning_effort: high
+
+workspace:
+  results_dir: "./results"
+  repo_path: "./examples/frontier_swe/lua-native-compiler/seed"
+
+run:
+  verbose: false
+  ui: false
+  session: local

--- a/tests/test_cli_test_eval_alias.py
+++ b/tests/test_cli_test_eval_alias.py
@@ -1,0 +1,53 @@
+"""Tests for the hidden ``coral test-eval`` -> ``coral validate`` alias.
+
+The alias parser must accept the same arguments as ``validate``; otherwise it
+cannot dispatch (``cmd_validate`` reads ``args.path``).
+"""
+
+import sys
+
+import pytest
+
+import coral.cli as cli_module
+import coral.cli.author as author_module
+
+
+def _capture_cmd_validate(monkeypatch, captured: dict) -> None:
+    def fake_cmd_validate(args):
+        captured["path"] = args.path
+        captured["json"] = getattr(args, "json", False)
+
+    monkeypatch.setattr(author_module, "cmd_validate", fake_cmd_validate)
+
+
+def test_test_eval_alias_forwards_path(monkeypatch):
+    captured: dict = {}
+    _capture_cmd_validate(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["coral", "test-eval", "my-task"])
+
+    cli_module.main()
+
+    assert captured == {"path": "my-task", "json": False}
+
+
+def test_test_eval_alias_accepts_json_flag(monkeypatch):
+    captured: dict = {}
+    _capture_cmd_validate(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["coral", "test-eval", "my-task", "--json"])
+
+    cli_module.main()
+
+    assert captured == {"path": "my-task", "json": True}
+
+
+def test_test_eval_alias_without_path_exits_with_usage_error(monkeypatch, capsys):
+    """A missing positional must be an argparse usage error, not a traceback."""
+    captured: dict = {}
+    _capture_cmd_validate(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["coral", "test-eval"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_module.main()
+
+    assert excinfo.value.code == 2
+    assert captured == {}

--- a/tests/test_deepseek_harness.py
+++ b/tests/test_deepseek_harness.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -151,3 +153,52 @@ def test_restart_does_not_invent_unsupported_resume_flag(
     assert cmd[:3] == ["dsh", "--profile", "headless"]
     assert cmd[-1] == "continue"
     assert "--resume" not in cmd
+
+
+def test_start_prepends_platform_aware_venv_bin_to_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """PATH must use the platform's venv executable dir (bin/ vs Scripts/).
+
+    Guards the cross-platform venv path contract (#231): a hardcoded
+    ``.venv/bin`` would point at a nonexistent directory on Windows.
+    """
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    worktree = _make_worktree(tmp_path)
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    DeepSeekHarnessRuntime().start(
+        worktree_path=worktree,
+        coral_md_path=worktree / "AGENTS.md",
+        log_dir=tmp_path / "logs",
+        prompt="task",
+    )
+
+    path_value = _FakePopen.captured[0]["kwargs"]["env"]["PATH"]
+    first_entry = path_value.split(os.pathsep)[0]
+    assert first_entry == str(worktree / ".venv" / "Scripts")
+
+
+def test_start_opens_log_file_utf8_with_replacement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The agent log must be UTF-8 with errors='replace' like all runtimes.
+
+    Without an explicit encoding, the log file inherits the locale encoding,
+    and the verbose tee (which writes UTF-8-decoded agent output through this
+    handle) raises UnicodeEncodeError under a non-UTF-8 locale.
+    """
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    worktree = _make_worktree(tmp_path)
+
+    handle = DeepSeekHarnessRuntime().start(
+        worktree_path=worktree,
+        coral_md_path=worktree / "AGENTS.md",
+        log_dir=tmp_path / "logs",
+        prompt="task",
+    )
+
+    log_file = handle._log_file
+    assert log_file is not None
+    assert log_file.encoding.lower().replace("-", "") == "utf8"
+    assert log_file.errors == "replace"

--- a/tests/test_gateway_agent_auth.py
+++ b/tests/test_gateway_agent_auth.py
@@ -1,0 +1,84 @@
+"""Tests for agent identification from auth headers in the gateway middleware."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from coral.gateway.middleware import CoralGatewayMiddleware
+
+
+@pytest.fixture
+def middleware(tmp_path: Path) -> CoralGatewayMiddleware:
+    async def dummy_app(scope, receive, send):  # pragma: no cover - never called
+        raise AssertionError("app should not be called in these tests")
+
+    return CoralGatewayMiddleware(dummy_app, log_dir=tmp_path, master_key="master")
+
+
+def test_matching_key_returns_agent(middleware: CoralGatewayMiddleware, tmp_path: Path) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+    middleware.register_agent("agent-2", tmp_path, "key-2")
+
+    info = middleware._get_agent_info("Bearer key-2")
+
+    assert info is not None
+    assert info.agent_id == "agent-2"
+
+
+def test_missing_header_falls_back_to_sole_agent_without_warning(
+    middleware: CoralGatewayMiddleware,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        info = middleware._get_agent_info("")
+
+    assert info is not None
+    assert info.agent_id == "agent-1"
+    assert not caplog.records
+
+
+def test_mismatched_key_falls_back_to_sole_agent_with_warning(
+    middleware: CoralGatewayMiddleware,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        info = middleware._get_agent_info("Bearer stale-key")
+
+    assert info is not None
+    assert info.agent_id == "agent-1"
+    assert len(caplog.records) == 1
+    assert "does not match any registered proxy key" in caplog.records[0].message
+    # The unrecognized key itself must not leak into the log
+    assert "stale-key" not in caplog.records[0].message
+
+
+def test_mismatched_key_warns_only_once_per_key(
+    middleware: CoralGatewayMiddleware,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        middleware._get_agent_info("Bearer stale-key")
+        middleware._get_agent_info("Bearer stale-key")
+        middleware._get_agent_info("Bearer other-stale-key")
+
+    assert len(caplog.records) == 2
+
+
+def test_mismatched_key_with_multiple_agents_returns_none(
+    middleware: CoralGatewayMiddleware, tmp_path: Path
+) -> None:
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+    middleware.register_agent("agent-2", tmp_path, "key-2")
+
+    assert middleware._get_agent_info("Bearer stale-key") is None
+    assert middleware._get_agent_info("") is None

--- a/tests/test_gateway_header_hook.py
+++ b/tests/test_gateway_header_hook.py
@@ -1,0 +1,156 @@
+"""Tests for the optional header_provider hook in the gateway middleware."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from coral.gateway.middleware import CoralGatewayMiddleware
+
+
+class FakeApp:
+    """Minimal ASGI app that captures the scope and returns a JSON body."""
+
+    def __init__(self) -> None:
+        self.captured_scope: dict | None = None
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        self.captured_scope = scope
+        await receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b'{"ok": true}'})
+
+
+def _make_scope() -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "headers": [
+            (b"authorization", b"Bearer key-1"),
+            (b"content-type", b"application/json"),
+        ],
+    }
+
+
+async def _run_request(middleware: CoralGatewayMiddleware, scope: dict) -> list[dict]:
+    sent: list[dict] = []
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b'{"model": "m"}', "more_body": False}
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+def _headers(app: FakeApp) -> dict[bytes, bytes]:
+    assert app.captured_scope is not None
+    return dict(app.captured_scope["headers"])
+
+
+async def test_no_provider_keeps_existing_behavior(tmp_path: Path) -> None:
+    app = FakeApp()
+    middleware = CoralGatewayMiddleware(app, log_dir=tmp_path, master_key="master")
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    sent = await _run_request(middleware, _make_scope())
+
+    headers = _headers(app)
+    assert headers[b"authorization"] == b"Bearer master"
+    assert headers[b"x-coral-agent-id"] == b"agent-1"
+    assert b"x-coral-session-id" in headers
+    assert sent[-1]["body"] == b'{"ok": true}'
+
+
+async def test_provider_headers_are_appended(tmp_path: Path) -> None:
+    app = FakeApp()
+    seen: list[tuple] = []
+
+    def provider(agent_info, scope):
+        seen.append((agent_info, scope))
+        return [(b"x-experiment-id", b"exp-42")]
+
+    middleware = CoralGatewayMiddleware(
+        app, log_dir=tmp_path, master_key="master", header_provider=provider
+    )
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    await _run_request(middleware, _make_scope())
+
+    assert _headers(app)[b"x-experiment-id"] == b"exp-42"
+    assert len(seen) == 1
+    agent_info, scope = seen[0]
+    assert agent_info is not None
+    assert agent_info.agent_id == "agent-1"
+    assert scope["path"] == "/v1/chat/completions"
+
+
+async def test_provider_gets_none_for_unknown_agent(tmp_path: Path) -> None:
+    app = FakeApp()
+    seen: list[Any] = []
+
+    def provider(agent_info, scope):
+        seen.append(agent_info)
+        return []
+
+    middleware = CoralGatewayMiddleware(
+        app, log_dir=tmp_path, master_key="master", header_provider=provider
+    )
+    # Two agents registered and a non-matching key -> no identification
+    middleware.register_agent("agent-1", tmp_path, "key-a")
+    middleware.register_agent("agent-2", tmp_path, "key-b")
+
+    await _run_request(middleware, _make_scope())
+
+    assert seen == [None]
+
+
+async def test_raising_provider_does_not_break_request(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    app = FakeApp()
+
+    def provider(agent_info, scope):
+        raise RuntimeError("boom")
+
+    middleware = CoralGatewayMiddleware(
+        app, log_dir=tmp_path, master_key="master", header_provider=provider
+    )
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        sent = await _run_request(middleware, _make_scope())
+
+    # Request still went through with the standard headers
+    headers = _headers(app)
+    assert headers[b"x-coral-agent-id"] == b"agent-1"
+    assert sent[-1]["body"] == b'{"ok": true}'
+    assert any("header_provider raised" in r.message for r in caplog.records)
+
+
+async def test_invalid_provider_result_is_skipped_atomically(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    app = FakeApp()
+
+    def provider(agent_info, scope):
+        # First pair valid, second is str, which is not a valid header value
+        return [(b"x-good", b"1"), (b"x-bad", "not-bytes")]
+
+    middleware = CoralGatewayMiddleware(
+        app, log_dir=tmp_path, master_key="master", header_provider=provider
+    )
+    middleware.register_agent("agent-1", tmp_path, "key-1")
+
+    with caplog.at_level(logging.WARNING, logger="coral.gateway.middleware"):
+        await _run_request(middleware, _make_scope())
+
+    # Neither header applied: partial application would be worse than none
+    headers = _headers(app)
+    assert b"x-good" not in headers
+    assert b"x-bad" not in headers
+    assert any("header_provider raised" in r.message for r in caplog.records)

--- a/tests/test_gateway_middleware.py
+++ b/tests/test_gateway_middleware.py
@@ -1,0 +1,159 @@
+"""Tests for SSE response assembly in the gateway middleware."""
+
+import json
+
+from coral.gateway.middleware import _assemble_response
+
+
+def _sse(events: list[dict], with_event_lines: bool = False) -> bytes:
+    """Render events as an SSE stream body."""
+    lines = []
+    for event in events:
+        if with_event_lines:
+            lines.append(f"event: {event.get('type', 'message')}")
+        lines.append(f"data: {json.dumps(event)}")
+        lines.append("")
+    return "\n".join(lines).encode("utf-8")
+
+
+def test_non_sse_json_body_is_parsed() -> None:
+    body = json.dumps({"id": "resp_1", "object": "chat.completion"}).encode()
+    assert _assemble_response(body) == {"id": "resp_1", "object": "chat.completion"}
+
+
+def test_empty_body_returns_none() -> None:
+    assert _assemble_response(b"") is None
+
+
+def test_chat_completions_stream_assembly() -> None:
+    events = [
+        {
+            "id": "chatcmpl-1",
+            "model": "gpt-x",
+            "choices": [{"delta": {"content": "Hello"}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1",
+            "choices": [{"delta": {"content": " world"}, "finish_reason": "stop"}],
+        },
+        {"id": "chatcmpl-1", "choices": [], "usage": {"total_tokens": 7}},
+    ]
+    raw = _sse(events) + b"data: [DONE]\n"
+
+    assembled = _assemble_response(raw)
+
+    assert assembled == {
+        "id": "chatcmpl-1",
+        "model": "gpt-x",
+        "content": "Hello world",
+        "finish_reason": "stop",
+        "usage": {"total_tokens": 7},
+    }
+
+
+def test_responses_api_stream_assembly() -> None:
+    events = [
+        {"type": "response.output_text.delta", "delta": "Hi"},
+        {"type": "response.output_text.delta", "delta": " there"},
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_9",
+                "model": "gpt-x",
+                "status": "completed",
+                "usage": {"total_tokens": 11},
+            },
+        },
+    ]
+
+    assembled = _assemble_response(_sse(events))
+
+    assert assembled == {
+        "id": "resp_9",
+        "model": "gpt-x",
+        "content": "Hi there",
+        "status": "completed",
+        "usage": {"total_tokens": 11},
+    }
+
+
+def test_anthropic_messages_stream_assembly() -> None:
+    events = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "model": "claude-x",
+                "usage": {"input_tokens": 25, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": " world"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 6},
+        },
+        {"type": "message_stop"},
+    ]
+
+    # The Anthropic SDK emits "event: <type>" lines before each data line,
+    # so the stream starts with "event: message_start", not "data:".
+    assembled = _assemble_response(_sse(events, with_event_lines=True))
+
+    assert assembled == {
+        "id": "msg_1",
+        "model": "claude-x",
+        "content": "Hello world",
+        "finish_reason": "end_turn",
+        "usage": {"input_tokens": 25, "output_tokens": 6},
+    }
+
+
+def test_anthropic_non_text_deltas_are_ignored() -> None:
+    events = [
+        {
+            "type": "message_start",
+            "message": {"id": "msg_2", "model": "claude-x", "usage": {"input_tokens": 3}},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '{"city": "SF"}'},
+        },
+        {"type": "ping"},
+        {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {}},
+    ]
+
+    assembled = _assemble_response(_sse(events, with_event_lines=True))
+
+    assert "content" not in assembled
+    assert assembled["finish_reason"] == "tool_use"
+
+
+def test_invalid_json_frames_are_skipped() -> None:
+    raw = (
+        b"data: not-json\n\n"
+        b'data: {"id": "chatcmpl-2", "choices": '
+        b'[{"delta": {"content": "ok"}, "finish_reason": "stop"}]}\n\n'
+        b"data: [DONE]\n"
+    )
+
+    assembled = _assemble_response(raw)
+
+    assert assembled["content"] == "ok"
+    assert assembled["finish_reason"] == "stop"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -196,6 +196,51 @@ def test_run_validation_returns_baseline_and_progress_events(tmp_path, monkeypat
     ]
 
 
+@pytest.mark.parametrize(
+    "seed_contents",
+    [
+        pytest.param(None, id="no-seed-dir"),
+        pytest.param([], id="empty-seed-dir"),
+        pytest.param(["__pycache__"], id="pycache-only-seed-dir"),
+    ],
+)
+def test_run_validation_reports_empty_workspace_consistently(tmp_path, monkeypatch, seed_contents):
+    """When nothing lands in the workspace, both the workspace warning and the
+    baseline-target message must say so — previously a seed/ dir that existed
+    but contributed nothing produced the 'No seed/' warning and then claimed
+    to run the grader 'against seed code'."""
+    task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
+    if seed_contents is not None:
+        seed_dir = task_dir / "seed"
+        seed_dir.mkdir()
+        for name in seed_contents:
+            (seed_dir / name).mkdir()
+
+    class FakeGrader:
+        async def grade(self, codebase_path, tasks):
+            assert list(Path(codebase_path).iterdir()) == []
+            return ScoreBundle(
+                scores={"eval": Score(value=0.0, name="eval", explanation="empty")},
+                aggregated=0.0,
+            )
+
+    monkeypatch.setattr(
+        "coral.workspace.grader_env.setup_grader_env",
+        lambda coral_dir, grader_config, config_dir: None,
+    )
+    monkeypatch.setattr(
+        "coral.grader.loader.load_grader",
+        lambda config, coral_dir: FakeGrader(),
+    )
+
+    result = task_validation.run_validation(task_dir)
+
+    assert result.successful
+    events = {(event.stage, event.status): event.message for event in result.events}
+    assert "No seed/ directory" in events[("workspace", "completed")]
+    assert events[("baseline", "started")] == "Running grader against empty workspace..."
+
+
 async def test_run_validation_async_runs_inside_existing_event_loop(tmp_path, monkeypatch):
     task_dir = _make_task(tmp_path, '  entrypoint: "p.g:G"')
 

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to CORAL! A few notes before you submit:

- Target the `dev` branch — all PRs go to `dev`, not `main` (see CONTRIBUTING.md).
- See CONTRIBUTING.md for the full workflow.
- Keep PRs scoped. Unrelated cleanups belong in a separate PR.
- Make sure `uv run pytest tests/ -v` and `uv run ruff check .` pass locally.
- If you used an AI coding agent to author this PR, also read AGENTS.md.
-->

## Motivation

Promote the nine commits integrated into `dev` since the last release promotion to `main`, as explicitly requested. This is the maintainer release flow described in CONTRIBUTING.md; the ordinary contribution target of `dev` does not apply to this promotion.

PR description prepared with assistance from Codex. This promotion adds no new implementation commits.

<!-- Why is this change needed? Link related issues (e.g. "Closes #123"). -->

## Changes

- Add four Frontier-SWE task ports: git-to-zig, lua-native-compiler, libexpat-to-x86asm, and dart-haskell (#256).
- Restrict docs and web Vercel builds to `main` (#257).
- Improve the gateway with an optional request-header provider, warnings for unknown proxy keys attributed to a sole agent, and Anthropic Messages SSE response assembly (#263, #262, #261).
- Fix the hidden `test-eval` alias argument handling and document `coral wait` plus missing `coral eval` flags (#267, #266).
- Fix DeepSeek Harness virtualenv paths and UTF-8 log handling (#264).
- Make validation baseline messages consistent for empty and cache-only seed directories (#265).

Compatibility: the gateway `header_provider` defaults to `None`, so existing callers require no changes. The hidden `test-eval` alias accepts the same required task path and optional `--json` flag as `validate`. No migration is required for the runtime and validation fixes.

<!-- What does this PR actually do? High-level summary, not a file-by-file rehash. -->

## Test plan

- Inspected the remote `main...dev` comparison: 9 incoming commits. The six commits exclusive to `main` are previous release merge commits.
- Checked for an existing open `dev` → `main` PR; none was present.
- Latest `dev` head at preparation: `896655d599331a09ac9468b6b395fabcb22d4086`. Its [CI run](https://github.com/Human-Agent-Society/CORAL/actions/runs/34023976483) was still in progress when this PR was prepared.
- No local full-suite, lint, or example smoke runs were performed for this release promotion. The local-test and example-verification checklist items remain unchecked; review the resulting PR checks before merging.

<!--
How did you verify this works? Concrete commands + results, not "I tested it".
Examples:
  - `uv run pytest tests/grader/ -v` (all green)
  - Smoke-ran `coral start -c examples/mnist/task.yaml agents.count=1` to first finalized score
  - `coral validate examples/<new-task>/`
-->

## Affected areas

<!-- Tick what this PR touches so reviewers know where to focus. -->

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [x] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [x] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [x] `examples/` (new or modified task)
- [x] `docs/` (docs site)
- [x] CI / tooling / packaging
- [x] Other: `coral/task/` validation runner; regression tests under `tests/`

## Checklist

The target-branch item is intentionally unchecked: this is the explicitly requested `dev` → `main` release promotion. Human review is not attested on anyone’s behalf.

- [ ] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [ ] `uv run pytest tests/ -v` passes locally.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change.
- [ ] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description.
- [ ] **New `examples/<task>/`**: `coral validate <task>` succeeds and a smoke run produces at least one finalized score. No hidden answer keys committed under `seed/`.
- [ ] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).
