### PR TITLE
fix(agent): replace deprecated datetime.utcnow() in agent-state stamping

### DIFF
--- a/coral/agent/state.py
+++ b/coral/agent/state.py
@@ -15,7 +15,7 @@ import json
 import os
 import tempfile
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -110,7 +110,7 @@ def write_agent_state(coral_dir: str | Path, document: AgentStateDocument) -> Pa
     target = state_file_path(coral_dir)
     target.parent.mkdir(parents=True, exist_ok=True)
 
-    document.updated_at = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    document.updated_at = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
     payload = json.dumps(document.to_dict(), indent=2, sort_keys=True)
 
     fd, tmp_path = tempfile.mkstemp(prefix=".agent_state.", suffix=".tmp", dir=str(target.parent))

--- a/tests/test_manager_reliability.py
+++ b/tests/test_manager_reliability.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -257,6 +258,25 @@ def test_write_and_read_agent_state_roundtrip(tmp_path: Path) -> None:
     assert restored.agents["agent-1"].pause_count == 3
     # updated_at should have been populated on write.
     assert restored.updated_at != ""
+
+
+def test_write_agent_state_stamps_utc_zulu_timestamp(tmp_path: Path) -> None:
+    """updated_at is an aware-UTC wall-clock reading in Z-suffixed ISO form.
+
+    Guards the datetime.utcnow() -> datetime.now(timezone.utc) migration:
+    the string shape readers see must not change, and the value must be the
+    real UTC time (utcnow() misused with a non-UTC-aware replacement would
+    drift by the local offset).
+    """
+    before = datetime.now(UTC).replace(microsecond=0)
+    write_agent_state(tmp_path / "coral", AgentStateDocument())
+    after = datetime.now(UTC)
+
+    stamp = read_agent_state(tmp_path / "coral").updated_at
+    assert stamp.endswith("Z")
+    assert "+00:00" not in stamp
+    parsed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    assert before <= parsed <= after
 
 
 def test_read_agent_state_missing_file_returns_empty(tmp_path: Path) -> None:


### PR DESCRIPTION
## Motivation

`datetime.utcnow()` is deprecated since Python 3.12 and scheduled for removal. `write_agent_state` calls it on every agent-state write, so the project's own test run currently prints the DeprecationWarning 8 times (`tests/test_manager_reliability.py`, `tests/test_steering.py`).

## Changes

- `coral/agent/state.py`: stamp `updated_at` from `datetime.now(UTC)` and normalize the `+00:00` offset back to the `Z` suffix, so the string readers see is byte-for-byte the same shape as before.
- `tests/test_manager_reliability.py`: new test pinning both properties — the stamp keeps its Z-suffixed ISO form (no `+00:00`), and its parsed value brackets the real UTC wall clock taken before/after the write.

## Test plan

- `uv run pytest tests/ -q` — 741 passed, 1 skipped (was 740; the new test is the +1)
- `uv run pytest tests/test_manager_reliability.py -q -W error::DeprecationWarning` — 37 passed (fails on `dev` without the fix)
- `uvx ruff check` / `ruff format --check` and `pre-commit run --files ...` — clean

## Affected areas

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart)

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows Conventional Commits.
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Docs: not needed — no user-visible or contract change (string shape unchanged).
- [x] No config field, CLI flag, hook, or runtime contract change.
- [x] Not a new example task.
- [x] AI-assisted PR: authored with an AI agent; every changed line reviewed. See AGENTS.md.