### PR TITLE
fix(cli): probe the tmux session name through a patchable seam

### DIFF
--- a/coral/cli/start.py
+++ b/coral/cli/start.py
@@ -89,6 +89,26 @@ def _enforce_docker_isolation(config: CoralConfig) -> None:
     config.agents.isolate_user = DOCKER_ISOLATION_USER
 
 
+def _current_tmux_session_name() -> str | None:
+    """Name of the tmux session this process is running inside, or None.
+
+    Callers gate on in_tmux() for intent; this probe still returns None when
+    tmux is missing or errors so the marker write is skipped, not crashed.
+    Tests patch this seam instead of depending on a real tmux server.
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "display-message", "-p", "#S"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 def _build_coral_command(args: argparse.Namespace) -> list[str]:
     """Reconstruct the coral start command with run.session=local added."""
     cmd = [_resolved_python(), "-m", "coral.cli", "start"]
@@ -528,13 +548,8 @@ def cmd_start(args: argparse.Namespace) -> None:
     print(f"Logs:          {manager.paths.coral_dir / 'public' / 'logs'}")
 
     if in_tmux():
-        result = subprocess.run(
-            ["tmux", "display-message", "-p", "#S"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            session_name = result.stdout.strip()
+        session_name = _current_tmux_session_name()
+        if session_name:
             # Mark as owned if coral created this tmux session (via _start_in_tmux)
             coral_owns = session_name.startswith("coral-")
             save_tmux_session_name(
@@ -718,13 +733,8 @@ def cmd_resume(args: argparse.Namespace) -> None:
     print(f"\nRun directory: {paths.run_dir}")
 
     if in_tmux():
-        result = subprocess.run(
-            ["tmux", "display-message", "-p", "#S"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            session_name = result.stdout.strip()
+        session_name = _current_tmux_session_name()
+        if session_name:
             # Mark as owned if coral created this tmux session (via _resume_in_tmux)
             coral_owns = session_name.startswith("coral-")
             save_tmux_session_name(paths.coral_dir / "public", session_name, owned=coral_owns)

--- a/tests/test_start_session_mode.py
+++ b/tests/test_start_session_mode.py
@@ -19,7 +19,16 @@ import coral.cli.start as start_mod
 from coral.config import CoralConfig
 
 
-def _drive_cmd_start(monkeypatch, tmp_path, *, session, wrapped_session, in_tmux, in_docker):
+def _drive_cmd_start(
+    monkeypatch,
+    tmp_path,
+    *,
+    session,
+    wrapped_session,
+    in_tmux,
+    in_docker,
+    tmux_session_name=None,
+):
     """Run cmd_start through the real restore path, returning the config the
     manager was constructed with."""
     base = CoralConfig()
@@ -31,6 +40,7 @@ def _drive_cmd_start(monkeypatch, tmp_path, *, session, wrapped_session, in_tmux
     monkeypatch.setattr(start_mod, "in_tmux", lambda: in_tmux)
     monkeypatch.setattr(start_mod, "in_docker", lambda: in_docker)
     monkeypatch.setattr(start_mod, "has_tmux", lambda: True)
+    monkeypatch.setattr(start_mod, "_current_tmux_session_name", lambda: tmux_session_name)
     monkeypatch.setattr("coral.cli.validation.validate_task", lambda task_dir: [])
 
     captured = {}
@@ -40,6 +50,7 @@ def _drive_cmd_start(monkeypatch, tmp_path, *, session, wrapped_session, in_tmux
             captured["config"] = config
             self.specs = []
             self.paths = SimpleNamespace(run_dir=tmp_path, coral_dir=tmp_path / ".coral")
+            (self.paths.coral_dir / "public").mkdir(parents=True, exist_ok=True)
 
         def start_all(self):
             return []
@@ -125,3 +136,39 @@ def test_wrappers_pass_wrapped_session_flag(mode):
         src = inspect.getsource(start_mod._start_in_docker)
     assert "--wrapped-session" in src
     assert f'"{mode}"' in src
+
+
+@pytest.mark.parametrize(
+    ("session_name", "expect_owned"),
+    [("coral-mytask-20260906", True), ("users-own-session", False)],
+)
+def test_start_in_tmux_saves_session_marker(monkeypatch, tmp_path, session_name, expect_owned):
+    """cmd_start inside tmux persists the session marker (and the owned flag
+    exactly when coral created the session) without touching a real tmux."""
+    _drive_cmd_start(
+        monkeypatch,
+        tmp_path,
+        session="local",
+        wrapped_session="tmux",
+        in_tmux=True,
+        in_docker=False,
+        tmux_session_name=session_name,
+    )
+    public = tmp_path / ".coral" / "public"
+    assert (public / ".coral_tmux_session").read_text(encoding="utf-8") == session_name
+    assert (public / ".coral_tmux_owned").exists() is expect_owned
+
+
+def test_start_in_tmux_skips_marker_when_probe_fails(monkeypatch, tmp_path):
+    """A failing tmux probe (no server, tmux missing) must skip the marker,
+    not crash cmd_start."""
+    _drive_cmd_start(
+        monkeypatch,
+        tmp_path,
+        session="local",
+        wrapped_session=None,
+        in_tmux=True,
+        in_docker=False,
+        tmux_session_name=None,
+    )
+    assert not (tmp_path / ".coral" / "public" / ".coral_tmux_session").exists()


### PR DESCRIPTION
## Motivation

`tests/test_start_session_mode.py` is not hermetic: it patches `in_tmux()` but `cmd_start`/`cmd_resume` then shell out to the real `tmux display-message -p '#S'`. On any development machine with a running tmux server the probe succeeds, and `save_tmux_session_name` crashes with `FileNotFoundError` because the test's fake manager never created `.coral/public`:

```
$ tmux new-session -d -s anything   # any running tmux server on the host
$ uv run pytest tests/test_start_session_mode.py -q
FAILED tests/test_start_session_mode.py::test_local_from_users_own_tmux_stays_local
FAILED tests/test_start_session_mode.py::test_tmux_wrapper_restores_tmux
2 failed, 4 passed
```

CI never sees this because its `tmux` has no server (the probe exits non-zero and the branch is skipped), so the suite is green in CI and red for any contributor who develops inside tmux.

The same shell-out is copy-pasted in `cmd_start` and `cmd_resume`, and neither guards against `tmux` being absent from PATH (`FileNotFoundError` from `subprocess.run` would crash the command right after agents started).

## Changes

- Extract the duplicated probe into `_current_tmux_session_name()` in `coral/cli/start.py`. It returns `None` when tmux is missing (`OSError`), exits non-zero, or prints nothing, so the marker write is skipped instead of crashing.
- The session-mode tests patch this seam (default `None`), so they pass on any host regardless of tmux state.
- New hermetic tests pin the marker behavior itself: session name written to `.coral/public/.coral_tmux_session`, the owned flag set exactly for `coral-` prefixed sessions, and the skip path when the probe fails.

No behavior change for real runs inside tmux: the probe command and the owned heuristic are unchanged.

## Test plan

- `uv run pytest tests/test_start_session_mode.py -q` — 9 passed (was 2 failed / 4 passed on a host with a running tmux server; the file had 6 tests).
- `uv run pytest tests/ -q` — 743 passed, 1 skipped.
- `uv run ruff check .` and `uvx pre-commit run --files coral/cli/start.py tests/test_start_session_mode.py` — clean.

## Affected areas

- [ ] `coral/agent/` (runtime, manager, heartbeat, warmstart)
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [x] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [x] CI / tooling / packaging

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally.
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [ ] Updated docs (`docs/content/`, README, or relevant skill under `.claude/skills/`) for any user-visible or contract change. <!-- no user-visible change -->
- [x] If this changes a config field, CLI flag, hook, or runtime contract — noted the migration path in the PR description. <!-- n/a -->
- [x] **New `examples/<task>/`**: n/a
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).