### PR TITLE
fix(workspace): raise actionable error when uv is missing from PATH

### DIFF
--- a/coral/workspace/grader_env.py
+++ b/coral/workspace/grader_env.py
@@ -139,6 +139,12 @@ def setup_grader_env(
     venv_dir.parent.mkdir(parents=True, exist_ok=True)
 
     if not python_path.exists():
+        if shutil.which("uv") is None:
+            raise RuntimeError(
+                "`uv` was not found on PATH; it is required to create the grader venv. "
+                "Install it from https://docs.astral.sh/uv/getting-started/installation/ "
+                "and re-run."
+            )
         logger.info(f"Creating grader venv at {venv_dir}")
         venv_cmd = ["uv", "venv", "--python", sys.executable, str(venv_dir)]
         result = subprocess.run(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,11 @@
 """Integration tests for the full CORAL flow."""
 
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+import pytest
 
 from coral.config import AgentConfig, CoralConfig, GraderConfig, TaskConfig, WorkspaceConfig
 from coral.hub.attempts import (
@@ -17,6 +20,7 @@ from coral.types import Attempt
 from coral.workspace import create_project
 
 
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv binary required")
 def test_full_workspace_creation():
     """Test creating a complete project structure with worktrees."""
     with tempfile.TemporaryDirectory() as d:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -897,3 +897,21 @@ def test_setup_worktree_env_uv_pip_install_failure(monkeypatch):
 
         with pytest.raises(RuntimeError, match="Failed to install coral into worktree venv"):
             setup_worktree_env(worktree, ["echo setup"])
+
+
+def test_setup_grader_env_missing_uv_raises_runtime_error(monkeypatch):
+    """A missing `uv` binary must surface as the documented RuntimeError.
+
+    Regression test: setup_grader_env promised RuntimeError on any failure
+    but let subprocess raise a raw FileNotFoundError when `uv` was not on
+    PATH at venv-creation time.
+    """
+    from coral.workspace.grader_env import setup_grader_env
+
+    monkeypatch.setattr("coral.workspace.grader_env.shutil.which", lambda cmd: None)
+
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        coral_dir = Path(d) / ".coral"
+
+        with pytest.raises(RuntimeError, match="`uv` was not found on PATH"):
+            setup_grader_env(coral_dir, GraderConfig(), Path(d))


### PR DESCRIPTION
## Summary
`setup_grader_env` documents "Raises RuntimeError on any failure", and the other two `uv` call sites already guard `shutil.which("uv")` (`worktree.py:736`, `task_grader.py:159`) — but the grader-venv creation path invokes `uv venv` unguarded. On a host without `uv` on PATH, `create_project()` crashes with a raw `FileNotFoundError: [Errno 2] No such file or directory: 'uv'` out of `subprocess`, instead of an actionable error.

## Repro (on dev, any host without `uv` on PATH)
```
python -m pytest tests/test_integration.py::test_full_workspace_creation
# FileNotFoundError: [Errno 2] No such file or directory: 'uv'
#   raised from subprocess.py, no hint about what is missing or how to fix it
```

## Changes
- `coral/workspace/grader_env.py`: guard `shutil.which("uv")` before creating the grader venv; raise `RuntimeError` with an install pointer, matching the module's existing error style.
- `tests/test_workspace.py`: regression test (monkeypatches `shutil.which` -> `None`) asserting the `RuntimeError`; fails on previous code with `FileNotFoundError`.
- `tests/test_integration.py`: skip `test_full_workspace_creation` when `uv` is absent, mirroring the existing `pytestmark` guard in `test_grader_env.py` (`create_project` builds the grader venv, so this test hard-crashed on uv-less hosts).

## Testing
- New regression test: FAILED pre-fix (`FileNotFoundError`) -> passes post-fix.
- `tests/test_integration.py`: 4 passed, 1 skipped without `uv` on PATH; all pass with it.
- Full suite: 739 passed, 1 skipped (the 2 `test_start_session_mode` failures on my host are the pre-existing live-tmux-server issue fixed by #271; present on clean dev, untouched here).
- `uvx pre-commit run --files ...`: all hooks pass.
