### PR TITLE
test(agent): make fake processes report an exited process

### DIFF
--- a/tests/test_cursor_agent.py
+++ b/tests/test_cursor_agent.py
@@ -123,7 +123,12 @@ class _FakePopen:
     def __init__(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
         type(self).captured.append({"cmd": list(cmd), "kwargs": dict(kwargs)})
         self.pid = 4242
-        self.returncode: int | None = None
+        # Report an already-exited process. If the fake claims to be alive,
+        # AgentHandle.__del__ SIGKILLs the process group of whatever real
+        # process happens to own pid 4242 on the host, and the AttributeError
+        # from the missing Popen surface aborts cleanup before the runtime's
+        # log handle is closed (ResourceWarning at teardown).
+        self.returncode: int | None = 0
         self.stdout = None
         self.stderr = None
 

--- a/tests/test_deepseek_harness.py
+++ b/tests/test_deepseek_harness.py
@@ -24,7 +24,12 @@ class _FakePopen:
     def __init__(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
         type(self).captured.append({"cmd": list(cmd), "kwargs": dict(kwargs)})
         self.pid = 4242
-        self.returncode: int | None = None
+        # Report an already-exited process. If the fake claims to be alive,
+        # AgentHandle.__del__ SIGKILLs the process group of whatever real
+        # process happens to own pid 4242 on the host, and the AttributeError
+        # from the missing Popen surface aborts cleanup before the runtime's
+        # log handle is closed (ResourceWarning at teardown).
+        self.returncode: int | None = 0
         self.stdout = None
         self.stderr = None
 

--- a/tests/test_pi_runtime.py
+++ b/tests/test_pi_runtime.py
@@ -11,12 +11,17 @@ from coral.agent.registry import default_model_for_runtime, get_runtime
 class FakeProcess:
     def __init__(self) -> None:
         self.pid = 4321
-        self.returncode = None
+        # Report an already-exited process. If the fake claims to be alive,
+        # AgentHandle.__del__ SIGKILLs the process group of whatever real
+        # process happens to own pid 4321 on the host, and the AttributeError
+        # from the missing Popen surface aborts cleanup before the runtime's
+        # log handle is closed (ResourceWarning at teardown).
+        self.returncode: int | None = 0
         self.stdout = None
         self.stderr = None
 
-    def poll(self) -> None:
-        return None
+    def poll(self) -> int | None:
+        return self.returncode
 
 
 def test_pi_runtime_is_registered() -> None:


### PR DESCRIPTION
## Motivation

The fake `Popen` objects in `tests/test_cursor_agent.py`, `tests/test_deepseek_harness.py`, and `tests/test_pi_runtime.py` report `poll() = None` — a live process — with a hardcoded real-looking pid (4242/4321). Two consequences when the discarded `AgentHandle` is garbage collected and its `__del__` safety net runs:

1. Because the handle believes the process is alive, `__del__` calls `os.killpg(os.getpgid(pid), SIGKILL)`. That targets whatever real process on the host happens to own pid 4242/4321 at that moment. On a developer machine or a busy CI runner with recycled pids, the test suite can kill an unrelated user-owned process group.
2. Where the fake lacks the `kill`/`wait` surface (the dsh and pi fakes), the resulting `AttributeError` aborts `__del__` before the runtime's log handle is closed. That is the source of 6 `ResourceWarning: unclosed file ... agent-*.log` at teardown:

```
$ uv run pytest tests/test_deepseek_harness.py tests/test_pi_runtime.py tests/test_cursor_agent.py -q -W always::ResourceWarning 2>&1 | grep -c ResourceWarning
6
```

## Changes

The fakes report an already-exited process (`returncode = 0`, `poll()` returns it). `AgentHandle.__del__` then skips the kill path entirely and closes the runtime log file. No test in these files asserts fake aliveness, so no behavior under test changes. Tests only.

## Test plan

- `uv run pytest tests/test_deepseek_harness.py tests/test_pi_runtime.py tests/test_cursor_agent.py -q` — 38 passed, before and after.
- Same command with `-W always::ResourceWarning`: 6 warnings before, 0 after.
- `uv run pytest tests/ -q` — 741 passed, 1 skipped, plus the 2 pre-existing host-dependent failures in `tests/test_start_session_mode.py` addressed separately in #271 (they occur on any machine with a running tmux server and are unrelated to this change).
- `uv run ruff check` and `uvx pre-commit run` on the three files — clean.

## Affected areas

- [x] `coral/agent/` (runtime, manager, heartbeat, warmstart) — tests only
- [ ] `coral/grader/` (daemon, TaskGrader, subprocess grader, loader)
- [ ] `coral/hub/` (attempts, notes, skills, checkpoint)
- [ ] `coral/workspace/` (project setup, worktrees, grader env)
- [ ] `coral/cli/` (commands, helpers)
- [ ] `coral/hooks/` (post_commit / submit_eval)
- [ ] `coral/template/` (CORAL.md, bundled skills/agents)
- [ ] `coral/gateway/` (LiteLLM gateway)
- [ ] `coral/web/` (dashboard)
- [ ] `examples/` (new or modified task)
- [ ] `docs/` (docs site)
- [x] CI / tooling / packaging

## Checklist

- [x] PR targets the `dev` branch (not `main`).
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
- [x] `uv run pytest tests/ -v` passes locally (modulo the pre-existing #271 host-dependent failures).
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] Added or updated tests under `tests/` for any behavior change.
- [x] Updated docs — n/a, tests only.
- [x] Config field / CLI flag / hook / runtime contract change — n/a.
- [x] **New `examples/<task>/`** — n/a.
- [x] **AI-assisted PR**: a human author has read every changed line and can defend the design. See [AGENTS.md](../AGENTS.md).